### PR TITLE
Issue #28: Add capability for user to input JSON file with additional context products

### DIFF
--- a/src/main/java/gov/nasa/pds/tools/validate/ProblemType.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/ProblemType.java
@@ -169,6 +169,7 @@ public enum ProblemType {
   UNREFERENCED_MEMBER("warning.integrity.unreferenced_member"),
   
   UNLABELED_FILE("warning.file.not_referenced_in_label"),
+  NON_REGISTERED_PRODUCT("warning.product_not_registered"),
   
   // Info message types
   

--- a/src/main/java/gov/nasa/pds/validate/ValidateLauncher.java
+++ b/src/main/java/gov/nasa/pds/validate/ValidateLauncher.java
@@ -37,7 +37,6 @@ import gov.nasa.pds.tools.label.MissingLabelSchemaException;
 import gov.nasa.pds.tools.label.SchematronTransformer;
 import gov.nasa.pds.tools.label.validate.DocumentValidator;
 import gov.nasa.pds.tools.util.LidVid;
-//import gov.nasa.pds.tools.util.SettingsManager;
 import gov.nasa.pds.tools.util.VersionInfo;
 import gov.nasa.pds.tools.util.XMLExtractor;
 import gov.nasa.pds.tools.validate.ContentProblem;
@@ -128,9 +127,6 @@ import com.google.gson.stream.JsonWriter;
  */
 public class ValidateLauncher {
 
-    /** A manager for validation settings. */
-    // private SettingsManager settings = SettingsManager.INSTANCE;
-
     /** List of targets to validate. */
     private List<URL> targets;
 
@@ -153,6 +149,9 @@ public class ValidateLauncher {
     
     /** Update register context products flag */
     private boolean updateRegisteredProducts;
+    
+    /** user no register context products flag */
+    private boolean nonRegisteredProducts;
 
 	/** The severity level and above to include in the report. */
     private ExceptionType severity;
@@ -212,8 +211,10 @@ public class ValidateLauncher {
     private boolean allowUnlabeledFiles;
 
     private File registeredProductsFile;
+    
+    private File nonRegisteredProductsFile;
 
-    private Map<String, List<LidVid>> registeredProducts;
+    private Map<String, List<LidVid>> registeredAndNonRegistedProducts;
 
     /**
      * Constructor.
@@ -245,9 +246,10 @@ public class ValidateLauncher {
         maxErrors = MAX_ERRORS;
         spotCheckData = -1;
         allowUnlabeledFiles = false;
-        registeredProducts = new HashMap<String, List<LidVid>>();
+        registeredAndNonRegistedProducts = new HashMap<String, List<LidVid>>();
         registeredProductsFile = new File(System.getProperty("resources.home") + "/" + ToolInfo.getOutputFileName());
         updateRegisteredProducts = false;
+        nonRegisteredProducts = false;
 
     }
 
@@ -356,6 +358,14 @@ public class ValidateLauncher {
                 setAllowUnlabeledFiles(true);
             } else if (Flag.LATEST_JSON_FILE.getLongName().equals(o.getLongOpt())) {
             	setUpdateRegisteredProducts(true);
+            }else if (Flag.NONREGPROD_JSON_FILE.getLongName().equals(o.getLongOpt())) {
+                File nonRegProdJson = new File(o.getValue());
+                if (nonRegProdJson.exists()) {
+                    nonRegisteredProductsFile = nonRegProdJson;
+                } else {
+                    throw new Exception("The user No Registered Product context file does not exist: " + nonRegProdJson);
+                }
+                setNonRegisteredProducts(true);
             }
         }
         if (!targetList.isEmpty()) {
@@ -389,54 +399,48 @@ public class ValidateLauncher {
         String endpoint = ToolInfo.getEndpoint();
         String query = ToolInfo.getQuery();
 
-//        System.out.println("Search Service url: " + url);
         SolrClient client = new HttpSolrClient.Builder(url).build();
         SolrQuery solrQuery = new SolrQuery(query);
         solrQuery.setRequestHandler("/" + endpoint);
         solrQuery.setStart(0);
         solrQuery.setParam("fl", "identifier, version_id");
 
-//        System.out.println("Query: " + solrQuery.getQuery());
-//        System.out.println("RequestHandler: " + solrQuery.getRequestHandler());
-
         QueryResponse resp;
-        ValidationProblem p = null;
+        List<ValidationProblem> pList = new ArrayList<ValidationProblem>();
         try {
             resp = client.query(solrQuery);
             SolrDocumentList res = resp.getResults();
-            // System.out.println("get rows: " + res.size());
-//            System.out.println("NumFound: " + res.getNumFound());
-
             solrQuery.setRows((int) res.getNumFound());
             resp = client.query(solrQuery);
             res = resp.getResults();
-//            System.out.println("get all rows: " + res.size());
-
             parseJsonObjectWriteTofile(res);
 
             client.close();
-            
-//            System.out.println("============================");
-//            System.out.println();
-
-            p = new ValidationProblem(
+            ValidationProblem p1 = new ValidationProblem(
                     new ProblemDefinition(ExceptionType.INFO, ProblemType.GENERAL_INFO,
-                    		"Successfully updated registered context products config file."),
+                    		"Successfully updated registered context products config file. "),
                     new URL(url));
+            pList.add(p1);
+            ValidationProblem p2 = new ValidationProblem(
+                    new ProblemDefinition(ExceptionType.INFO, ProblemType.GENERAL_INFO,
+                            "Number Found from the latest registered products: " + res.size()),
+                    new URL(url));
+            pList.add(p2);
             
         } catch (SolrServerException | IOException ex) {
         	try {
-	            p = new ValidationProblem(
+        	    ValidationProblem p = new ValidationProblem(
 	                    new ProblemDefinition(ExceptionType.ERROR, ProblemType.INTERNAL_ERROR,
 	                    		"Error connecting to Registry to update registered context products config file. Verify internet connection and try again."),
 	                    new URL(url));
+	            report.record(new URI(System.getProperty("resources.home") + "/" + ToolInfo.getOutputFileName()), p);
         	} catch (Exception e) {
 		        e.printStackTrace();
 		    }
         }
         
         try {
-        	report.record(new URI(System.getProperty("resources.home") + "/" + ToolInfo.getOutputFileName()), p);
+        	report.record(new URI(System.getProperty("resources.home") + "/" + ToolInfo.getOutputFileName()), pList);
         } catch (Exception e) {
         	e.printStackTrace();
         }
@@ -454,17 +458,12 @@ public class ValidateLauncher {
         }
 
         List<String> contextIDVer = new ArrayList<String>();
-        int count = 0;
         for (SolrDocument document : docs) {
             String id = (String) document.getFirstValue("identifier");
             String ver = (String) document.getFirstValue("version_id");
-
-            // System.out.println("id: " + id + "; ver: " + ver);
             contextIDVer.add(id + "::" + ver);
-            count++;
         }
-//        System.out.println("Number of records: " + count);
-
+        
         try {
             JsonWriter writer = new JsonWriter(
                     new FileWriter(System.getProperty("resources.home") + "/" + ToolInfo.getOutputFileName()));
@@ -599,7 +598,10 @@ public class ValidateLauncher {
             if (config.containsKey(ConfigKey.LATEST_JSON_FILE)) {
                 setUpdateRegisteredProducts(true);
             }
-
+            if (config.containsKey(ConfigKey.NONREGPROD_JSON_FILE)) {
+                nonRegisteredProductsFile = new File (config.getString(ConfigKey.NONREGPROD_JSON_FILE));
+                setNonRegisteredProducts(true);
+            }
         } catch (Exception e) {
             throw new ConfigurationException(e.getMessage());
         }
@@ -841,20 +843,63 @@ public class ValidateLauncher {
 
     @SuppressWarnings("unchecked")
     private void setRegisteredProducts() throws IOException {
+        
+        List<ValidationProblem> pList = new ArrayList<ValidationProblem>();
+        
         Gson gson = new Gson();
         JsonObject json = gson.fromJson(new FileReader(registeredProductsFile), JsonObject.class);
         JsonArray array = json.get("Product_Context").getAsJsonArray();
         List<LidVid> lidvids = new ArrayList<LidVid>();
         List<String> jsonObjList = gson.fromJson(array, ArrayList.class);
+        URL url = null;
+        ValidationProblem p1 = new ValidationProblem(
+                new ProblemDefinition(ExceptionType.INFO, ProblemType.GENERAL_INFO,
+                        "number of Registered Products: " + jsonObjList.size()),
+                url);
+        pList.add(p1);
         for (String jsonObj : jsonObjList) {
             lidvids.add(new LidVid(jsonObj.split("::")[0], jsonObj.split("::")[1]));
         }
-        this.registeredProducts.put("Product_Context", lidvids);
+        if(nonRegisteredProducts){
+            gson = new Gson();
+            JsonObject jsonN = gson.fromJson(new FileReader(nonRegisteredProductsFile), JsonObject.class);
+            JsonArray arrayN = jsonN.get("Product_Context").getAsJsonArray();
+            List<String> jsonObjListN = gson.fromJson(arrayN, ArrayList.class);
+            ValidationProblem p2 = new ValidationProblem(
+                    new ProblemDefinition(ExceptionType.INFO, ProblemType.GENERAL_INFO,
+                            "number of Non Registered Products: " + jsonObjListN.size()),
+                    url);
+            pList.add(p2);
+            ValidationProblem pW = new ValidationProblem(
+                    new ProblemDefinition(ExceptionType.WARNING, ProblemType.NON_REGISTERED_PRODUCT,
+                            "This should be used for archive development only, and all context products need to be registered for a valid released archive bundle. "),
+                    url);
+            pList.add(pW);
+            for (String jsonObj : jsonObjListN) {
+                lidvids.add(new LidVid(jsonObj.split("::")[0], jsonObj.split("::")[1]));
+            }
+            
+        }
+        ValidationProblem p3 = new ValidationProblem(
+                new ProblemDefinition(ExceptionType.INFO, ProblemType.GENERAL_INFO,
+                        "Tatal number of Product Context: " + lidvids.size()),
+                url);
+        pList.add(p3);
+        //System.out.println(new Gson().toJson(lidvids));
+        try {
+            report.record(new URI(ValidateLauncher.class.getName()), pList);
+        } catch (URISyntaxException e) {
+            System.out.println(e.getMessage());
+        }
+        this.registeredAndNonRegistedProducts.put("Product_Context", lidvids);
     }
 
 	public void setUpdateRegisteredProducts(boolean updateRegisteredProducts) {
 		this.updateRegisteredProducts = updateRegisteredProducts;
 	}
+	public void setNonRegisteredProducts(boolean nonRegisteredProducts) {
+        this.nonRegisteredProducts = nonRegisteredProducts;
+    }
 
     /**
      * Displays tool usage.
@@ -964,6 +1009,8 @@ public class ValidateLauncher {
         }
         report.addParameter("   Max Errors                    " + maxErrors);
         report.addParameter("   Registered Contexts File      " + registeredProductsFile.toString());
+        if(nonRegisteredProductsFile != null)
+            report.addParameter("   Non Registered Contexts File  " + nonRegisteredProductsFile.toString());
         report.printHeader();
     }
 
@@ -987,7 +1034,7 @@ public class ValidateLauncher {
                 validator.setCheckData(checkData);
                 validator.setSpotCheckData(spotCheckData);
                 validator.setAllowUnlabeledFiles(allowUnlabeledFiles);
-                validator.setRegisteredProducts(this.registeredProducts);
+                validator.setRegisteredProducts(this.registeredAndNonRegistedProducts); //this map may include Non registered products  
                 if (!checksumManifest.isEmpty()) {
                     validator.setChecksumManifest(checksumManifest);
                 }

--- a/src/main/java/gov/nasa/pds/validate/ValidateLauncher.java
+++ b/src/main/java/gov/nasa/pds/validate/ValidateLauncher.java
@@ -882,7 +882,7 @@ public class ValidateLauncher {
         }
         ValidationProblem p3 = new ValidationProblem(
                 new ProblemDefinition(ExceptionType.INFO, ProblemType.GENERAL_INFO,
-                        "Tatal number of Product Context: " + lidvids.size()),
+                        "Total number of Product Context: " + lidvids.size()),
                 url);
         pList.add(p3);
         //System.out.println(new Gson().toJson(lidvids));

--- a/src/main/java/gov/nasa/pds/validate/ValidateLauncher.java
+++ b/src/main/java/gov/nasa/pds/validate/ValidateLauncher.java
@@ -854,7 +854,7 @@ public class ValidateLauncher {
     }
 
     @SuppressWarnings("unchecked")
-    private void setRegisteredProducts() throws IOException {
+    private void setRegisteredProducts() throws Exception {
         
         List<ValidationProblem> pList = new ArrayList<ValidationProblem>();
         
@@ -866,29 +866,33 @@ public class ValidateLauncher {
         URL url = null;
         ValidationProblem p1 = new ValidationProblem(
                 new ProblemDefinition(ExceptionType.INFO, ProblemType.GENERAL_INFO,
-                        "number of Registered Products: " + jsonObjList.size()),
+                        "number of registered context products used for validation: " + jsonObjList.size()),
                 url);
         pList.add(p1);
         for (String jsonObj : jsonObjList) {
             lidvids.add(new LidVid(jsonObj.split("::")[0], jsonObj.split("::")[1]));
         }
         if(nonRegisteredProducts){
-            gson = new Gson();
-            JsonObject jsonN = gson.fromJson(new FileReader(nonRegisteredProductsFile), JsonObject.class);
-            JsonArray arrayN = jsonN.get("Product_Context").getAsJsonArray();
-            List<String> jsonObjListN = gson.fromJson(arrayN, ArrayList.class);
-            ValidationProblem p2 = new ValidationProblem(
-                    new ProblemDefinition(ExceptionType.INFO, ProblemType.GENERAL_INFO,
-                            "number of Non Registered Products: " + jsonObjListN.size()),
-                    url);
-            pList.add(p2);
-            ValidationProblem pW = new ValidationProblem(
-                    new ProblemDefinition(ExceptionType.WARNING, ProblemType.NON_REGISTERED_PRODUCT,
-                            "This should be used for archive development only, and all context products need to be registered for a valid released archive bundle. "),
-                    url);
-            pList.add(pW);
-            for (String jsonObj : jsonObjListN) {
-                lidvids.add(new LidVid(jsonObj.split("::")[0], jsonObj.split("::")[1]));
+            try {
+                gson = new Gson();
+                JsonObject jsonN = gson.fromJson(new FileReader(nonRegisteredProductsFile), JsonObject.class);
+                JsonArray arrayN = jsonN.get("Product_Context").getAsJsonArray();
+                List<String> jsonObjListN = gson.fromJson(arrayN, ArrayList.class);
+                ValidationProblem p2 = new ValidationProblem(
+                        new ProblemDefinition(ExceptionType.INFO, ProblemType.GENERAL_INFO,
+                                "number of non-registered context products used for validation: " + jsonObjListN.size()),
+                        url);
+                pList.add(p2);
+                ValidationProblem pW = new ValidationProblem(
+                        new ProblemDefinition(ExceptionType.WARNING, ProblemType.NON_REGISTERED_PRODUCT,
+                                "Non-registered context products should only be used during archive development. All context products must be registered for a valid, released archive bundle. "),
+                        url);
+                pList.add(pW);
+                for (String jsonObj : jsonObjListN) {
+                    lidvids.add(new LidVid(jsonObj.split("::")[0], jsonObj.split("::")[1]));
+                }
+            } catch (Exception e) {
+                throw new Exception("Invalid JSON File: Verify format and values match that in default JSON file.");
             }
             
         }

--- a/src/main/java/gov/nasa/pds/validate/commandline/options/ConfigKey.java
+++ b/src/main/java/gov/nasa/pds/validate/commandline/options/ConfigKey.java
@@ -115,7 +115,7 @@ public class ConfigKey {
      * Property to download the latest Registered Context Products JSON file and
      * replace the existing file.
      */
-    public static final String LATEST_JSON_FILE = "validate.latestJsonFile";
+    public static final String LATEST_JSON_FILE = "validate.updateContextProducts";
     
-    public static final String NONREGPROD_JSON_FILE = "validate.nonRegisteredProdContextJsonFile";
+    public static final String NONREGPROD_JSON_FILE = "validate.addContextProducts";
 }

--- a/src/main/java/gov/nasa/pds/validate/commandline/options/ConfigKey.java
+++ b/src/main/java/gov/nasa/pds/validate/commandline/options/ConfigKey.java
@@ -116,4 +116,6 @@ public class ConfigKey {
      * replace the existing file.
      */
     public static final String LATEST_JSON_FILE = "validate.latestJsonFile";
+    
+    public static final String NONREGPROD_JSON_FILE = "validate.nonRegisteredProdContextJsonFile";
 }

--- a/src/main/java/gov/nasa/pds/validate/commandline/options/Flag.java
+++ b/src/main/java/gov/nasa/pds/validate/commandline/options/Flag.java
@@ -140,7 +140,9 @@ public enum Flag {
      * Flag to download the latest Registered Context Products JSON file and
      * replace the existing file.
      */
-    LATEST_JSON_FILE("u", "latest-json-file", "download the latest Registered Context Productes JSON file and replace the existing file.");
+    LATEST_JSON_FILE("u", "latest-json-file", "download the latest Registered Context Productes JSON file and replace the existing file."),
+    
+    NONREGPROD_JSON_FILE(null, "no-registe-prod-context", "dir/files", String.class, true, "Explicitly specify " + "the NON Registered Context Products JSON file (directory/file)");
 
     /** The short name. */
     private final String shortName;

--- a/src/main/java/gov/nasa/pds/validate/commandline/options/Flag.java
+++ b/src/main/java/gov/nasa/pds/validate/commandline/options/Flag.java
@@ -142,9 +142,11 @@ public enum Flag {
      * Flag to download the latest Registered Context Products JSON file and
      * replace the existing file.
      */
-    LATEST_JSON_FILE("u", "latest-json-file", "download the latest Registered Context Productes JSON file and replace the existing file."),
+    LATEST_JSON_FILE("u", "update-context-products", "Update the Context Product information used for validating context product references in labels."),
     
-    NONREGPROD_JSON_FILE(null, "no-registe-prod-context", "dir/files", String.class, true, "Explicitly specify " + "the NON Registered Context Products JSON file (directory/file)");
+    NONREGPROD_JSON_FILE(null, "add-context-products", "dir/files", String.class, true,
+            "Explicitly specify a JSON file (or directory of files) containing additional context product information used for validation. " +
+            "WARNING: This should only be used for development purposes. All context products must be registered for validity of a product in an archive.");
 
     /** The short name. */
     private final String shortName;

--- a/src/main/java/gov/nasa/pds/validate/commandline/options/FlagOptions.java
+++ b/src/main/java/gov/nasa/pds/validate/commandline/options/FlagOptions.java
@@ -67,6 +67,7 @@ public class FlagOptions {
         options.addOption(new ToolsOption(Flag.SPOT_CHECK_DATA));
         options.addOption(new ToolsOption(Flag.ALLOW_UNLABELED_FILES));
         options.addOption(new ToolsOption(Flag.LATEST_JSON_FILE));
+        options.addOption(new ToolsOption(Flag.NONREGPROD_JSON_FILE));
     }
 
     /**


### PR DESCRIPTION
Added option --no-registe-prod-context <dir/file.json> to give the
not-registered_context_products JSON file.

Created Product_Context map with REGISTERED_PRODUCTs and
NON_REGISTERED_PRODUCTs if it is available.

Added a problem type NON_REGISTERED_PRODUCT for warning message.

To test this:
Run the script:
validate --no-registe-prod-context <non registered product context json file> 

For example:
validate --no-registe-prod-context ~/PDS-EN/temp/non_registered_context_products_test.json

In the output of report will see:
_PDS Validate Tool Report
... ...
Parameters:
... ...
   Registered Contexts File      /Users/danyu/git/validate/target/validate-1.16.0-SNAPSHOT/resources/registered_context_products.json
   Non Registered Contexts File  /Users/danyu/PDS-EN/temp/non_registered_context_products_test.json

Product Level Validation Results

  PASS: gov.nasa.pds.validate.ValidateLauncher
      INFO  [info.validation.general]   number of Registered Products: 1893
      INFO  [info.validation.general]   number of Non Registered Products: 10
      WARNING  [warning.product_not_registered]   This should be used for archive development only, and all context products need to be registered for a valid released archive bundle. 
      INFO  [info.validation.general]   Total number of Product Context: 1903

Summary:

  0 error(s)
  1 warning(s)

  Message Types:
    1            warning.product_not_registered

End of Report_

Resolves #28 

