### PR TITLE
Add new target-manifest flag for user to provide a manifest of file/directory paths

### DIFF
--- a/src/main/java/gov/nasa/pds/validate/ValidateLauncher.java
+++ b/src/main/java/gov/nasa/pds/validate/ValidateLauncher.java
@@ -328,7 +328,7 @@ public class ValidateLauncher {
                 setForce(false);
             } else if (Flag.TARGET.getShortName().equals(o.getOpt())) {
                 targetList.addAll(o.getValuesList());
-            } else if (Flag.TARGET_LIST_FILE.getLongName().equals(o.getLongOpt())) {
+            } else if (Flag.TARGET_MANIFEST.getLongName().equals(o.getLongOpt())) {
                 String fileName = o.getValue();
                 File listF = new File(fileName);               
                 if (listF.exists()) {

--- a/src/main/java/gov/nasa/pds/validate/ValidateLauncher.java
+++ b/src/main/java/gov/nasa/pds/validate/ValidateLauncher.java
@@ -663,8 +663,8 @@ public class ValidateLauncher {
                     setValidateContext(false);
                 }
             }
-            if (config.containsKey(ConfigKey.TARGET_LIST_FILE)) {
-                String fileName = config.getString(ConfigKey.TARGET_LIST_FILE);
+            if (config.containsKey(ConfigKey.TARGET_MANIFEST)) {
+                String fileName = config.getString(ConfigKey.TARGET_MANIFEST);
                 File listF = new File(fileName);               
                 if (listF.exists()) {
                     List<String> listTgt;

--- a/src/main/java/gov/nasa/pds/validate/commandline/options/ConfigKey.java
+++ b/src/main/java/gov/nasa/pds/validate/commandline/options/ConfigKey.java
@@ -123,4 +123,9 @@ public class ConfigKey {
      * Property to disable context validation.
      */
     public static final String SKIP_CONTEXT_VALIDATION = "validate.skipContextValidation";
+    
+    /**
+     * Property to specify the file that contains a list of files/directories to validate.
+     */
+    public static final String TARGET_LIST_FILE = "validate.targetListFile";
 }

--- a/src/main/java/gov/nasa/pds/validate/commandline/options/ConfigKey.java
+++ b/src/main/java/gov/nasa/pds/validate/commandline/options/ConfigKey.java
@@ -127,5 +127,5 @@ public class ConfigKey {
     /**
      * Property to specify the file that contains a list of files/directories to validate.
      */
-    public static final String TARGET_LIST_FILE = "validate.targetListFile";
+    public static final String TARGET_MANIFEST = "validate.targetManifest";
 }

--- a/src/main/java/gov/nasa/pds/validate/commandline/options/Flag.java
+++ b/src/main/java/gov/nasa/pds/validate/commandline/options/Flag.java
@@ -157,7 +157,7 @@ public enum Flag {
     /**
      * flag to Flag to specify the file that contains a list of files/directories to validate.
      */
-    TARGET_LIST_FILE(null, "target-list-file", "dir/file", String.class, true, "Explicitly specify a file that contains a list of files/directories to validate.");
+    TARGET_MANIFEST(null, "target-manifest", "file", String.class, true, "Specify a manifest file of files/directory paths to validate.");
     
     /** The short name. */
     private final String shortName;

--- a/src/main/java/gov/nasa/pds/validate/commandline/options/Flag.java
+++ b/src/main/java/gov/nasa/pds/validate/commandline/options/Flag.java
@@ -153,7 +153,11 @@ public enum Flag {
      * enabled, the output logs will throw WARNING messages instead of failing
      * validation. Only be enabled during development
      */
-    SKIP_CONTEXT_VALIDATION(null, "skip-context-validation", "Disable context product reference validation. WARNING: This should only be used for development purposes only. All context products must be registered for validity of a product in an archive.");
+    SKIP_CONTEXT_VALIDATION(null, "skip-context-validation", "Disable context product reference validation. WARNING: This should only be used for development purposes only. All context products must be registered for validity of a product in an archive."),
+    /**
+     * flag to Flag to specify the file that contains a list of files/directories to validate.
+     */
+    TARGET_LIST_FILE(null, "target-list-file", "dir/file", String.class, true, "Explicitly specify a file that contains a list of files/directories to validate.");
     
     /** The short name. */
     private final String shortName;

--- a/src/main/java/gov/nasa/pds/validate/commandline/options/FlagOptions.java
+++ b/src/main/java/gov/nasa/pds/validate/commandline/options/FlagOptions.java
@@ -67,7 +67,7 @@ public class FlagOptions {
         options.addOption(new ToolsOption(Flag.LATEST_JSON_FILE));
         options.addOption(new ToolsOption(Flag.NONREGPROD_JSON_FILE));
         options.addOption(new ToolsOption(Flag.SKIP_CONTEXT_VALIDATION));
-        options.addOption(new ToolsOption(Flag.TARGET_LIST_FILE));
+        options.addOption(new ToolsOption(Flag.TARGET_MANIFEST));
         /** DEPRECATED Options **/
         options.addOption(new ToolsOption(Flag.FORCE));
         options.addOption(new ToolsOption(Flag.MODEL));

--- a/src/main/java/gov/nasa/pds/validate/commandline/options/FlagOptions.java
+++ b/src/main/java/gov/nasa/pds/validate/commandline/options/FlagOptions.java
@@ -67,6 +67,7 @@ public class FlagOptions {
         options.addOption(new ToolsOption(Flag.LATEST_JSON_FILE));
         options.addOption(new ToolsOption(Flag.NONREGPROD_JSON_FILE));
         options.addOption(new ToolsOption(Flag.SKIP_CONTEXT_VALIDATION));
+        options.addOption(new ToolsOption(Flag.TARGET_LIST_FILE));
         /** DEPRECATED Options **/
         options.addOption(new ToolsOption(Flag.FORCE));
         options.addOption(new ToolsOption(Flag.MODEL));

--- a/src/site/xdoc/operate/index.xml.vm
+++ b/src/site/xdoc/operate/index.xml.vm
@@ -86,36 +86,98 @@ POSSIBILITY OF SUCH DAMAGE.
     </section>
 
     <section name="Command-Line Options">
-      <p>The following table describes the command-line options available:
+      <p>The following shows all command-line options, and can be accessed by running the tool with the -h flag:
       </p>      
-      <table>
-        <tr><th>Command-Line Option</th><th>Description</th></tr>
-        <tr><td nowrap="nowrap">-t, --target &lt;files,directories&gt;</td><td>Explicitly specify the targets (product files, directories) to validate. Targets can be specified implicitly as well (example: Validate product.xml). For more details on target specification, see the <a href="#Specifying_Targets">Specifying Targets</a> section.</td></tr>
-        <tr><td nowrap="nowrap">-R, --rule &lt;validation rule name&gt;</td><td>Specify the validation rules to apply. Valid values are "pds4.bundle", "pds4.collection", "pds4.folder", "pds4.label", or "pds3.volume". Default is to use "pds4.label" for target file inputs and to use "pds4.folder" for target directory inputs. See <a href="#Validation_Rules">Validation Rules</a> for more details.</td></tr>
-        <tr><td nowrap="nowrap">-M, --checksum-manifest &lt;file&gt;</td><td>Specify a Checksum Manifest file to perform additional checksum validation. For more details on checksum vaildation, see the <a href="#Checksum_Manifest_File_Validation">Checksum Manifest File Validation</a> section.</td></tr>
-        <tr><td nowrap="nowrap">-B, --base-path &lt;file&gt;</td><td>Specify a base path in order for the tool to properly resolve relative file references found in a checksum manifest file. For more details on checksum vaildation, see the <a href="#Checksum_Manifest_File_Validation">Checksum Manifest File Validation</a> section.</td></tr>
-        <tr><td nowrap="nowrap">-x, --schema &lt;schemas&gt;</td><td>Specify XML Schema files to use during validation. By using this flag, this will override using the PDS XML Schemas packaged with the tool. When passing in multiple schemas, specify the schema for the <i>pds</i> namespace (otherwise known as the core schema) first, followed by the other schemas. For more details on passing in multiple schemas, see the <a href="#Passing_in_Multiple_Schemas">Passing in Multiple Schemas</a> section.</td></tr>
-        <tr><td nowrap="nowrap">-S, --schematron &lt;schematrons&gt;</td><td>Specify Schematron files to use during validation. By using this flag, this will override using the PDS Schematron files packaged with the tool.</td></tr>
-        <tr><td nowrap="nowrap">-C, --catalog &lt;xml-catalogs&gt;</td><td>Specify XML Catalog files to use during validation.</td></tr>
-        <tr><td nowrap="nowrap">-r, --report-file &lt;file&gt;</td><td>Specify the report file name. Default is to output results to standard out.</td></tr>
-        <tr><td nowrap="nowrap">-s, --report-style &lt;json|xml&gt;</td><td>Specify the standard human-readable report format. Valid values are "full" for a full view, "xml" for an XML view, or "json" for a JSON view. Default is to generate a full report if this option is not specified. For more details on these report styles, see the <a href="#Report_Format">Report Format</a> section.</td></tr>
-        <tr><td nowrap="nowrap">-D, --no-data-check</td><td>Specify to disable data content validation.</td></tr>
-        <tr><td nowrap="nowrap">--spot-check-data &lt;num&gt;</td><td>Specify to skip every nth record (or line in Arrays) during data content validation.</td></tr>
-        <tr><td nowrap="nowrap">--allow-unlabeled-files</td><td>Specify this flag to tell the tool to not check for un-labeled files in a bundle or collection.</td></tr>
-        <tr><td nowrap="nowrap">-v, --verbose &lt;1|2|3&gt;</td><td>Specify the severity level and above to include in the human-readable report: (1=Info, 2=Warning, 3=Error). Default is Warning and above.</td></tr>
-        <tr><td nowrap="nowrap">-e, --regexp &lt;file-patterns&gt;</td><td>Specify file patterns to look for when validating a target directory. This flag is ignored when validating under the pds4.collection or pds4.bundle rules. Each pattern must be surrounded in quotes (example: "*.xml"). Pattern matching is case-insensitive in Windows, but case-sensitive for other systems. The default behavior is to search for files ending in "*.xml" or "*.XML". This flag option will override this default behavior.</td></tr>
-        <tr><td nowrap="nowrap">-m, --model-version &lt;model&gt;</td><td>DEPRECATED: Tool performs validation against the schema and schematron specified in a given label by default. Use -x and/or -S flag(s) to validate with the core PDS or user-specified schema and schematron.</td></tr>
-        <tr><td nowrap="nowrap">-L, --local</td><td>Validate files only in the target directory instead of recursively traversing down the sub-directories.</td></tr>
-        <tr><td nowrap="nowrap">-f, --force</td><td>DEPRECATED: Tool performs validation against the schema and schematron specified in a given label by default. Use -x and/or -S flag(s) to validate with the core PDS or user-specified schema and schematron.</td></tr>
-        <tr><td nowrap="nowrap">-c, --config</td><td>Specify a configuration file to set the tool behavior.</td></tr>
-        <tr><td nowrap="nowrap">-E, --max-errors</td><td>Specify the max number of errors that the tool will report on before gracefully exiting a validation run. Default is 100,000.</td></tr>
-		<tr><td nowrap="nowrap">--add-context-products &lt;dir/files&gt;</td><td>Explicitly specify a JSON file (or directory of files) containing additional context product information used for validation. WARNING: This should only be used for development purposes. All context products must be registered for validity of a product in an archive.</td></tr>
-		<tr><td nowrap="nowrap">--skip-context-validation</td><td>Disable context validation.Only be enabled during development.</td></tr>
-		<tr><td nowrap="nowrap">--target-list-file &lt;dir/file&gt;</td><td>Explicitly specify a file that contains a list of files/directories to validate.</td></tr>
-		<tr><td nowrap="nowrap">-u,--update-context-products</td><td>Update the Context Product information used for validating context product references in labels.</td></tr>
-        <tr><td nowrap="nowrap">-V, --version</td><td>Display the release number and copyright information.</td></tr>
-        <tr><td nowrap="nowrap">-h, --help</td><td>Display Harvest usage.</td></tr>
-      </table>
+      <source>
+    --add-context-products &lt;dir/files&gt;   Explicitly specify a JSON file (or
+                                         directory of files) containing
+                                         additional context product information
+                                         used for validation. WARNING: This
+                                         should only be used for development
+                                         purposes. All context products must be
+                                         registered for validity of a product in
+                                         an archive.
+    --allow-unlabeled-files              Tells the tool to not check for
+                                         unlabeled files in a bundle or
+                                         collection.
+ -B,--base-path &lt;path&gt;                   Specify a path for the tool to use in
+                                         order to properly resolve relative file
+                                         references found in a checksum manifest
+                                         file.
+ -C,--catalog &lt;catalog files&gt;            Specify catalog files to use during
+                                         validation.
+ -c,--config &lt;file&gt;                      Specify a configuration file to set the
+                                         tool behavior.
+ -D,--no-data-check                      Disable data content validation.
+ -E,--max-errors &lt;value&gt;                 Specify the max number of errors that
+                                         the tool will report on before
+                                         gracefully exiting a validation run.
+                                         Default is 100,000.
+ -e,--regexp &lt;patterns&gt;                  Specify file patterns to look for when
+                                         validating a directory. Each pattern
+                                         should be surrounded by quotes. Default
+                                         is to look for files ending with a
+                                         '.xml' or '.XML' file extension.
+ -f,--force                              DEPRECATED: Tool performs validation
+                                         against the schema and schematron
+                                         specified in a given label by default.
+                                         Use -x and/or -S flag(s) to validate
+                                         with the core PDS or user-specified
+                                         schema and schematron.
+ -h,--help                               Display usage.
+ -L,--local                              Validate files only in the target
+                                         directory rather than recursively
+                                         traversing down the subdirectories.
+ -M,--checksum-manifest &lt;file&gt;           Specify a checksum manifest file to
+                                         perform checksum validation against the
+                                         targets being validated.
+ -m,--model-version &lt;version&gt;            DEPRECATED: Tool performs validation
+                                         against the schema and schematron
+                                         specified in a given label by default.
+                                         Use -x and/or -S flag(s) to validate
+                                         with the core PDS or user-specified
+                                         schema and schematron.
+ -r,--report-file &lt;file name&gt;            Specify the report file name. Default
+                                         is standard out.
+ -R,--rule &lt;validation rule name&gt;        Specifies the validation rules to
+                                         apply.
+                                         (pds4.bundle|pds4.collection|pds4.folde
+                                         r|pds4.label|pds3.volume). Default is
+                                         to auto-detect based on the contents at
+                                         the location specified.
+ -S,--schematron &lt;schematron files&gt;      Specify schematron files.
+ -s,--report-style &lt;full|json|xml&gt;       Specify the level of detail for the
+                                         reporting. Valid values are 'full' for
+                                         a full view, 'json' for a json view,
+                                         and 'xml' for an XML view. Default is
+                                         to see a full report if this flag is
+                                         not specified
+    --skip-context-validation            Disable context product reference
+                                         validation. WARNING: This should only
+                                         be used for development purposes only.
+                                         All context products must be registered
+                                         for validity of a product in an
+                                         archive.
+    --spot-check-data &lt;num&gt;              Tells the tool to skip every nth
+                                         records or lines during data content
+                                         validation.
+ -t,--target &lt;files,dirs&gt;                Explicitly specify the targets (files,
+                                         directories) to validate. Targets can
+                                         be specified implicitly as well.
+                                         (example: validate product.xml)
+    --target-manifest &lt;file&gt;             Specify a manifest file of
+                                         files/directory paths to validate.
+ -u,--update-context-products            Update the Context Product information
+                                         used for validating context product
+                                         references in labels.
+ -v,--verbose &lt;1|2|3&gt;                    Specify the severity level and above to
+                                         include in the human-readable report:
+                                         (1=Info, 2=Warning, 3=Error). Default
+                                         is Warning and above.
+ -V,--version                            Display application version.
+ -x,--schema &lt;schema files&gt;              Specify schema files.
+
+      </source>
       
     </section>
 

--- a/src/site/xdoc/operate/index.xml.vm
+++ b/src/site/xdoc/operate/index.xml.vm
@@ -111,6 +111,7 @@ POSSIBILITY OF SUCH DAMAGE.
         <tr><td nowrap="nowrap">-E, --max-errors</td><td>Specify the max number of errors that the tool will report on before gracefully exiting a validation run. Default is 100,000.</td></tr>
 		<tr><td nowrap="nowrap">--add-context-products &lt;dir/files&gt;</td><td>Explicitly specify a JSON file (or directory of files) containing additional context product information used for validation. WARNING: This should only be used for development purposes. All context products must be registered for validity of a product in an archive.</td></tr>
 		<tr><td nowrap="nowrap">--skip-context-validation</td><td>Disable context validation.Only be enabled during development.</td></tr>
+		<tr><td nowrap="nowrap">--target-list-file &lt;dir/file&gt;</td><td>Explicitly specify a file that contains a list of files/directories to validate.</td></tr>
 		<tr><td nowrap="nowrap">-u,--update-context-products</td><td>Update the Context Product information used for validating context product references in labels.</td></tr>
         <tr><td nowrap="nowrap">-V, --version</td><td>Display the release number and copyright information.</td></tr>
         <tr><td nowrap="nowrap">-h, --help</td><td>Display Harvest usage.</td></tr>
@@ -652,6 +653,7 @@ c226a6a0867e003696a752b8c24e56f3  .\context\PDS4_host_VG2_1.0.xml
 		  <tr><td>validate.updateContextProducts</td><td>true</td><td>-u,--update-context-products</td></tr>
 		  <tr><td>validate.addContextProducts</td><td>[dir/files]</td><td>--add-context-products</td></tr>
 		  <tr><td>validate.skipContextValidation</td><td>true</td><td>--skip-context-validation</td></tr>
+		  <tr><td>validate.targetListFile</td><td>[dir/file]</td><td>--target-list-file</td></tr>
         </table>
         <p>The following example demonstrates how to set a configuration file:
         </p>

--- a/src/test/java/gov/nasa/pds/validate/ValidationIntegrationTests.java
+++ b/src/test/java/gov/nasa/pds/validate/ValidationIntegrationTests.java
@@ -457,7 +457,7 @@ class ValidationIntegrationTests {
         }
     }
     
-    /*@Test
+    @Test
     void testGithub50() {
         try {
             // Setup paths
@@ -465,13 +465,23 @@ class ValidationIntegrationTests {
             String testPath = Utility.getAbsolutePath(TestConstants.TEST_DATA_DIR + "/github50");
             String outFilePath = TestConstants.TEST_OUT_DIR;
             File report = new File(outFilePath + File.separator + "report_github50_1.json");
-            
+
+            String manifestFile = outFilePath + File.separator + "target-manifest.xml";
+
+            // Create catalog file
+            String manifestText = testPath + "/ele_evt_12hr_orbit_2011-2012.xml\n" +
+                    testPath + "/ele_evt_8hr_orbit_2012-2013.xml";
+
+            BufferedWriter writer = new BufferedWriter(new FileWriter(manifestFile));
+            writer.write(manifestText);
+            writer.close();
+
             // First test that we get file of target list from command line, and add to the target list to validate.
             String[] args = {
                     "-r", report.getAbsolutePath(),
                     "-s", "json",
-                    "--target-list-file", testPath + File.separator + "target-list.txt",
-                    "-t", testPath + File.separator + "test_context_products.xml"
+                    "--no-data-check",
+                    "--target-manifest", manifestFile
                     };
 
             ValidateLauncher.main(args);
@@ -479,28 +489,27 @@ class ValidationIntegrationTests {
             Gson gson = new Gson();
             JsonObject reportJson = gson.fromJson(new FileReader(report), JsonObject.class);
 
-            int count1 = this.getMessageCount(reportJson, ProblemType.CONTEXT_REFERENCE_FOUND_MISMATCH.getKey());
-            count1 += this.getMessageCount(reportJson, ProblemType.CONTEXT_REFERENCE_NOT_FOUND.getKey());
+            int count = this.getMessageCount(reportJson, ProblemType.MISSING_REFERENCED_FILE.getKey());
 
-            assertEquals(count1, 24, ProblemType.CONTEXT_REFERENCE_FOUND_MISMATCH.getKey() + " and " + ProblemType.CONTEXT_REFERENCE_NOT_FOUND.getKey() + " info/error messages expected.\n" + reportJson.toString());
-
-            // Now let's test that we get file of target list from the config file, and add to the target list to validate.
-            report = new File(outFilePath + File.separator + "report_github50_2.json");
+            assertEquals(count, 2, "2 " + ProblemType.MISSING_REFERENCED_FILE.getKey() + " error messages expected.\n" + reportJson.toString());
+            
+            // Now try with manifest and target
             String[] args2 = {
                     "-r", report.getAbsolutePath(),
                     "-s", "json",
-                    "-c", testPath + File.separator + "config.properties"
+                    "--no-data-check",
+                    "--target-manifest", manifestFile,
+                    "-t", testPath + "/ele_evt_8hr_orbit_2014-2015.xml"
                     };
 
             ValidateLauncher.main(args2);
 
             gson = new Gson();
             reportJson = gson.fromJson(new FileReader(report), JsonObject.class);
-            
-            int count = this.getMessageCount(reportJson, ProblemType.CONTEXT_REFERENCE_FOUND_MISMATCH.getKey());
-            count += this.getMessageCount(reportJson, ProblemType.CONTEXT_REFERENCE_NOT_FOUND.getKey());
 
-            assertEquals(count, 24, ProblemType.CONTEXT_REFERENCE_FOUND_MISMATCH.getKey() + " and " + ProblemType.CONTEXT_REFERENCE_NOT_FOUND.getKey() + " info/error messages expected.\n" + reportJson.toString());
+            count = this.getMessageCount(reportJson, ProblemType.MISSING_REFERENCED_FILE.getKey());
+
+            assertEquals(count, 3, "3 " + ProblemType.MISSING_REFERENCED_FILE.getKey() + " error messages expected.\n" + reportJson.toString());
 
         } catch (ExitException e) {
             assertEquals(0, e.status, "Exit status");
@@ -508,7 +517,7 @@ class ValidationIntegrationTests {
             e.printStackTrace();
             fail("Test Failed Due To Exception: " + e.getMessage());
         }
-    }*/
+    }
     
     int getMessageCount(JsonObject reportJson, String messageTypeName) {
         int i = 0;

--- a/src/test/java/gov/nasa/pds/validate/ValidationIntegrationTests.java
+++ b/src/test/java/gov/nasa/pds/validate/ValidationIntegrationTests.java
@@ -457,6 +457,59 @@ class ValidationIntegrationTests {
         }
     }
     
+    /*@Test
+    void testGithub50() {
+        try {
+            // Setup paths
+            System.setProperty("resources.home", TestConstants.RESOURCES_DIR);
+            String testPath = Utility.getAbsolutePath(TestConstants.TEST_DATA_DIR + "/github50");
+            String outFilePath = TestConstants.TEST_OUT_DIR;
+            File report = new File(outFilePath + File.separator + "report_github50_1.json");
+            
+            // First test that we get file of target list from command line, and add to the target list to validate.
+            String[] args = {
+                    "-r", report.getAbsolutePath(),
+                    "-s", "json",
+                    "--target-list-file", testPath + File.separator + "target-list.txt",
+                    "-t", testPath + File.separator + "test_context_products.xml"
+                    };
+
+            ValidateLauncher.main(args);
+
+            Gson gson = new Gson();
+            JsonObject reportJson = gson.fromJson(new FileReader(report), JsonObject.class);
+
+            int count1 = this.getMessageCount(reportJson, ProblemType.CONTEXT_REFERENCE_FOUND_MISMATCH.getKey());
+            count1 += this.getMessageCount(reportJson, ProblemType.CONTEXT_REFERENCE_NOT_FOUND.getKey());
+
+            assertEquals(count1, 24, ProblemType.CONTEXT_REFERENCE_FOUND_MISMATCH.getKey() + " and " + ProblemType.CONTEXT_REFERENCE_NOT_FOUND.getKey() + " info/error messages expected.\n" + reportJson.toString());
+
+            // Now let's test that we get file of target list from the config file, and add to the target list to validate.
+            report = new File(outFilePath + File.separator + "report_github50_2.json");
+            String[] args2 = {
+                    "-r", report.getAbsolutePath(),
+                    "-s", "json",
+                    "-c", testPath + File.separator + "config.properties"
+                    };
+
+            ValidateLauncher.main(args2);
+
+            gson = new Gson();
+            reportJson = gson.fromJson(new FileReader(report), JsonObject.class);
+            
+            int count = this.getMessageCount(reportJson, ProblemType.CONTEXT_REFERENCE_FOUND_MISMATCH.getKey());
+            count += this.getMessageCount(reportJson, ProblemType.CONTEXT_REFERENCE_NOT_FOUND.getKey());
+
+            assertEquals(count, 24, ProblemType.CONTEXT_REFERENCE_FOUND_MISMATCH.getKey() + " and " + ProblemType.CONTEXT_REFERENCE_NOT_FOUND.getKey() + " info/error messages expected.\n" + reportJson.toString());
+
+        } catch (ExitException e) {
+            assertEquals(0, e.status, "Exit status");
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail("Test Failed Due To Exception: " + e.getMessage());
+        }
+    }*/
+    
     int getMessageCount(JsonObject reportJson, String messageTypeName) {
         int i = 0;
         JsonObject message = null;

--- a/src/test/resources/github50/ele_evt_12hr_orbit_2011-2012.xml
+++ b/src/test/resources/github50/ele_evt_12hr_orbit_2011-2012.xml
@@ -1,0 +1,319 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1700.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+
+<Product_Observational xmlns="http://pds.nasa.gov/pds4/pds/v1"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1 http://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1700.xsd">
+    <Identification_Area>
+        <logical_identifier>urn:nasa:pds:izenberg_pdart14_meap:data_eetable:ele_evt_12hr_orbit_2011-2012</logical_identifier>
+        <version_id>1.0</version_id>
+        <title>Mercury Energetic Electrons Events Table</title>
+        <information_model_version>1.7.0.0</information_model_version>
+        <product_class>Product_Observational</product_class>
+        <Modification_History>
+            <Modification_Detail>
+                <modification_date>2017-02-09</modification_date>
+                <version_id>1.0</version_id>
+                <description>Izenberg PDART 2014 MEAP Energetic Electron Events Table. 12 hr orbit 2011-2012.</description>
+            </Modification_Detail>
+        </Modification_History>
+    </Identification_Area>
+    <Observation_Area>
+        <Time_Coordinates>
+            <start_date_time>2011-03-25Z</start_date_time>
+            <stop_date_time>2012-04-15Z</stop_date_time>
+        </Time_Coordinates>
+        <Primary_Result_Summary>
+            <purpose>Science</purpose>
+            <processing_level>Derived</processing_level>
+            <description>Data from the MESSENGER Neutron Spectrometer (NS) have been used to detect
+              and characterize energetic electron (EE) events within Mercury's magnetosphere.</description>
+        </Primary_Result_Summary>
+        <Investigation_Area>
+            <name>MESSENGER</name>
+            <type>Mission</type>
+            <Internal_Reference>
+                <lid_reference>urn:nasa:pds:context:investigation:mission.messenger</lid_reference>
+                <reference_type>data_to_investigation</reference_type>
+            </Internal_Reference>
+        </Investigation_Area>
+        <Observing_System>
+            <name>MESSENGER NS</name>
+            <Observing_System_Component>
+                <name>MESSENGER</name>
+                <type>Spacecraft</type>
+                <Internal_Reference>
+                    <lid_reference>urn:nasa:pds:context:instrument_host:spacecraft.mess</lid_reference>
+                    <reference_type>is_instrument_host</reference_type>
+                </Internal_Reference>
+            </Observing_System_Component>
+            <Observing_System_Component>
+                <name>NS</name>
+                <type>Instrument</type>
+                <Internal_Reference>
+                    <lid_reference>urn:nasa:pds:context:instrument:ns.mess</lid_reference>
+                    <reference_type>is_instrument</reference_type>
+                </Internal_Reference>
+            </Observing_System_Component>            
+        </Observing_System>
+        <Target_Identification>
+            <name>Mercury</name>
+            <type>Planet</type>
+            <Internal_Reference>
+                <lid_reference>urn:nasa:pds:context:target:planet.mercury</lid_reference>
+                <reference_type>collection_to_target</reference_type>
+            </Internal_Reference>
+        </Target_Identification>
+    </Observation_Area>
+    <Reference_List>
+        <External_Reference>
+            <doi>10.1126/science.1211141</doi>
+            <reference_text>Ho et al., 2011, MESSENGER observations of transient bursts of 
+               energetic electrons in Mercury's magnetosphere, Science, 333, 1865-8.
+            </reference_text>
+        </External_Reference>
+    </Reference_List>
+    <File_Area_Observational>
+        <File>
+            <file_name>ele_evt_12hr_orbit_2011-2012.tab</file_name>
+            <creation_date_time>2017-02-09T12:44:00Z</creation_date_time>
+            <file_size unit="byte">4639170</file_size>
+        </File>
+        <Header>
+            <offset unit="byte">0</offset>
+            <object_length unit="byte">354</object_length>
+            <parsing_standard_id>7-Bit ASCII Text</parsing_standard_id>
+            <description>The first row of the table contains column headings.</description>
+        </Header>
+        <Table_Character>
+            <name>Energetic Electron events, 12 hour orbit, 2011-2012</name>
+            <offset unit="byte">354</offset>
+            <records>13104</records>
+            <record_delimiter>Carriage-Return Line-Feed</record_delimiter>
+            <Record_Character>
+                <fields>22</fields>
+                <groups>0</groups>
+                <record_length unit="byte">354</record_length>
+                <Field_Character>
+                    <name>Event Number</name>
+                    <field_number>1</field_number>
+                    <field_location unit="byte">1</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <description>EE event number. The value is repeated for 'Event 
+                      Length' rows in the file.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>Event Length</name>
+                    <field_number>2</field_number>
+                    <field_location unit="byte">17</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <description>Number of 20-second accumulations.  The value is repeated 
+                      for 'Event Length' rows in the file.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>Day of Year</name>
+                    <field_number>3</field_number>
+                    <field_location unit="byte">33</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <description>Day of year on which the 20-second accumulation 
+                      occurs.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>Month</name>
+                    <field_number>4</field_number>
+                    <field_location unit="byte">49</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <description>Month in which the 20-second accumulation 
+                      occurs.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>Day</name>
+                    <field_number>5</field_number>
+                    <field_location unit="byte">65</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <description>Day in the month in which the 20-second 
+                      accumulation occurs.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>Year</name>
+                    <field_number>6</field_number>
+                    <field_location unit="byte">81</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <description>Year in which the 20-second accumulation 
+                      occurs.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>Hour</name>
+                    <field_number>7</field_number>
+                    <field_location unit="byte">97</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <description>Hour within the day in which the 20-second 
+                      accumulation occurs.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>Minute</name>
+                    <field_number>8</field_number>
+                    <field_location unit="byte">113</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <description>Minute within the hour in which the 20-second 
+                      accumulation occurs.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>Second</name>
+                    <field_number>9</field_number>
+                    <field_location unit="byte">129</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <description>Second within the minute in which the 
+                      20-second accumulation occurs.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>MET</name>
+                    <field_number>10</field_number>
+                    <field_location unit="byte">145</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <unit>s</unit>
+                    <description>Mission elapsed time, and is the mission tag 
+                      time in seconds of the start of the associated 
+                      accumulated period.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>Orbit Number</name>
+                    <field_number>11</field_number>
+                    <field_location unit="byte">161</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <description>Unique identifier for a given orbit of 
+                      MESSENGER around Mercury. Orbit number is defined as 
+                      starting at apoherm and is calculated using the MET 
+                      value and the appropriate SPICE kernels. Orbit 
+                      numbering does not start until MESSENGER performs the 
+                      Mercury orbit insertion. Until that time the value for 
+                      orbit number is 0.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>Altitude</name>
+                    <field_number>12</field_number>
+                    <field_location unit="byte">177</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <unit>km</unit>
+                    <description>Spacecraft altitude above the subsatellite 
+                      point on the target in units of km.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>Latitude</name>
+                    <field_number>13</field_number>
+                    <field_location unit="byte">193</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <unit>deg</unit>
+                    <description>Target-centric latitude of the spacecraft 
+                      subsatellite point in degrees.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>Longitude</name>
+                    <field_number>14</field_number>
+                    <field_location unit="byte">209</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <unit>deg</unit>
+                    <description>Target-centric longitude of the spacecraft 
+                      subsatellite point in degrees.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>Local Time</name>
+                    <field_number>15</field_number>
+                    <field_location unit="byte">225</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <unit>hr</unit>
+                    <description>Local time of the spacecraft subsatellite 
+                      point in hours from 0 to 24.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>Beta Angle</name>
+                    <field_number>16</field_number>
+                    <field_location unit="byte">241</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <unit>deg</unit>
+                    <description>Angle of the normal of the spacecraft 
+                      orbital plane with respect to Mercury-to-Sun vector 
+                      in degrees.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>Sun Distance</name>
+                    <field_number>17</field_number>
+                    <field_location unit="byte">257</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <unit>km</unit>
+                    <description>Distance of the spacecraft to the Sun in 
+                      units of km.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>Periapsis Latitude</name>
+                    <field_number>18</field_number>
+                    <field_location unit="byte">273</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <unit>deg</unit>
+                    <description>Target-centric latitude of the spacecraft 
+                      when it is at the periapsis (lowest) altitude for the 
+                      given orbit number.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>Event Length Minute</name>
+                    <field_number>19</field_number>
+                    <field_location unit="byte">289</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <unit>min</unit>
+                    <description>Length of the EE event in minutes. The 
+                      value is repeated for 'Event Length' rows in the file.
+                      </description>
+                </Field_Character>
+                <Field_Character>
+                    <name>SN</name>
+                    <field_number>20</field_number>
+                    <field_location unit="byte">305</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <unit>none</unit>
+                    <description>Event signal-to-noise, and is the measure 
+                      of the size of the event within each 20-second 
+                      accumulation.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>BP_TOT</name>
+                    <field_number>21</field_number>
+                    <field_location unit="byte">321</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <description>Total counts within the Borated Plastic 
+                      sensor, 64-channel, 20-s spectral accumulation.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>BP_LOW</name>
+                    <field_number>22</field_number>
+                    <field_location unit="byte">337</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <description>Total counts within the lowest 12 channels 
+                      of the Borated Plastic sensor, 64-channel, 20-s spectral 
+                      accumulation.</description>
+                </Field_Character>
+            </Record_Character>
+        </Table_Character>
+    </File_Area_Observational>
+</Product_Observational>

--- a/src/test/resources/github50/ele_evt_8hr_orbit_2012-2013.xml
+++ b/src/test/resources/github50/ele_evt_8hr_orbit_2012-2013.xml
@@ -1,0 +1,319 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1700.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+
+<Product_Observational xmlns="http://pds.nasa.gov/pds4/pds/v1"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1 http://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1700.xsd">
+    <Identification_Area>
+        <logical_identifier>urn:nasa:pds:izenberg_pdart14_meap:data_eetable:ele_evt_8hr_orbit_2012-2013</logical_identifier>
+        <version_id>1.0</version_id>
+        <title>Mercury Energetic Electrons Events Table</title>
+        <information_model_version>1.7.0.0</information_model_version>
+        <product_class>Product_Observational</product_class>
+        <Modification_History>
+            <Modification_Detail>
+                <modification_date>2016-04-12</modification_date>
+                <version_id>1.0</version_id>
+                <description>Izenberg PDART 2014 MEAP Energetic Electron Events Table. 8 hr orbit 2012-2013.</description>
+            </Modification_Detail>
+        </Modification_History>
+    </Identification_Area>
+    <Observation_Area>
+        <Time_Coordinates>
+            <start_date_time>2012-04-21Z</start_date_time>
+            <stop_date_time>2013-12-26Z</stop_date_time>
+        </Time_Coordinates>
+        <Primary_Result_Summary>
+            <purpose>Science</purpose>
+            <processing_level>Derived</processing_level>
+            <description>Data from the MESSENGER Neutron Spectrometer (NS) have been used to detect
+              and characterize energetic electron (EE) events within Mercury's magnetosphere.</description>
+        </Primary_Result_Summary>
+        <Investigation_Area>
+            <name>MESSENGER</name>
+            <type>Mission</type>
+            <Internal_Reference>
+                <lid_reference>urn:nasa:pds:context:investigation:mission.messenger</lid_reference>
+                <reference_type>data_to_investigation</reference_type>
+            </Internal_Reference>
+        </Investigation_Area>
+        <Observing_System>
+            <name>MESSENGER NS</name>
+            <Observing_System_Component>
+                <name>MESSENGER</name>
+                <type>Spacecraft</type>
+                <Internal_Reference>
+                    <lid_reference>urn:nasa:pds:context:instrument_host:spacecraft.mess</lid_reference>
+                    <reference_type>is_instrument_host</reference_type>
+                </Internal_Reference>
+            </Observing_System_Component>
+            <Observing_System_Component>
+                <name>NS</name>
+                <type>Instrument</type>
+                <Internal_Reference>
+                    <lid_reference>urn:nasa:pds:context:instrument:ns.mess</lid_reference>
+                    <reference_type>is_instrument</reference_type>
+                </Internal_Reference>
+            </Observing_System_Component>            
+        </Observing_System>
+        <Target_Identification>
+            <name>Mercury</name>
+            <type>Planet</type>
+            <Internal_Reference>
+                <lid_reference>urn:nasa:pds:context:target:planet.mercury</lid_reference>
+                <reference_type>collection_to_target</reference_type>
+            </Internal_Reference>
+        </Target_Identification>
+    </Observation_Area>
+    <Reference_List>
+        <External_Reference>
+            <doi>10.1126/science.1211141</doi>
+            <reference_text>Ho et al., 2011, MESSENGER observations of transient bursts of 
+               energetic electrons in Mercury's magnetosphere, Science, 333, 1865-8.
+            </reference_text>
+        </External_Reference>
+    </Reference_List>
+    <File_Area_Observational>
+        <File>
+            <file_name>ele_evt_8hr_orbit_2012-2013.tab</file_name>
+            <creation_date_time>2016-03-16T13:20:13Z</creation_date_time>
+            <file_size unit="byte">10879836</file_size>
+        </File>
+        <Header>
+            <offset unit="byte">0</offset>
+            <object_length unit="byte">354</object_length>
+            <parsing_standard_id>7-Bit ASCII Text</parsing_standard_id>
+            <description>The first row of the table contains column headings.</description>
+        </Header>
+        <Table_Character>
+            <name>Energetic Electron events, 8 hour orbit, 2012-2013</name>
+            <offset unit="byte">354</offset>
+            <records>30733</records>
+            <record_delimiter>Carriage-Return Line-Feed</record_delimiter>
+            <Record_Character>
+                <fields>22</fields>
+                <groups>0</groups>
+                <record_length unit="byte">354</record_length>
+                <Field_Character>
+                    <name>Event Number</name>
+                    <field_number>1</field_number>
+                    <field_location unit="byte">1</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <description>EE event number. The value is repeated for 'Event 
+                      Length' rows in the file.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>Event Length</name>
+                    <field_number>2</field_number>
+                    <field_location unit="byte">17</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <description>Number of 20-second accumulations.  The value is repeated 
+                      for 'Event Length' rows in the file.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>Day of Year</name>
+                    <field_number>3</field_number>
+                    <field_location unit="byte">33</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <description>Day of year on which the 20-second accumulation 
+                      occurs.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>Month</name>
+                    <field_number>4</field_number>
+                    <field_location unit="byte">49</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <description>Month in which the 20-second accumulation 
+                      occurs.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>Day</name>
+                    <field_number>5</field_number>
+                    <field_location unit="byte">65</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <description>Day in the month in which the 20-second 
+                      accumulation occurs.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>Year</name>
+                    <field_number>6</field_number>
+                    <field_location unit="byte">81</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <description>Year in which the 20-second accumulation 
+                      occurs.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>Hour</name>
+                    <field_number>7</field_number>
+                    <field_location unit="byte">97</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <description>Hour within the day in which the 20-second 
+                      accumulation occurs.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>Minute</name>
+                    <field_number>8</field_number>
+                    <field_location unit="byte">113</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <description>Minute within the hour in which the 20-second 
+                      accumulation occurs.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>Second</name>
+                    <field_number>9</field_number>
+                    <field_location unit="byte">129</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <description>Second within the minute in which the 
+                      20-second accumulation occurs.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>MET</name>
+                    <field_number>10</field_number>
+                    <field_location unit="byte">145</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <unit>s</unit>
+                    <description>Mission elapsed time, and is the mission tag 
+                      time in seconds of the start of the associated 
+                      accumulated period.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>Orbit Number</name>
+                    <field_number>11</field_number>
+                    <field_location unit="byte">161</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <description>Unique identifier for a given orbit of 
+                      MESSENGER around Mercury. Orbit number is defined as 
+                      starting at apoherm and is calculated using the MET 
+                      value and the appropriate SPICE kernels. Orbit 
+                      numbering does not start until MESSENGER performs the 
+                      Mercury orbit insertion. Until that time the value for 
+                      orbit number is 0.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>Altitude</name>
+                    <field_number>12</field_number>
+                    <field_location unit="byte">177</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <unit>km</unit>
+                    <description>Spacecraft altitude above the subsatellite 
+                      point on the target in units of km.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>Latitude</name>
+                    <field_number>13</field_number>
+                    <field_location unit="byte">193</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <unit>deg</unit>
+                    <description>Target-centric latitude of the spacecraft 
+                      subsatellite point in degrees.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>Longitude</name>
+                    <field_number>14</field_number>
+                    <field_location unit="byte">209</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <unit>deg</unit>
+                    <description>Target-centric longitude of the spacecraft 
+                      subsatellite point in degrees.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>Local Time</name>
+                    <field_number>15</field_number>
+                    <field_location unit="byte">225</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <unit>hr</unit>
+                    <description>Local time of the spacecraft subsatellite 
+                      point in hours from 0 to 24.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>Beta Angle</name>
+                    <field_number>16</field_number>
+                    <field_location unit="byte">241</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <unit>deg</unit>
+                    <description>Angle of the normal of the spacecraft 
+                      orbital plane with respect to Mercury-to-Sun vector 
+                      in degrees.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>Sun Distance</name>
+                    <field_number>17</field_number>
+                    <field_location unit="byte">257</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <unit>km</unit>
+                    <description>Distance of the spacecraft to the Sun in 
+                      units of km.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>Periapsis Latitude</name>
+                    <field_number>18</field_number>
+                    <field_location unit="byte">273</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <unit>deg</unit>
+                    <description>Target-centric latitude of the spacecraft 
+                      when it is at the periapsis (lowest) altitude for the 
+                      given orbit number.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>Event Length Minute</name>
+                    <field_number>19</field_number>
+                    <field_location unit="byte">289</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <unit>min</unit>
+                    <description>Length of the EE event in minutes. The 
+                      value is repeated for 'Event Length' rows in the file.
+                      </description>
+                </Field_Character>
+                <Field_Character>
+                    <name>SN</name>
+                    <field_number>20</field_number>
+                    <field_location unit="byte">305</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <unit>none</unit>
+                    <description>Event signal-to-noise, and is the measure 
+                      of the size of the event within each 20-second 
+                      accumulation.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>BP_TOT</name>
+                    <field_number>21</field_number>
+                    <field_location unit="byte">321</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <description>Total counts within the Borated Plastic 
+                      sensor, 64-channel, 20-s spectral accumulation.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>BP_LOW</name>
+                    <field_number>22</field_number>
+                    <field_location unit="byte">337</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <description>Total counts within the lowest 12 channels 
+                      of the Borated Plastic sensor, 64-channel, 20-s spectral 
+                      accumulation.</description>
+                </Field_Character>
+            </Record_Character>
+        </Table_Character>
+    </File_Area_Observational>
+</Product_Observational>

--- a/src/test/resources/github50/ele_evt_8hr_orbit_2014-2015.xml
+++ b/src/test/resources/github50/ele_evt_8hr_orbit_2014-2015.xml
@@ -1,0 +1,319 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1700.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+
+<Product_Observational xmlns="http://pds.nasa.gov/pds4/pds/v1"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1 http://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1700.xsd">
+    <Identification_Area>
+        <logical_identifier>urn:nasa:pds:izenberg_pdart14_meap:data_eetable:ele_evt_8hr_orbit_2014-2015</logical_identifier>
+        <version_id>1.0</version_id>
+        <title>Mercury Energetic Electrons Events Table</title>
+        <information_model_version>1.7.0.0</information_model_version>
+        <product_class>Product_Observational</product_class>
+        <Modification_History>
+            <Modification_Detail>
+                <modification_date>2017-02-09</modification_date>
+                <version_id>1.0</version_id>
+                <description>Izenberg PDART 2014 MEAP Energetic Electron Events Table. 8 hr orbit 2014-2015.</description>
+            </Modification_Detail>
+        </Modification_History>
+    </Identification_Area>
+    <Observation_Area>
+        <Time_Coordinates>
+            <start_date_time>2014-01-01Z</start_date_time>
+            <stop_date_time>2015-04-30Z</stop_date_time>
+        </Time_Coordinates>
+        <Primary_Result_Summary>
+            <purpose>Science</purpose>
+            <processing_level>Derived</processing_level>
+            <description>Data from the MESSENGER Neutron Spectrometer (NS) have been used to detect
+              and characterize energetic electron (EE) events within Mercury's magnetosphere.</description>
+        </Primary_Result_Summary>
+        <Investigation_Area>
+            <name>MESSENGER</name>
+            <type>Mission</type>
+            <Internal_Reference>
+                <lid_reference>urn:nasa:pds:context:investigation:mission.messenger</lid_reference>
+                <reference_type>data_to_investigation</reference_type>
+            </Internal_Reference>
+        </Investigation_Area>
+        <Observing_System>
+            <name>MESSENGER NS</name>
+            <Observing_System_Component>
+                <name>MESSENGER</name>
+                <type>Spacecraft</type>
+                <Internal_Reference>
+                    <lid_reference>urn:nasa:pds:context:instrument_host:spacecraft.mess</lid_reference>
+                    <reference_type>is_instrument_host</reference_type>
+                </Internal_Reference>
+            </Observing_System_Component>
+            <Observing_System_Component>
+                <name>NS</name>
+                <type>Instrument</type>
+                <Internal_Reference>
+                    <lid_reference>urn:nasa:pds:context:instrument:ns.mess</lid_reference>
+                    <reference_type>is_instrument</reference_type>
+                </Internal_Reference>
+            </Observing_System_Component>            
+        </Observing_System>
+        <Target_Identification>
+            <name>Mercury</name>
+            <type>Planet</type>
+            <Internal_Reference>
+                <lid_reference>urn:nasa:pds:context:target:planet.mercury</lid_reference>
+                <reference_type>collection_to_target</reference_type>
+            </Internal_Reference>
+        </Target_Identification>
+    </Observation_Area>
+    <Reference_List>
+        <External_Reference>
+            <doi>10.1126/science.1211141</doi>
+            <reference_text>Ho et al., 2011, MESSENGER observations of transient bursts of 
+               energetic electrons in Mercury's magnetosphere, Science, 333, 1865-8.
+            </reference_text>
+        </External_Reference>
+    </Reference_List>
+    <File_Area_Observational>
+        <File>
+            <file_name>ele_evt_8hr_orbit_2014-2015.tab</file_name>
+            <creation_date_time>2017-02-09T12:44:00Z</creation_date_time>
+            <file_size unit="byte">7789416</file_size>
+        </File>
+        <Header>
+            <offset unit="byte">0</offset>
+            <object_length unit="byte">354</object_length>
+            <parsing_standard_id>7-Bit ASCII Text</parsing_standard_id>
+            <description>The first row of the table contains column headings.</description>
+        </Header>
+        <Table_Character>
+            <name>Energetic Electron events, 8 hour orbit, 2014-2015</name>
+            <offset unit="byte">354</offset>
+            <records>22003</records>
+            <record_delimiter>Carriage-Return Line-Feed</record_delimiter>
+            <Record_Character>
+                <fields>22</fields>
+                <groups>0</groups>
+                <record_length unit="byte">354</record_length>
+                <Field_Character>
+                    <name>Event Number</name>
+                    <field_number>1</field_number>
+                    <field_location unit="byte">1</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <description>EE event number. The value is repeated for 'Event 
+                      Length' rows in the file.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>Event Length</name>
+                    <field_number>2</field_number>
+                    <field_location unit="byte">17</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <description>Number of 20-second accumulations.  The value is repeated 
+                      for 'Event Length' rows in the file.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>Day of Year</name>
+                    <field_number>3</field_number>
+                    <field_location unit="byte">33</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <description>Day of year on which the 20-second accumulation 
+                      occurs.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>Month</name>
+                    <field_number>4</field_number>
+                    <field_location unit="byte">49</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <description>Month in which the 20-second accumulation 
+                      occurs.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>Day</name>
+                    <field_number>5</field_number>
+                    <field_location unit="byte">65</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <description>Day in the month in which the 20-second 
+                      accumulation occurs.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>Year</name>
+                    <field_number>6</field_number>
+                    <field_location unit="byte">81</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <description>Year in which the 20-second accumulation 
+                      occurs.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>Hour</name>
+                    <field_number>7</field_number>
+                    <field_location unit="byte">97</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <description>Hour within the day in which the 20-second 
+                      accumulation occurs.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>Minute</name>
+                    <field_number>8</field_number>
+                    <field_location unit="byte">113</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <description>Minute within the hour in which the 20-second 
+                      accumulation occurs.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>Second</name>
+                    <field_number>9</field_number>
+                    <field_location unit="byte">129</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <description>Second within the minute in which the 
+                      20-second accumulation occurs.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>MET</name>
+                    <field_number>10</field_number>
+                    <field_location unit="byte">145</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <unit>s</unit>
+                    <description>Mission elapsed time, and is the mission tag 
+                      time in seconds of the start of the associated 
+                      accumulated period.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>Orbit Number</name>
+                    <field_number>11</field_number>
+                    <field_location unit="byte">161</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <description>Unique identifier for a given orbit of 
+                      MESSENGER around Mercury. Orbit number is defined as 
+                      starting at apoherm and is calculated using the MET 
+                      value and the appropriate SPICE kernels. Orbit 
+                      numbering does not start until MESSENGER performs the 
+                      Mercury orbit insertion. Until that time the value for 
+                      orbit number is 0.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>Altitude</name>
+                    <field_number>12</field_number>
+                    <field_location unit="byte">177</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <unit>km</unit>
+                    <description>Spacecraft altitude above the subsatellite 
+                      point on the target in units of km.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>Latitude</name>
+                    <field_number>13</field_number>
+                    <field_location unit="byte">193</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <unit>deg</unit>
+                    <description>Target-centric latitude of the spacecraft 
+                      subsatellite point in degrees.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>Longitude</name>
+                    <field_number>14</field_number>
+                    <field_location unit="byte">209</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <unit>deg</unit>
+                    <description>Target-centric longitude of the spacecraft 
+                      subsatellite point in degrees.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>Local Time</name>
+                    <field_number>15</field_number>
+                    <field_location unit="byte">225</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <unit>hr</unit>
+                    <description>Local time of the spacecraft subsatellite 
+                      point in hours from 0 to 24.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>Beta Angle</name>
+                    <field_number>16</field_number>
+                    <field_location unit="byte">241</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <unit>deg</unit>
+                    <description>Angle of the normal of the spacecraft 
+                      orbital plane with respect to Mercury-to-Sun vector 
+                      in degrees.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>Sun Distance</name>
+                    <field_number>17</field_number>
+                    <field_location unit="byte">257</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <unit>km</unit>
+                    <description>Distance of the spacecraft to the Sun in 
+                      units of km.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>Periapsis Latitude</name>
+                    <field_number>18</field_number>
+                    <field_location unit="byte">273</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <unit>deg</unit>
+                    <description>Target-centric latitude of the spacecraft 
+                      when it is at the periapsis (lowest) altitude for the 
+                      given orbit number.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>Event Length Minute</name>
+                    <field_number>19</field_number>
+                    <field_location unit="byte">289</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <unit>min</unit>
+                    <description>Length of the EE event in minutes. The 
+                      value is repeated for 'Event Length' rows in the file.
+                      </description>
+                </Field_Character>
+                <Field_Character>
+                    <name>SN</name>
+                    <field_number>20</field_number>
+                    <field_location unit="byte">305</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <unit>none</unit>
+                    <description>Event signal-to-noise, and is the measure 
+                      of the size of the event within each 20-second 
+                      accumulation.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>BP_TOT</name>
+                    <field_number>21</field_number>
+                    <field_location unit="byte">321</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <description>Total counts within the Borated Plastic 
+                      sensor, 64-channel, 20-s spectral accumulation.</description>
+                </Field_Character>
+                <Field_Character>
+                    <name>BP_LOW</name>
+                    <field_number>22</field_number>
+                    <field_location unit="byte">337</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">16</field_length>
+                    <description>Total counts within the lowest 12 channels 
+                      of the Borated Plastic sensor, 64-channel, 20-s spectral 
+                      accumulation.</description>
+                </Field_Character>
+            </Record_Character>
+        </Table_Character>
+    </File_Area_Observational>
+</Product_Observational>


### PR DESCRIPTION
Added new option "--target-manfiest" for the command line and
"validate.targetManifestFile" for the config file.

Modified index.xml.vm for the new option.

To test:
bin/validate -c [config file]
bin/validate --target-list-file [target list file] -t [target]
bin/validate --target-list-file [target list file]

Check the target files in the report (Parameters:Targets).

Resolves #50