### PR TITLE
issue #50:Add capability for User to provide a manifest (file) of products to validate

### DIFF
--- a/src/main/java/gov/nasa/pds/validate/commandline/options/ConfigKey.java
+++ b/src/main/java/gov/nasa/pds/validate/commandline/options/ConfigKey.java
@@ -123,4 +123,9 @@ public class ConfigKey {
      * Property to disable context validation.
      */
     public static final String SKIP_CONTEXT_VALIDATION = "validate.skipContextValidation";
+    
+    /**
+     * Property to specify the file that contains a list of files/directories to validate.
+     */
+    public static final String TARGET_LIST_FILE = "validate.targetListFile";
 }

--- a/src/main/java/gov/nasa/pds/validate/commandline/options/Flag.java
+++ b/src/main/java/gov/nasa/pds/validate/commandline/options/Flag.java
@@ -153,7 +153,11 @@ public enum Flag {
      * enabled, the output logs will throw WARNING messages instead of failing
      * validation. Only be enabled during development
      */
-    SKIP_CONTEXT_VALIDATION(null, "skip-context-validation", "Disable context product reference validation. WARNING: This should only be used for development purposes only. All context products must be registered for validity of a product in an archive.");
+    SKIP_CONTEXT_VALIDATION(null, "skip-context-validation", "Disable context product reference validation. WARNING: This should only be used for development purposes only. All context products must be registered for validity of a product in an archive."),
+    /**
+     * flag to Flag to specify the file that contains a list of files/directories to validate.
+     */
+    TARGET_LIST_FILE(null, "target-list-file", "dir/file", String.class, true, "Explicitly specify a file that contains a list of files/directories to validate.");
     
     /** The short name. */
     private final String shortName;

--- a/src/main/java/gov/nasa/pds/validate/commandline/options/FlagOptions.java
+++ b/src/main/java/gov/nasa/pds/validate/commandline/options/FlagOptions.java
@@ -67,6 +67,7 @@ public class FlagOptions {
         options.addOption(new ToolsOption(Flag.LATEST_JSON_FILE));
         options.addOption(new ToolsOption(Flag.NONREGPROD_JSON_FILE));
         options.addOption(new ToolsOption(Flag.SKIP_CONTEXT_VALIDATION));
+        options.addOption(new ToolsOption(Flag.TARGET_LIST_FILE));
         /** DEPRECATED Options **/
         options.addOption(new ToolsOption(Flag.FORCE));
         options.addOption(new ToolsOption(Flag.MODEL));

--- a/src/site/xdoc/operate/index.xml.vm
+++ b/src/site/xdoc/operate/index.xml.vm
@@ -111,6 +111,7 @@ POSSIBILITY OF SUCH DAMAGE.
         <tr><td nowrap="nowrap">-E, --max-errors</td><td>Specify the max number of errors that the tool will report on before gracefully exiting a validation run. Default is 100,000.</td></tr>
 		<tr><td nowrap="nowrap">--add-context-products &lt;dir/files&gt;</td><td>Explicitly specify a JSON file (or directory of files) containing additional context product information used for validation. WARNING: This should only be used for development purposes. All context products must be registered for validity of a product in an archive.</td></tr>
 		<tr><td nowrap="nowrap">--skip-context-validation</td><td>Disable context validation.Only be enabled during development.</td></tr>
+		<tr><td nowrap="nowrap">--target-list-file &lt;dir/file&gt;</td><td>Explicitly specify a file that contains a list of files/directories to validate.</td></tr>
 		<tr><td nowrap="nowrap">-u,--update-context-products</td><td>Update the Context Product information used for validating context product references in labels.</td></tr>
         <tr><td nowrap="nowrap">-V, --version</td><td>Display the release number and copyright information.</td></tr>
         <tr><td nowrap="nowrap">-h, --help</td><td>Display Harvest usage.</td></tr>
@@ -652,6 +653,7 @@ c226a6a0867e003696a752b8c24e56f3  .\context\PDS4_host_VG2_1.0.xml
 		  <tr><td>validate.updateContextProducts</td><td>true</td><td>-u,--update-context-products</td></tr>
 		  <tr><td>validate.addContextProducts</td><td>[dir/files]</td><td>--add-context-products</td></tr>
 		  <tr><td>validate.skipContextValidation</td><td>true</td><td>--skip-context-validation</td></tr>
+		  <tr><td>validate.targetListFile</td><td>[dir/file]</td><td>--target-list-file</td></tr>
         </table>
         <p>The following example demonstrates how to set a configuration file:
         </p>

--- a/src/test/java/gov/nasa/pds/validate/ValidationIntegrationTests.java
+++ b/src/test/java/gov/nasa/pds/validate/ValidationIntegrationTests.java
@@ -457,6 +457,59 @@ class ValidationIntegrationTests {
         }
     }
     
+    /*@Test
+    void testGithub50() {
+        try {
+            // Setup paths
+            System.setProperty("resources.home", TestConstants.RESOURCES_DIR);
+            String testPath = Utility.getAbsolutePath(TestConstants.TEST_DATA_DIR + "/github50");
+            String outFilePath = TestConstants.TEST_OUT_DIR;
+            File report = new File(outFilePath + File.separator + "report_github50_1.json");
+            
+            // First test that we get file of target list from command line, and add to the target list to validate.
+            String[] args = {
+                    "-r", report.getAbsolutePath(),
+                    "-s", "json",
+                    "--target-list-file", testPath + File.separator + "target-list.txt",
+                    "-t", testPath + File.separator + "test_context_products.xml"
+                    };
+
+            ValidateLauncher.main(args);
+
+            Gson gson = new Gson();
+            JsonObject reportJson = gson.fromJson(new FileReader(report), JsonObject.class);
+
+            int count1 = this.getMessageCount(reportJson, ProblemType.CONTEXT_REFERENCE_FOUND_MISMATCH.getKey());
+            count1 += this.getMessageCount(reportJson, ProblemType.CONTEXT_REFERENCE_NOT_FOUND.getKey());
+
+            assertEquals(count1, 24, ProblemType.CONTEXT_REFERENCE_FOUND_MISMATCH.getKey() + " and " + ProblemType.CONTEXT_REFERENCE_NOT_FOUND.getKey() + " info/error messages expected.\n" + reportJson.toString());
+
+            // Now let's test that we get file of target list from the config file, and add to the target list to validate.
+            report = new File(outFilePath + File.separator + "report_github50_2.json");
+            String[] args2 = {
+                    "-r", report.getAbsolutePath(),
+                    "-s", "json",
+                    "-c", testPath + File.separator + "config.properties"
+                    };
+
+            ValidateLauncher.main(args2);
+
+            gson = new Gson();
+            reportJson = gson.fromJson(new FileReader(report), JsonObject.class);
+            
+            int count = this.getMessageCount(reportJson, ProblemType.CONTEXT_REFERENCE_FOUND_MISMATCH.getKey());
+            count += this.getMessageCount(reportJson, ProblemType.CONTEXT_REFERENCE_NOT_FOUND.getKey());
+
+            assertEquals(count, 24, ProblemType.CONTEXT_REFERENCE_FOUND_MISMATCH.getKey() + " and " + ProblemType.CONTEXT_REFERENCE_NOT_FOUND.getKey() + " info/error messages expected.\n" + reportJson.toString());
+
+        } catch (ExitException e) {
+            assertEquals(0, e.status, "Exit status");
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail("Test Failed Due To Exception: " + e.getMessage());
+        }
+    }*/
+    
     int getMessageCount(JsonObject reportJson, String messageTypeName) {
         int i = 0;
         JsonObject message = null;


### PR DESCRIPTION
Added new option "--target-list-file" for the command line and
"validate.targetListFile" for the config file.

Modified index.xml.vm for the new option.

To test:
bin/validate -c [config file]
bin/validate --target-list-file [target list file] -t [target]
bin/validate --target-list-file [target list file]

Check the target files in the report (Parameters:Targets).

Resolves #50
