### PR TITLE
Update context product check to allow multi-valued name/type

### DIFF
--- a/src/main/java/gov/nasa/pds/tools/util/ContextProductReference.java
+++ b/src/main/java/gov/nasa/pds/tools/util/ContextProductReference.java
@@ -13,6 +13,8 @@
 // $Id: LidVid.java 10921 2012-09-10 22:11:40Z mcayanan $
 package gov.nasa.pds.tools.util;
 
+import java.util.List;
+
 /**
  * Class that represents the lidvid of a PDS4 data product.
  *
@@ -27,11 +29,11 @@ public class ContextProductReference {
     /** The version. */
     private String version;
 
-    /** The type. */
-    private String type;
+    /** The context types. */
+    private List<String> types;
 
-    /** The name. */
-    private String name;
+    /** The context names. */
+    private List<String> names;
 
     /** Flag to indicate if a version exists. */
     private boolean hasVersion;
@@ -40,11 +42,11 @@ public class ContextProductReference {
         this(lid, null, null, null);
     }
 
-    public ContextProductReference(String lid, String version, String type, String name) {
+    public ContextProductReference(String lid, String version, List<String> types, List<String> names) {
         this.lid = lid;
         this.version = version;
-        this.type = type;
-        this.name = name;
+        this.types = types;
+        this.names = names;
         if (this.version == null) {
             hasVersion = false;
         } else {
@@ -62,12 +64,12 @@ public class ContextProductReference {
         return this.version;
     }
 
-    public String getType() {
-        return this.type;
+    public List<String> getTypes() {
+        return this.types;
     }
 
-    public String getName() {
-        return this.name;
+    public List<String> getNames() {
+        return this.names;
     }
     
     public void setLid(String lid) {
@@ -78,12 +80,12 @@ public class ContextProductReference {
         this.version = version;
     }
 
-    public void setType(String type) {
-        this.type = type;
+    public void setTypes(List<String> types) {
+        this.types = types;
     }
 
-    public void setName(String name) {
-        this.name = name;
+    public void setName(List<String> names) {
+        this.names = names;
     }
 
     public boolean hasVersion() {

--- a/src/main/java/gov/nasa/pds/validate/ValidateLauncher.java
+++ b/src/main/java/gov/nasa/pds/validate/ValidateLauncher.java
@@ -518,16 +518,38 @@ public class ValidateLauncher {
                 String id = (String) document.getFirstValue("identifier");
                 String ver = (String) document.getFirstValue("version_id");
                 String data_type = (String) document.getFirstValue("data_product_type");
-                String name = (String) document.getFirstValue(data_type.toLowerCase() + "_name");
-                String type = (String) document.getFirstValue(data_type.toLowerCase() + "_type");
-                /*
-                 * System.out.println("Name: " + name);
-                 * System.out.println("Type: " + type);
-                 */
+                List<Object> names = (ArrayList<Object>) document.getFieldValues(data_type.toLowerCase() + "_name");
+                List<Object> types = (ArrayList<Object>) document.getFieldValues(data_type.toLowerCase() + "_type");
 
+                System.out.println("Name: " + names);
+                System.out.println("Type: " + types);
+                
                 jsonWriter.beginObject(); // start a product
-                jsonWriter.name("name").value(name != null ? name : "N/A");
-                jsonWriter.name("type").value(type != null ? type : "N/A");
+                
+                jsonWriter.name("name");
+                jsonWriter.beginArray();
+                if (names == null) {
+                    jsonWriter.value("N/A");
+                } else {
+                    for (Object n : names) {
+                        System.out.println((String) n);
+                        jsonWriter.value((String) n);
+                    }
+                }
+                jsonWriter.endArray();
+                
+                jsonWriter.name("type");
+                jsonWriter.beginArray();
+                if (names == null) {
+                    jsonWriter.value("N/A");
+                } else {
+                    for (Object t : types) {
+                        System.out.println((String) t);
+                        jsonWriter.value((String) t);
+                    }
+                }
+                jsonWriter.endArray();
+
                 jsonWriter.name("lidvid").value(id + "::" + ver);
                 jsonWriter.endObject(); // end a product
             }
@@ -947,17 +969,26 @@ public class ValidateLauncher {
 
                 JsonObject jsonObj = jsonElm.getAsJsonObject();
                 String lidvidString = jsonObj.get("lidvid").getAsString();
-                String typeString = "N/A";
+                List<String> types = new ArrayList<String>();
                 if (!jsonObj.get("type").isJsonNull()) {
-                    typeString = jsonObj.get("type").getAsString();
+                    for (JsonElement e : jsonObj.get("type").getAsJsonArray()) {
+                        types.add(e.getAsString());
+                    }
+                } else {
+                    types.add("N/A");
                 }
-                String nameString = "N/A";
+                
+                List<String> names = new ArrayList<String>();
                 if (!jsonObj.get("name").isJsonNull()) {
-                    nameString = jsonObj.get("name").getAsString();
+                    for (JsonElement e : jsonObj.get("name").getAsJsonArray()) {
+                        names.add(e.getAsString());
+                    }
+                } else {
+                    names.add("N/A");
                 }
 
                 contextProducts.add(
-                        new ContextProductReference(lidvidString.split("::")[0], lidvidString.split("::")[1], typeString, nameString));
+                        new ContextProductReference(lidvidString.split("::")[0], lidvidString.split("::")[1], types, names));
 
             }
         } catch (Exception e) {
@@ -983,16 +1014,25 @@ public class ValidateLauncher {
 
                     JsonObject jsonObjN = jsonElmN.getAsJsonObject();
                     String lidvidStringN = jsonObjN.get("lidvid").getAsString();
-                    String typeStringN = "N/A";
+                    List<String> typesN = new ArrayList<String>();
                     if (!jsonObjN.get("type").isJsonNull()) {
-                        typeStringN = jsonObjN.get("type").getAsString();
+                        for (JsonElement e : jsonObjN.get("type").getAsJsonArray()) {
+                            typesN.add(e.getAsString());
+                        }
+                    } else {
+                        typesN.add("N/A");
                     }
-                    String nameStringN = "N/A";
+                    
+                    List<String> namesN = new ArrayList<String>();
                     if (!jsonObjN.get("name").isJsonNull()) {
-                        nameStringN = jsonObjN.get("name").getAsString();
+                        for (JsonElement e : jsonObjN.get("name").getAsJsonArray()) {
+                            namesN.add(e.getAsString());
+                        }
+                    } else {
+                        namesN.add("N/A");
                     }
-                    contextProducts.add(new ContextProductReference(lidvidStringN.split("::")[0], lidvidStringN.split("::")[1], typeStringN,
-                            nameStringN));
+                    contextProducts.add(new ContextProductReference(lidvidStringN.split("::")[0], lidvidStringN.split("::")[1], typesN,
+                            namesN));
                 }
                 
                 report.record(new URI(ValidateLauncher.class.getName()), pList);

--- a/src/main/resources/util/registered_context_products.json
+++ b/src/main/resources/util/registered_context_products.json
@@ -1,9463 +1,17098 @@
 {
      "Product_Context": [
           {
-               "name": "Mars Science Laboratory (MSL) Archive Information",
-               "type": "Information.Investigation",
+               "name": [
+                    "Mars Science Laboratory (MSL) Archive Information"
+               ],
+               "type": [
+                    "Information.Investigation"
+               ],
                "lidvid": "urn:nasa:pds:context_pds3:resource:resource.mars_science_laboratory_archive_information::1.0"
           },
           {
-               "name": "Mars Global Surveyor Archive Information",
-               "type": "Information.Investigation",
+               "name": [
+                    "Mars Global Surveyor Archive Information"
+               ],
+               "type": [
+                    "Information.Investigation"
+               ],
                "lidvid": "urn:nasa:pds:context_pds3:resource:resource.mars_global_surveyor_archive_information::1.0"
           },
           {
-               "name": "Lunar Atmosphere and Dust Environment Explorer (LADEE) Archive Information",
-               "type": "Information.Investigation",
+               "name": [
+                    "Lunar Atmosphere and Dust Environment Explorer (LADEE) Archive Information"
+               ],
+               "type": [
+                    "Information.Investigation"
+               ],
                "lidvid": "urn:nasa:pds:context:resource:resource.ladee_archive_information::1.0"
           },
           {
-               "name": "MAVEN Archive Information",
-               "type": "Information.Investigation",
+               "name": [
+                    "MAVEN Archive Information"
+               ],
+               "type": [
+                    "Information.Investigation"
+               ],
                "lidvid": "urn:nasa:pds:context:resource:resource.maven_archive_information::1.0"
           },
           {
-               "name": "Chandrayaan-1 Archive Information",
-               "type": "Information.Investigation",
+               "name": [
+                    "Chandrayaan-1 Archive Information"
+               ],
+               "type": [
+                    "Information.Investigation"
+               ],
                "lidvid": "urn:nasa:pds:context_pds3:resource:resource.chandrayaan-1_archive_information::1.0"
           },
           {
-               "name": "Apollo Archive Information",
-               "type": "Information.Investigation",
+               "name": [
+                    "Apollo Archive Information"
+               ],
+               "type": [
+                    "Information.Investigation"
+               ],
                "lidvid": "urn:nasa:pds:context_pds3:resource:resource.apollo_archive_information::1.0"
           },
           {
-               "name": "Cassini Archive Information",
-               "type": "Information.Investigation",
+               "name": [
+                    "Cassini Archive Information"
+               ],
+               "type": [
+                    "Information.Investigation"
+               ],
                "lidvid": "urn:nasa:pds:context_pds3:resource:resource.cassini_archive_information::1.0"
           },
           {
-               "name": "Mars Exploration Rover (MER) Archive Information",
-               "type": "Information.Investigation",
+               "name": [
+                    "Mars Exploration Rover (MER) Archive Information"
+               ],
+               "type": [
+                    "Information.Investigation"
+               ],
                "lidvid": "urn:nasa:pds:context_pds3:resource:resource.mars_exploration_rover_archive_information::1.0"
           },
           {
-               "name": "New Horizons Archive Information",
-               "type": "Information.Investigation",
+               "name": [
+                    "New Horizons Archive Information"
+               ],
+               "type": [
+                    "Information.Investigation"
+               ],
                "lidvid": "urn:nasa:pds:context_pds3:resource:resource.new_horizons_archive_information::1.0"
           },
           {
-               "name": "Gravity Recovery And Interior Laboratory (GRAIL) Archive Information",
-               "type": "Information.Investigation",
+               "name": [
+                    "Gravity Recovery And Interior Laboratory (GRAIL) Archive Information"
+               ],
+               "type": [
+                    "Information.Investigation"
+               ],
                "lidvid": "urn:nasa:pds:context_pds3:resource:resource.gravity_recovery_and_interior_laboratory_archive_information::1.0"
           },
           {
-               "name": "Lunar Crater Observation And Sensing Satellite (LCROSS) Archive Information",
-               "type": "Information.Investigation",
+               "name": [
+                    "Lunar Crater Observation And Sensing Satellite (LCROSS) Archive Information"
+               ],
+               "type": [
+                    "Information.Investigation"
+               ],
                "lidvid": "urn:nasa:pds:context_pds3:resource:resource.lunar_crater_observation_and_sensing_satellite_archive_information::1.0"
           },
           {
-               "name": "Viking Archive Information",
-               "type": "Information.Investigation",
+               "name": [
+                    "Viking Archive Information"
+               ],
+               "type": [
+                    "Information.Investigation"
+               ],
                "lidvid": "urn:nasa:pds:context_pds3:resource:resource.viking_archive_information::1.0"
           },
           {
-               "name": "Magellan Archive Information",
-               "type": "Information.Investigation",
+               "name": [
+                    "Magellan Archive Information"
+               ],
+               "type": [
+                    "Information.Investigation"
+               ],
                "lidvid": "urn:nasa:pds:context_pds3:resource:resource.magellan_archive_information::1.0"
           },
           {
-               "name": "Mars Reconnaissance Orbiter (MRO) Archive Information",
-               "type": "Information.Investigation",
+               "name": [
+                    "Mars Reconnaissance Orbiter (MRO) Archive Information"
+               ],
+               "type": [
+                    "Information.Investigation"
+               ],
                "lidvid": "urn:nasa:pds:context_pds3:resource:resource.mars_reconnaissance_orbiter_archive_information::1.0"
           },
           {
-               "name": "Juno Archive Information",
-               "type": "Information.Investigation",
+               "name": [
+                    "Juno Archive Information"
+               ],
+               "type": [
+                    "Information.Investigation"
+               ],
                "lidvid": "urn:nasa:pds:context_pds3:resource:resource.juno_archive_information::1.0"
           },
           {
-               "name": "Messenger Archive Information",
-               "type": "Information.Investigation",
+               "name": [
+                    "Messenger Archive Information"
+               ],
+               "type": [
+                    "Information.Investigation"
+               ],
                "lidvid": "urn:nasa:pds:context_pds3:resource:resource.messenger_archive_information::1.0"
           },
           {
-               "name": "Mars Express (MEX) Archive Information",
-               "type": "Information.Investigation",
+               "name": [
+                    "Mars Express (MEX) Archive Information"
+               ],
+               "type": [
+                    "Information.Investigation"
+               ],
                "lidvid": "urn:nasa:pds:context_pds3:resource:resource.mars_express_archive_information::1.0"
           },
           {
-               "name": "Mars Pathfinder (MPF) Archive Information",
-               "type": "Information.Investigation",
+               "name": [
+                    "Mars Pathfinder (MPF) Archive Information"
+               ],
+               "type": [
+                    "Information.Investigation"
+               ],
                "lidvid": "urn:nasa:pds:context_pds3:resource:resource.mars_pathfinder_archive_information::1.0"
           },
           {
-               "name": "Lunar Prospector Archive Information",
-               "type": "Information.Investigation",
+               "name": [
+                    "Lunar Prospector Archive Information"
+               ],
+               "type": [
+                    "Information.Investigation"
+               ],
                "lidvid": "urn:nasa:pds:context_pds3:resource:resource.lunar_prospector_archive_information::1.0"
           },
           {
-               "name": "Deep Space Program Science Experiment Archive Information",
-               "type": "Information.Investigation",
+               "name": [
+                    "Deep Space Program Science Experiment Archive Information"
+               ],
+               "type": [
+                    "Information.Investigation"
+               ],
                "lidvid": "urn:nasa:pds:context_pds3:resource:resource.deep_space_program_science_experiment_archive_information::1.0"
           },
           {
-               "name": "Lunar Reconnaissance Orbiter (LRO) Archive Information",
-               "type": "Information.Investigation",
+               "name": [
+                    "Lunar Reconnaissance Orbiter (LRO) Archive Information"
+               ],
+               "type": [
+                    "Information.Investigation"
+               ],
                "lidvid": "urn:nasa:pds:context_pds3:resource:resource.lunar_reconnaissance_orbiter_archive_information::1.0"
           },
           {
-               "name": "2001 Mars Odyssey Archive Information",
-               "type": "Information.Investigation",
+               "name": [
+                    "2001 Mars Odyssey Archive Information"
+               ],
+               "type": [
+                    "Information.Investigation"
+               ],
                "lidvid": "urn:nasa:pds:context_pds3:resource:resource.2001_mars_odyssey_archive_information::1.0"
           },
           {
-               "name": "1997 SZ10",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "1997 SZ10"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.1997_sz10::1.0"
           },
           {
-               "name": "(51914) 2001 QM70",
-               "type": "ASTEROID",
+               "name": [
+                    "(51914) 2001 QM70"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.51914_2001_qm70::1.0"
           },
           {
-               "name": "MICROSCOPIC IMAGER",
-               "type": "IMAGER",
+               "name": [
+                    "MICROSCOPIC IMAGER"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:mi.mer1::1.0"
           },
           {
-               "name": "2000 PM30",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2000 PM30"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2000_pm30::1.0"
           },
           {
-               "name": "RESPONSIVITY",
-               "type": "CALIBRATOR",
+               "name": [
+                    "RESPONSIVITY"
+               ],
+               "type": [
+                    "CALIBRATOR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:calibrator.responsivity::1.0"
           },
           {
-               "name": "(413666) 2005 VJ119",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(413666) 2005 VJ119"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.413666_2005_vj119::1.0"
           },
           {
-               "name": "PIONEER 10",
-               "type": "Spacecraft",
+               "name": [
+                    "PIONEER 10"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.p10::1.0"
           },
           {
-               "name": "NEUTRAL GAS AND ION MASS SPECTROMETER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "NEUTRAL GAS AND ION MASS SPECTROMETER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:ngims.con::1.0"
           },
           {
-               "name": "89 JULIA",
-               "type": "ASTEROID",
+               "name": [
+                    "89 JULIA"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.89_julia::1.1"
           },
           {
-               "name": "ROSALIND",
-               "type": "SATELLITE",
+               "name": [
+                    "ROSALIND"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.uranus.rosalind::1.1"
           },
           {
-               "name": "MARS SCIENCE LABORATORY",
-               "type": "Spacecraft",
+               "name": [
+                    "MARS SCIENCE LABORATORY"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.msl::1.1"
           },
           {
-               "name": "(160147) 2001 KN76",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(160147) 2001 KN76"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.160147_2001_kn76::1.0"
           },
           {
-               "name": "(145453) 2005 RR43",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(145453) 2005 RR43"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.145453_2005_rr43::1.0"
           },
           {
-               "name": "(300208) 2006 WF139",
-               "type": "ASTEROID",
+               "name": [
+                    "(300208) 2006 WF139"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300208_2006_wf139::1.0"
           },
           {
-               "name": "PROTEUS",
-               "type": "SATELLITE",
+               "name": [
+                    "PROTEUS"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.neptune.proteus::1.2"
           },
           {
-               "name": "PLANETARY RADIO ASTRONOMY RECEIVER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "PLANETARY RADIO ASTRONOMY RECEIVER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:pra.vg2::1.0"
           },
           {
-               "name": "(300164) 2006 VE140",
-               "type": "ASTEROID",
+               "name": [
+                    "(300164) 2006 VE140"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300164_2006_ve140::1.0"
           },
           {
-               "name": "REAR HAZARD AVOIDANCE CAMERA RIGHT STRING B",
-               "type": "IMAGER",
+               "name": [
+                    "REAR HAZARD AVOIDANCE CAMERA RIGHT STRING B"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:rhaz_right_b.msl::1.0"
           },
           {
-               "name": "MESSENGER",
-               "type": "Spacecraft",
+               "name": [
+                    "MESSENGER"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.mess::1.1"
           },
           {
-               "name": "ALPHA PARTICLE X-RAY SPECTROMETER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "ALPHA PARTICLE X-RAY SPECTROMETER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:apxs.mer1::1.0"
           },
           {
-               "name": "2004 VE131",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2004 VE131"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2004_ve131::1.0"
           },
           {
-               "name": "624 HEKTOR",
-               "type": "ASTEROID",
+               "name": [
+                    "624 HEKTOR"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.624_hektor::1.1"
           },
           {
-               "name": "1P/HALLEY",
-               "type": "COMET",
+               "name": [
+                    "1P/HALLEY"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.1p_halley::1.0"
           },
           {
-               "name": "(126154) 2001 YH140",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(126154) 2001 YH140"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.126154_2001_yh140::1.0"
           },
           {
-               "name": "D/1993 F2-G (SHOEMAKER-LEVY 9-G)",
-               "type": "COMET",
+               "name": [
+                    "D/1993 F2-G (SHOEMAKER-LEVY 9-G)"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.d1993_f2-g_shoemaker-levy_9-g::1.0"
           },
           {
-               "name": "(469506) 2003 FF128",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(469506) 2003 FF128"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.469506_2003_ff128::1.0"
           },
           {
-               "name": "6070 RHEINLAND",
-               "type": "ASTEROID",
+               "name": [
+                    "6070 RHEINLAND"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.6070_rheinland::1.1"
           },
           {
-               "name": "(126619) 2002 CX154",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(126619) 2002 CX154"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.126619_2002_cx154::1.0"
           },
           {
-               "name": "CHALDENE",
-               "type": "SATELLITE",
+               "name": [
+                    "CHALDENE"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.chaldene::1.1"
           },
           {
-               "name": "2004 PX107",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2004 PX107"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2004_px107::1.0"
           },
           {
-               "name": "216 KLEOPATRA",
-               "type": "ASTEROID",
+               "name": [
+                    "216 KLEOPATRA"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.216_kleopatra::1.1"
           },
           {
-               "name": "MARS EXPRESS",
-               "type": "Spacecraft",
+               "name": [
+                    "MARS EXPRESS"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.mex::1.0"
           },
           {
-               "name": "EARTH",
-               "type": "PLANET",
+               "name": [
+                    "EARTH"
+               ],
+               "type": [
+                    "PLANET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:planet.earth::1.2"
           },
           {
-               "name": "BELINDA",
-               "type": "SATELLITE",
+               "name": [
+                    "BELINDA"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.uranus.belinda::1.1"
           },
           {
-               "name": "29P/SCHWASSMANN-WACHMANN 1",
-               "type": "COMET",
+               "name": [
+                    "29P/SCHWASSMANN-WACHMANN 1"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.29p_schwassmann-wachmann_1::1.0"
           },
           {
-               "name": "ULYSSES DUST DETECTION SYSTEM",
-               "type": "DUST",
+               "name": [
+                    "ULYSSES DUST DETECTION SYSTEM"
+               ],
+               "type": [
+                    "DUST"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:udds.uly::1.0"
           },
           {
-               "name": "385446 MANWE",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "385446 MANWE"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.385446_manwe::1.1"
           },
           {
-               "name": "2001 OQ108",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2001 OQ108"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2001_oq108::1.0"
           },
           {
-               "name": "INFRARED ASTRONOMICAL SATELLITE",
-               "type": "Spacecraft",
+               "name": [
+                    "INFRARED ASTRONOMICAL SATELLITE"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.iras::1.1"
           },
           {
-               "name": "AARHUS WIND TUNNEL AWTSII 2010",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "AARHUS WIND TUNNEL AWTSII 2010"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:au-msl.awtsii-2010::1.0"
           },
           {
-               "name": "APOLLO 12 COMMAND AND SERVICE MODULE",
-               "type": "Spacecraft",
+               "name": [
+                    "APOLLO 12 COMMAND AND SERVICE MODULE"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.a12c::1.1"
           },
           {
-               "name": "(131695) 2001 XS254",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(131695) 2001 XS254"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.131695_2001_xs254::1.0"
           },
           {
-               "name": "WT THRESHOLD",
-               "type": "Other Investigation",
+               "name": [
+                    "WT THRESHOLD"
+               ],
+               "type": [
+                    "Other Investigation"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:other_investigation.wt_threshold::1.0"
           },
           {
-               "name": "(32480) 2000 SG348",
-               "type": "ASTEROID",
+               "name": [
+                    "(32480) 2000 SG348"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.32480_2000_sg348::1.0"
           },
           {
-               "name": "ULTRA LOW ENERGY CHARGE ANALYZER",
-               "type": "PARTICLE DETECTOR",
+               "name": [
+                    "ULTRA LOW ENERGY CHARGE ANALYZER"
+               ],
+               "type": [
+                    "PARTICLE DETECTOR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:uleca.ice::1.0"
           },
           {
-               "name": "VECTOR HELIUM/FLUXGATE MAGNETOMETERS",
-               "type": "MAGNETOMETER",
+               "name": [
+                    "VECTOR HELIUM/FLUXGATE MAGNETOMETERS"
+               ],
+               "type": [
+                    "MAGNETOMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:vhm-fgm.uly::1.0"
           },
           {
-               "name": "C/1992 J2 (BRADFIELD)",
-               "type": "COMET",
+               "name": [
+                    "C/1992 J2 (BRADFIELD)"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.c1992_j2_bradfield::1.1"
           },
           {
-               "name": "(15788) 1993 SB",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(15788) 1993 SB"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.15788_1993_sb::1.0"
           },
           {
-               "name": "TELEVISION SYSTEM",
-               "type": "IMAGER",
+               "name": [
+                    "TELEVISION SYSTEM"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:tvs.vega2::1.0"
           },
           {
-               "name": "(15874) 1996 TL66",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(15874) 1996 TL66"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.15874_1996_tl66::1.0"
           },
           {
-               "name": "MERCURY LASER ALTIMETER",
-               "type": "ALTIMETER",
+               "name": [
+                    "MERCURY LASER ALTIMETER"
+               ],
+               "type": [
+                    "ALTIMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:mla.mess::1.1"
           },
           {
-               "name": "(13366) 1998 US24",
-               "type": "ASTEROID",
+               "name": [
+                    "(13366) 1998 US24"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.13366_1998_us24::1.0"
           },
           {
-               "name": "NEAR EARTH ASTEROID RENDEZVOUS",
-               "type": "Mission",
+               "name": [
+                    "NEAR EARTH ASTEROID RENDEZVOUS"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.near_earth_asteroid_rendezvous::1.1"
           },
           {
-               "name": "NEAR INFRARED CAMERA 1",
-               "type": "IMAGER",
+               "name": [
+                    "NEAR INFRARED CAMERA 1"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:nir1.lcross::1.0"
           },
           {
-               "name": "136108 HAUMEA",
-               "type": "DWARF PLANET",
+               "name": [
+                    "136108 HAUMEA"
+               ],
+               "type": [
+                    "DWARF PLANET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:dwarf_planet.136108_haumea::1.1"
           },
           {
-               "name": "(300252) 2007 FN32",
-               "type": "ASTEROID",
+               "name": [
+                    "(300252) 2007 FN32"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300252_2007_fn32::1.0"
           },
           {
-               "name": "FRONT HAZARD AVOIDANCE CAMERA RIGHT STRING B",
-               "type": "IMAGER",
+               "name": [
+                    "FRONT HAZARD AVOIDANCE CAMERA RIGHT STRING B"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:fhaz_right_b.msl::1.0"
           },
           {
-               "name": "(364171) 2006 JZ81",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(364171) 2006 JZ81"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.364171_2006_jz81::1.0"
           },
           {
-               "name": "(134860) 2000 OJ67",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(134860) 2000 OJ67"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.134860_2000_oj67::1.0"
           },
           {
-               "name": "111 ATE",
-               "type": "ASTEROID",
+               "name": [
+                    "111 ATE"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.111_ate::1.1"
           },
           {
-               "name": "SATURN LABORATORY ANALOG",
-               "type": "LABORATORY ANALOG",
+               "name": [
+                    "SATURN LABORATORY ANALOG"
+               ],
+               "type": [
+                    "LABORATORY ANALOG"
+               ],
                "lidvid": "urn:nasa:pds:context:target:laboratory_analog.saturn::1.0"
           },
           {
-               "name": "22P/KOPFF",
-               "type": "COMET",
+               "name": [
+                    "22P/KOPFF"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.22p_kopff::1.0"
           },
           {
-               "name": "PIONEER VENUS ORBITER ULTRAVIOLET SPECTROMETER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "PIONEER VENUS ORBITER ULTRAVIOLET SPECTROMETER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:ouvs.pvo::1.0"
           },
           {
-               "name": "(300229) 2006 XF73",
-               "type": "ASTEROID",
+               "name": [
+                    "(300229) 2006 XF73"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300229_2006_xf73::1.0"
           },
           {
-               "name": "FRONT HAZARD AVOIDANCE CAMERA LEFT STRING A",
-               "type": "IMAGER",
+               "name": [
+                    "FRONT HAZARD AVOIDANCE CAMERA LEFT STRING A"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:fhaz_left_a.msl::1.0"
           },
           {
-               "name": "(143685) 2003 SS317",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(143685) 2003 SS317"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.143685_2003_ss317::1.0"
           },
           {
-               "name": "D/1993 F2-Q1 (SHOEMAKER-LEVY 9-Q1)",
-               "type": "COMET",
+               "name": [
+                    "D/1993 F2-Q1 (SHOEMAKER-LEVY 9-Q1)"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.d1993_f2-q1_shoemaker-levy_9-q1::1.0"
           },
           {
-               "name": "(88268) 2001 KK76",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(88268) 2001 KK76"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.88268_2001_kk76::1.0"
           },
           {
-               "name": "106 DIONE",
-               "type": "ASTEROID",
+               "name": [
+                    "106 DIONE"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.106_dione::1.1"
           },
           {
-               "name": "INERTIAL MEASUREMENT UNIT",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "INERTIAL MEASUREMENT UNIT"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:imu.mer1::1.0"
           },
           {
-               "name": "(300247) 2007 EX111",
-               "type": "ASTEROID",
+               "name": [
+                    "(300247) 2007 EX111"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300247_2007_ex111::1.0"
           },
           {
-               "name": "IOWA STATE UNIVERSITY BOUNDARY LAYER WIND TUNNEL",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "IOWA STATE UNIVERSITY BOUNDARY LAYER WIND TUNNEL"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:isu_ae.isuwt::1.0"
           },
           {
-               "name": "SOLAR WIND ION COMPOSITION SPECTROMETER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "SOLAR WIND ION COMPOSITION SPECTROMETER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:swics.uly::1.0"
           },
           {
-               "name": "2005 TN53",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2005 TN53"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2005_tn53::1.0"
           },
           {
-               "name": "QUADRISPHERICAL PLASMA ANALYZER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "QUADRISPHERICAL PLASMA ANALYZER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:pa.p11::1.0"
           },
           {
-               "name": "REAR HAZARD AVOIDANCE CAMERA RIGHT STRING A",
-               "type": "IMAGER",
+               "name": [
+                    "REAR HAZARD AVOIDANCE CAMERA RIGHT STRING A"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:rhaz_right_a.msl::1.0"
           },
           {
-               "name": "ROBOTIC ARM",
-               "type": "REGOLITH PROPERTIES",
+               "name": [
+                    "ROBOTIC ARM"
+               ],
+               "type": [
+                    "REGOLITH PROPERTIES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:ra.phx::1.0"
           },
           {
-               "name": "RADIO SCIENCE SUBSYSTEM",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "RADIO SCIENCE SUBSYSTEM"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:rss.vg2::1.0"
           },
           {
-               "name": "GALILEO ORBITER STAR SCANNER",
-               "type": "IMAGER",
+               "name": [
+                    "GALILEO ORBITER STAR SCANNER"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:ssd.go::1.0"
           },
           {
-               "name": "PERDITA",
-               "type": "SATELLITE",
+               "name": [
+                    "PERDITA"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.uranus.perdita::1.1"
           },
           {
-               "name": "(48639) 1995 TL8",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(48639) 1995 TL8"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.48639_1995_tl8::1.0"
           },
           {
-               "name": "DUNHUANG PORTABLE WIND TUNNEL",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "DUNHUANG PORTABLE WIND TUNNEL"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:no-host.dunhuang-portable_wt::1.0"
           },
           {
-               "name": "(469750) 2005 PU21",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(469750) 2005 PU21"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.469750_2005_pu21::1.0"
           },
           {
-               "name": "D/1993 F2-F (SHOEMAKER-LEVY 9-F)",
-               "type": "COMET",
+               "name": [
+                    "D/1993 F2-F (SHOEMAKER-LEVY 9-F)"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.d1993_f2-f_shoemaker-levy_9-f::1.0"
           },
           {
-               "name": "2002 CU154",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2002 CU154"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2002_cu154::1.0"
           },
           {
-               "name": "(19255) 1994 VK8",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(19255) 1994 VK8"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.19255_1994_vk8::1.0"
           },
           {
-               "name": "C/2002 T7 (LINEAR)",
-               "type": "COMET",
+               "name": [
+                    "C/2002 T7 (LINEAR)"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.c2002_t7_linear::1.0"
           },
           {
-               "name": "(154783) 2004 PA44",
-               "type": "CENTAUR",
+               "name": [
+                    "(154783) 2004 PA44"
+               ],
+               "type": [
+                    "CENTAUR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:centaur.154783_2004_pa44::1.0"
           },
           {
-               "name": "2000 PX29",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2000 PX29"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2000_px29::1.0"
           },
           {
-               "name": "1999 RJ215",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "1999 RJ215"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.1999_rj215::1.0"
           },
           {
-               "name": "LUNAR SELF-RECORDING PENETROMETER",
-               "type": "REGOLITH PROPERTIES",
+               "name": [
+                    "LUNAR SELF-RECORDING PENETROMETER"
+               ],
+               "type": [
+                    "REGOLITH PROPERTIES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:lsrp.a16l::1.0"
           },
           {
-               "name": "(182294) 2001 KU76",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(182294) 2001 KU76"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.182294_2001_ku76::1.0"
           },
           {
-               "name": "COSPIN-ANISOTROPY TELESCOPE",
-               "type": "PARTICLE DETECTOR",
+               "name": [
+                    "COSPIN-ANISOTROPY TELESCOPE"
+               ],
+               "type": [
+                    "PARTICLE DETECTOR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:cospin-at.uly::1.0"
           },
           {
-               "name": "2006 HX122",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2006 HX122"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2006_hx122::1.0"
           },
           {
-               "name": "IMAGING SCIENCE SUBSYSTEM - NARROW ANGLE",
-               "type": "IMAGER",
+               "name": [
+                    "IMAGING SCIENCE SUBSYSTEM - NARROW ANGLE"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:issn.vg2::1.0"
           },
           {
-               "name": "SOLAR SYSTEM",
-               "type": "PLANETARY SYSTEM",
+               "name": [
+                    "SOLAR SYSTEM"
+               ],
+               "type": [
+                    "PLANETARY SYSTEM"
+               ],
                "lidvid": "urn:nasa:pds:context:target:planetary_system.solar_system::1.0"
           },
           {
-               "name": "SOLAR WIND SPECTROMETER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "SOLAR WIND SPECTROMETER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:sws.a15a::1.0"
           },
           {
-               "name": "379 HUENNA",
-               "type": "ASTEROID",
+               "name": [
+                    "379 HUENNA"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.379_huenna::1.1"
           },
           {
-               "name": "ROSETTA PLASMA CONSORTIUM - LANGMUIR PROBE",
-               "type": "PARTICLE DETECTOR",
+               "name": [
+                    "ROSETTA PLASMA CONSORTIUM - LANGMUIR PROBE"
+               ],
+               "type": [
+                    "PARTICLE DETECTOR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:rpclap.ro::1.0"
           },
           {
-               "name": "(42367) 2002 CQ134",
-               "type": "ASTEROID",
+               "name": [
+                    "(42367) 2002 CQ134"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.42367_2002_cq134::1.0"
           },
           {
-               "name": "2003 WU188",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2003 WU188"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2003_wu188::1.0"
           },
           {
-               "name": "1999 OA4",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "1999 OA4"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.1999_oa4::1.0"
           },
           {
-               "name": "ASTEROID MULTI-BAND IMAGING CAMERA",
-               "type": "IMAGER",
+               "name": [
+                    "ASTEROID MULTI-BAND IMAGING CAMERA"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:amica.hay::1.0"
           },
           {
-               "name": "MAGNETOMETER",
-               "type": "MAGNETOMETER",
+               "name": [
+                    "MAGNETOMETER"
+               ],
+               "type": [
+                    "MAGNETOMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:mag.ice::1.0"
           },
           {
-               "name": "2P/ENCKE",
-               "type": "COMET",
+               "name": [
+                    "2P/ENCKE"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.2p_encke::1.0"
           },
           {
-               "name": "2006 BR284",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2006 BR284"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2006_br284::1.0"
           },
           {
-               "name": "1042 AMAZONE",
-               "type": "ASTEROID",
+               "name": [
+                    "1042 AMAZONE"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.1042_amazone::1.1"
           },
           {
-               "name": "2003 QN91",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2003 QN91"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2003_qn91::1.0"
           },
           {
-               "name": "(40314) 1999 KR16",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(40314) 1999 KR16"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.40314_1999_kr16::1.0"
           },
           {
-               "name": "(80806) 2000 CM105",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(80806) 2000 CM105"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.80806_2000_cm105::1.0"
           },
           {
-               "name": "2004 VY130",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2004 VY130"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2004_vy130::1.0"
           },
           {
-               "name": "(471143) 2010 EK139",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(471143) 2010 EK139"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.471143_2010_ek139::1.0"
           },
           {
-               "name": "2000 CG105",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2000 CG105"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2000_cg105::1.0"
           },
           {
-               "name": "SATURN",
-               "type": "PLANET",
+               "name": [
+                    "SATURN"
+               ],
+               "type": [
+                    "PLANET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:planet.saturn::1.2"
           },
           {
-               "name": "71P/CLARK",
-               "type": "COMET",
+               "name": [
+                    "71P/CLARK"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.71p_clark::1.0"
           },
           {
-               "name": "REXIS",
-               "type": "SPECTROMETER",
+               "name": [
+                    "REXIS"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:rexis.orex::1.0"
           },
           {
-               "name": "MAGELLAN",
-               "type": "Mission",
+               "name": [
+                    "MAGELLAN"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.magellan::1.0"
           },
           {
-               "name": "(127871) 2003 FC128",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(127871) 2003 FC128"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.127871_2003_fc128::1.0"
           },
           {
-               "name": "17246 CHRISTOPHEDUMAS",
-               "type": "ASTEROID",
+               "name": [
+                    "17246 CHRISTOPHEDUMAS"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.17246_christophedumas::1.0"
           },
           {
-               "name": "IRTF IO OBSERVING CAMPAIGN",
-               "type": "Observing Campaign",
+               "name": [
+                    "IRTF IO OBSERVING CAMPAIGN"
+               ],
+               "type": [
+                    "Observing Campaign"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:observing_campaign.irtf_io::1.0"
           },
           {
-               "name": "RADIO SCIENCE SUBSYSTEM",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "RADIO SCIENCE SUBSYSTEM"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:rss-vg2s.vg2::1.0"
           },
           {
-               "name": "GAMMA RAY/NEUTRON SPECTROMETER/HIGH ENERGY NEUTRON DETECTOR",
-               "type": "SPECTROMETER",
+               "name": [
+                    "GAMMA RAY/NEUTRON SPECTROMETER/HIGH ENERGY NEUTRON DETECTOR"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:grs.ody::1.0"
           },
           {
-               "name": "MAGELLAN",
-               "type": "Spacecraft",
+               "name": [
+                    "MAGELLAN"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.mgn::1.0"
           },
           {
-               "name": "(300198) 2006 WH100",
-               "type": "ASTEROID",
+               "name": [
+                    "(300198) 2006 WH100"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300198_2006_wh100::1.0"
           },
           {
-               "name": "(300181) 2006 WK45",
-               "type": "ASTEROID",
+               "name": [
+                    "(300181) 2006 WK45"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300181_2006_wk45::1.0"
           },
           {
-               "name": "(300218) 2006 WG187",
-               "type": "ASTEROID",
+               "name": [
+                    "(300218) 2006 WG187"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300218_2006_wg187::1.0"
           },
           {
-               "name": "RADIO OCCULTATION EXPERIMENT",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "RADIO OCCULTATION EXPERIMENT"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:roe.v16::1.0"
           },
           {
-               "name": "INTERNATIONAL ULTRAVIOLET EXPLORER",
-               "type": "Spacecraft",
+               "name": [
+                    "INTERNATIONAL ULTRAVIOLET EXPLORER"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.iue::1.0"
           },
           {
-               "name": "ULTRAVIOLET/VISIBLE CAMERA",
-               "type": "IMAGER",
+               "name": [
+                    "ULTRAVIOLET/VISIBLE CAMERA"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:uvvis.clem1::1.0"
           },
           {
-               "name": "LUNAR ORBITER LASER ALTIMETER",
-               "type": "ALTIMETER",
+               "name": [
+                    "LUNAR ORBITER LASER ALTIMETER"
+               ],
+               "type": [
+                    "ALTIMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:lola.lro::1.0"
           },
           {
-               "name": "MAST CAMERA RIGHT",
-               "type": "IMAGER",
+               "name": [
+                    "MAST CAMERA RIGHT"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:mast_right.msl::1.0"
           },
           {
-               "name": "HIGH RESOLUTION IMAGING SCIENCE EXPERIMENT",
-               "type": "IMAGER",
+               "name": [
+                    "HIGH RESOLUTION IMAGING SCIENCE EXPERIMENT"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:hirise.mro::1.0"
           },
           {
-               "name": "2001 UP18",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2001 UP18"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2001_up18::1.0"
           },
           {
-               "name": "(20161) 1996 TR66",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(20161) 1996 TR66"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.20161_1996_tr66::1.0"
           },
           {
-               "name": "NESO",
-               "type": "SATELLITE",
+               "name": [
+                    "NESO"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.neptune.neso::1.1"
           },
           {
-               "name": "HELIUM VECTOR MAGNETOMETER",
-               "type": "MAGNETOMETER",
+               "name": [
+                    "HELIUM VECTOR MAGNETOMETER"
+               ],
+               "type": [
+                    "MAGNETOMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:hvm.p11::1.0"
           },
           {
-               "name": "CASSINI-HUYGENS",
-               "type": "Mission",
+               "name": [
+                    "CASSINI-HUYGENS"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.cassini-huygens::1.1"
           },
           {
-               "name": "(300211) 2006 WP152",
-               "type": "ASTEROID",
+               "name": [
+                    "(300211) 2006 WP152"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300211_2006_wp152::1.0"
           },
           {
-               "name": "(60608) 2000 EE173",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(60608) 2000 EE173"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.60608_2000_ee173::1.0"
           },
           {
-               "name": "FLUXGATE MAGNETOMETER",
-               "type": "MAGNETOMETER",
+               "name": [
+                    "FLUXGATE MAGNETOMETER"
+               ],
+               "type": [
+                    "MAGNETOMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:mischa.vega2::1.0"
           },
           {
-               "name": "D/1993 F2-S (SHOEMAKER-LEVY 9-S)",
-               "type": "COMET",
+               "name": [
+                    "HOT ION ATMOS ESCAPE"
+               ],
+               "type": [
+                    "Other Investigation"
+               ],
+               "lidvid": "urn:nasa:pds:context:investigation:other_investigation.hot_ion_atmos_escape::1.0"
+          },
+          {
+               "name": [
+                    "D/1993 F2-S (SHOEMAKER-LEVY 9-S)"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.d1993_f2-s_shoemaker-levy_9-s::1.0"
           },
           {
-               "name": "MID INFRARED CAMERA 1",
-               "type": "IMAGER",
+               "name": [
+                    "MID INFRARED CAMERA 1"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:mir1.lcross::1.0"
           },
           {
-               "name": "ULTRAVIOLET SPECTROGRAPH",
-               "type": "SPECTROMETER",
+               "name": [
+                    "ULTRAVIOLET SPECTROGRAPH"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:uvs.jno::1.0"
           },
           {
-               "name": "TRAPPED RADIATION DETECTOR",
-               "type": "PARTICLE DETECTOR",
+               "name": [
+                    "TRAPPED RADIATION DETECTOR"
+               ],
+               "type": [
+                    "PARTICLE DETECTOR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:trd.p11::1.0"
           },
           {
-               "name": "2003 UN284",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2003 UN284"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2003_un284::1.0"
           },
           {
-               "name": "(40506) 1999 RB86",
-               "type": "ASTEROID",
+               "name": [
+                    "(40506) 1999 RB86"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.40506_1999_rb86::1.0"
           },
           {
-               "name": "VENERA 15 AND 16",
-               "type": "Mission",
+               "name": [
+                    "VENERA 15 AND 16"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.venera_15_and_16::1.0"
           },
           {
-               "name": "2001 HZ58",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2001 HZ58"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2001_hz58::1.0"
           },
           {
-               "name": "2007 RH283",
-               "type": "CENTAUR",
+               "name": [
+                    "2007 RH283"
+               ],
+               "type": [
+                    "CENTAUR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:centaur.2007_rh283::1.0"
           },
           {
-               "name": "2000 YH2",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2000 YH2"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2000_yh2::1.0"
           },
           {
-               "name": "44 NYSA",
-               "type": "ASTEROID",
+               "name": [
+                    "44 NYSA"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.44_nysa::1.1"
           },
           {
-               "name": "444 GYPTIS",
-               "type": "ASTEROID",
+               "name": [
+                    "444 GYPTIS"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.444_gyptis::1.1"
           },
           {
-               "name": "LARGE ANGLE SPECTROMETRIC CORONAGRAPH",
-               "type": "IMAGER",
+               "name": [
+                    "LARGE ANGLE SPECTROMETRIC CORONAGRAPH"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:lasco.soho::1.0"
           },
           {
-               "name": "PIONEER VENUS",
-               "type": "Mission",
+               "name": [
+                    "PIONEER VENUS"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.pioneer_venus::1.0"
           },
           {
-               "name": "(119070) 2001 KP77",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(119070) 2001 KP77"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.119070_2001_kp77::1.0"
           },
           {
-               "name": "GALILEO PROBE NEPHELOMETER",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "GALILEO PROBE NEPHELOMETER"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:nep.gp::1.0"
           },
           {
-               "name": "COMETARY SECONDARY ION MASS ANALYZER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "COMETARY SECONDARY ION MASS ANALYZER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:cosima.ro::1.0"
           },
           {
-               "name": "18 MELPOMENE",
-               "type": "ASTEROID",
+               "name": [
+                    "18 MELPOMENE"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.18_melpomene::1.1"
           },
           {
-               "name": "CAL TARGET",
-               "type": "CALIBRATION FIELD",
+               "name": [
+                    "CAL TARGET"
+               ],
+               "type": [
+                    "CALIBRATION FIELD"
+               ],
                "lidvid": "urn:nasa:pds:context:target:calibration_field.cal_target::1.0"
           },
           {
-               "name": "1998 WZ31",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "1998 WZ31"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.1998_wz31::1.0"
           },
           {
-               "name": "2003 BG91",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2003 BG91"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2003_bg91::1.0"
           },
           {
-               "name": "IMAGER FOR MARS PATHFINDER",
-               "type": "IMAGER",
+               "name": [
+                    "IMAGER FOR MARS PATHFINDER"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:imp.mpfl::1.0"
           },
           {
-               "name": "NEAR INFRARED CAMERA 2",
-               "type": "IMAGER",
+               "name": [
+                    "NEAR INFRARED CAMERA 2"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:nir2.lcross::1.0"
           },
           {
-               "name": "VENUS EXPRESS",
-               "type": "Mission",
+               "name": [
+                    "VENUS EXPRESS"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.venus_express::1.0"
           },
           {
-               "name": "(10783) 1991 RB9",
-               "type": "ASTEROID",
+               "name": [
+                    "(10783) 1991 RB9"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.10783_1991_rb9::1.0"
           },
           {
-               "name": "(13807) 1998 XE13",
-               "type": "ASTEROID",
+               "name": [
+                    "(13807) 1998 XE13"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.13807_1998_xe13::1.0"
           },
           {
-               "name": "RADIO SCIENCE SUBSYSTEM",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "RADIO SCIENCE SUBSYSTEM"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:rss.dif::1.0"
           },
           {
-               "name": "MNEME",
-               "type": "SATELLITE",
+               "name": [
+                    "MNEME"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.mneme::1.1"
           },
           {
-               "name": "2003 QK91",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2003 QK91"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2003_qk91::1.0"
           },
           {
-               "name": "8405 ASBOLUS",
-               "type": "CENTAUR",
+               "name": [
+                    "8405 ASBOLUS"
+               ],
+               "type": [
+                    "CENTAUR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:centaur.8405_asbolus::1.0"
           },
           {
-               "name": "2003 YV179",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2003 YV179"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2003_yv179::1.0"
           },
           {
-               "name": "C/1988 B1 (SHOEMAKER)",
-               "type": "COMET",
+               "name": [
+                    "C/1988 B1 (SHOEMAKER)"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.c1988_b1_shoemaker::1.0"
           },
           {
-               "name": "2000 FV53",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2000 FV53"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2000_fv53::1.0"
           },
           {
-               "name": "METEOROLOGY SUITE, PRESSURE & TEMPERATURE",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "METEOROLOGY SUITE, PRESSURE & TEMPERATURE"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:met.phx::1.0"
           },
           {
-               "name": "SHORT-WAVELENGTH PRIME",
-               "type": "SPECTROGRAPH",
+               "name": [
+                    "SHORT-WAVELENGTH PRIME"
+               ],
+               "type": [
+                    "SPECTROGRAPH"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:swp.iue::1.0"
           },
           {
-               "name": "2005 VZ122",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2005 VZ122"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2005_vz122::1.0"
           },
           {
-               "name": "(506439) 2000 YB2",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(506439) 2000 YB2"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.506439_2000_yb2::1.0"
           },
           {
-               "name": "HAZARD AVOIDANCE CAMERA",
-               "type": "IMAGER",
+               "name": [
+                    "HAZARD AVOIDANCE CAMERA"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:hazcam.msl::1.0"
           },
           {
-               "name": "SOLID STATE IMAGING SYSTEM",
-               "type": "IMAGER",
+               "name": [
+                    "SOLID STATE IMAGING SYSTEM"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:ssi.go::1.0"
           },
           {
-               "name": "2003 YP179",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2003 YP179"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2003_yp179::1.0"
           },
           {
-               "name": "LUNAR DUST EXPERIMENT",
-               "type": "DUST DETECTOR",
+               "name": [
+                    "LUNAR DUST EXPERIMENT"
+               ],
+               "type": [
+                    "DUST DETECTOR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:instrument.ldex__ladee::1.0"
           },
           {
-               "name": "USDA-ARS WIND TUNNEL AT UNITED STATES DEPARTMENT OF AGRICULTURE, AGRICULTURAL RESEARCH SERVICE, WIND EROSION AND WATER CONSERVATION RESEARCH UNIT, LUBBOCK, TX",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "USDA-ARS WIND TUNNEL AT UNITED STATES DEPARTMENT OF AGRICULTURE, AGRICULTURAL RESEARCH SERVICE, WIND EROSION AND WATER CONSERVATION RESEARCH UNIT, LUBBOCK, TX"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:usda-ars-lubbock.usda-ars_wt::1.0"
           },
           {
-               "name": "(131697) 2001 XH255",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(131697) 2001 XH255"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.131697_2001_xh255::1.0"
           },
           {
-               "name": "252P/LINEAR",
-               "type": "COMET",
+               "name": [
+                    "252P/LINEAR"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.252p_linear::1.0"
           },
           {
-               "name": "LUNAR RECONNAISSANCE ORBITER",
-               "type": "Mission",
+               "name": [
+                    "LUNAR RECONNAISSANCE ORBITER"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.lunar_reconnaissance_orbiter::1.1"
           },
           {
-               "name": "PIONEER 9 COSMIC DUST DETECTOR",
-               "type": "DUST",
+               "name": [
+                    "PIONEER 9 COSMIC DUST DETECTOR"
+               ],
+               "type": [
+                    "DUST"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:cdd.pioneer_9::1.0"
           },
           {
-               "name": "ULYSSES",
-               "type": "Spacecraft",
+               "name": [
+                    "ULYSSES"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.uly::1.0"
           },
           {
-               "name": "(385194) 1998 KG62",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(385194) 1998 KG62"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.385194_1998_kg62::1.0"
           },
           {
-               "name": "LABELED RELEASE",
-               "type": "REGOLITH PROPERTIES",
+               "name": [
+                    "LABELED RELEASE"
+               ],
+               "type": [
+                    "REGOLITH PROPERTIES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:lr1.vl1::1.0"
           },
           {
-               "name": "(91133) 1998 HK151",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(91133) 1998 HK151"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.91133_1998_hk151::1.0"
           },
           {
-               "name": "(33128) 1998 BU48",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(33128) 1998 BU48"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.33128_1998_bu48::1.0"
           },
           {
-               "name": "MARS ORBITER LASER ALTIMETER",
-               "type": "ALTIMETER",
+               "name": [
+                    "MARS ORBITER LASER ALTIMETER"
+               ],
+               "type": [
+                    "ALTIMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:mola.mgs::1.0"
           },
           {
-               "name": "GAMMA RAY SPECTROMETER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "GAMMA RAY SPECTROMETER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:grs.lp::1.0"
           },
           {
-               "name": "COSMIC DUST ANALYZER",
-               "type": "DUST",
+               "name": [
+                    "COSMIC DUST ANALYZER"
+               ],
+               "type": [
+                    "DUST"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:cda.co::1.0"
           },
           {
-               "name": "2002 QX47",
-               "type": "CENTAUR",
+               "name": [
+                    "2002 QX47"
+               ],
+               "type": [
+                    "CENTAUR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:centaur.2002_qx47::1.0"
           },
           {
-               "name": "SYSTEM",
-               "type": "CALIBRATOR",
+               "name": [
+                    "SYSTEM"
+               ],
+               "type": [
+                    "CALIBRATOR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:calibrator.system::1.0"
           },
           {
-               "name": "PHOEBE",
-               "type": "SATELLITE",
+               "name": [
+                    "PHOEBE"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.phoebe::1.1"
           },
           {
-               "name": "2003 LD9",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2003 LD9"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2003_ld9::1.0"
           },
           {
-               "name": "SYCORAX",
-               "type": "SATELLITE",
+               "name": [
+                    "SYCORAX"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.uranus.sycorax::1.1"
           },
           {
-               "name": "2001 FQ185",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2001 FQ185"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2001_fq185::1.0"
           },
           {
-               "name": "(300250) 2007 EF222",
-               "type": "ASTEROID",
+               "name": [
+                    "(300250) 2007 EF222"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300250_2007_ef222::1.0"
           },
           {
-               "name": "(300223) 2006 XK32",
-               "type": "ASTEROID",
+               "name": [
+                    "(300223) 2006 XK32"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300223_2006_xk32::1.0"
           },
           {
-               "name": "OBSERVATOIRE MINERALOGIE, EAU, GLACES, ACTIVITE",
-               "type": "IMAGER",
+               "name": [
+                    "OBSERVATOIRE MINERALOGIE, EAU, GLACES, ACTIVITE"
+               ],
+               "type": [
+                    "IMAGER",
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:omega.mex::1.0"
           },
           {
-               "name": "APOLLO 17 ALSEP LUNAR EJECTA AND METEORITES (LEAM) EXPERIMENT",
-               "type": "DUST",
+               "name": [
+                    "APOLLO 17 ALSEP LUNAR EJECTA AND METEORITES (LEAM) EXPERIMENT"
+               ],
+               "type": [
+                    "DUST"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:leam.a17a::2.0"
           },
           {
-               "name": "(79969) 1999 CP133",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(79969) 1999 CP133"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.79969_1999_cp133::1.0"
           },
           {
-               "name": "NICOLET IN10MX FTIR MICROSCOPE",
-               "type": "MICROSCOPE",
+               "name": [
+                    "NICOLET IN10MX FTIR MICROSCOPE"
+               ],
+               "type": [
+                    "MICROSCOPE"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:sbu_cpex.ftir::1.0"
           },
           {
-               "name": "CHEMISTRY CAMERA LASER INDUCED BREAKDOWN SPECTROMETER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "CHEMISTRY CAMERA LASER INDUCED BREAKDOWN SPECTROMETER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:chemcam_libs.msl::1.0"
           },
           {
-               "name": "16974 IPHTHIME",
-               "type": "ASTEROID",
+               "name": [
+                    "16974 IPHTHIME"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.16974_iphthime::1.0"
           },
           {
-               "name": "ULTRAVIOLET IMAGING SPECTROGRAPH",
-               "type": "SPECTROGRAPH",
+               "name": [
+                    "ULTRAVIOLET IMAGING SPECTROGRAPH"
+               ],
+               "type": [
+                    "SPECTROGRAPH"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:uvis.co::1.0"
           },
           {
-               "name": "S/2006 S 1",
-               "type": "SATELLITE",
+               "name": [
+                    "S/2006 S 1"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.s2006s1::1.1"
           },
           {
-               "name": "MERCURY",
-               "type": "PLANET",
+               "name": [
+                    "MERCURY"
+               ],
+               "type": [
+                    "PLANET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:planet.mercury::1.2"
           },
           {
-               "name": "DUST IMPACT PLASMA DETECTOR",
-               "type": "PARTICLE DETECTOR",
+               "name": [
+                    "DUST IMPACT PLASMA DETECTOR"
+               ],
+               "type": [
+                    "PARTICLE DETECTOR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:sp1.vega2::1.0"
           },
           {
-               "name": "12916 ETEONEUS",
-               "type": "ASTEROID",
+               "name": [
+                    "12916 ETEONEUS"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.12916_eteoneus::1.1"
           },
           {
-               "name": "PAN",
-               "type": "SATELLITE",
+               "name": [
+                    "PAN"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.pan::1.1"
           },
           {
-               "name": "(30726) 1978 VK7",
-               "type": "ASTEROID",
+               "name": [
+                    "(30726) 1978 VK7"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.30726_1978_vk7::1.0"
           },
           {
-               "name": "2000 OH67",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2000 OH67"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2000_oh67::1.0"
           },
           {
-               "name": "MECA COMMON ELECTRONICS",
-               "type": "REGOLITH PROPERTIES",
+               "name": [
+                    "MECA COMMON ELECTRONICS"
+               ],
+               "type": [
+                    "REGOLITH PROPERTIES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:meca_elec.phx::1.0"
           },
           {
-               "name": "DUAL TECHNIQUE MAGNETOMETER",
-               "type": "MAGNETOMETER",
+               "name": [
+                    "DUAL TECHNIQUE MAGNETOMETER"
+               ],
+               "type": [
+                    "MAGNETOMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:mag.co::1.0"
           },
           {
-               "name": "ANANKE",
-               "type": "SATELLITE",
+               "name": [
+                    "ANANKE"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.ananke::1.1"
           },
           {
-               "name": "VISIBLE CAMERA",
-               "type": "IMAGER",
+               "name": [
+                    "VISIBLE CAMERA"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:vis.lcross::1.0"
           },
           {
-               "name": "C/1999 T1 (MCNAUGHT-HARTLEY)",
-               "type": "COMET",
+               "name": [
+                    "C/1999 T1 (MCNAUGHT-HARTLEY)"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.c1999_t1_mcnaught-hartley::1.0"
           },
           {
-               "name": "(24978) 1998 HJ151",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(24978) 1998 HJ151"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.24978_1998_hj151::1.0"
           },
           {
-               "name": "(119069) 2001 KN77",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(119069) 2001 KN77"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.119069_2001_kn77::1.0"
           },
           {
-               "name": "MICROROVER FLIGHT EXPERIMENT",
-               "type": "Spacecraft",
+               "name": [
+                    "MICROROVER FLIGHT EXPERIMENT"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.mpfr::1.0"
           },
           {
-               "name": "VISUAL AND INFRARED MAPPING SPECTROMETER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "VISUAL AND INFRARED MAPPING SPECTROMETER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:vims.co::1.0"
           },
           {
-               "name": "APOLLO 14 LUNAR MODULE",
-               "type": "Spacecraft",
+               "name": [
+                    "APOLLO 14 LUNAR MODULE"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.a14l::1.1"
           },
           {
-               "name": "INTERSTELLAR PARTICLES",
-               "type": "DUST",
+               "name": [
+                    "INTERSTELLAR PARTICLES"
+               ],
+               "type": [
+                    "DUST"
+               ],
                "lidvid": "urn:nasa:pds:context:target:dust.interstellar_particles::1.0"
           },
           {
-               "name": "(139775) 2001 QG298",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(139775) 2001 QG298"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.139775_2001_qg298::1.0"
           },
           {
-               "name": "ENERGETIC PARTICLES INVESTIGATION",
-               "type": "PARTICLE DETECTOR",
+               "name": [
+                    "ENERGETIC PARTICLES INVESTIGATION"
+               ],
+               "type": [
+                    "PARTICLE DETECTOR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:epi.gp::1.0"
           },
           {
-               "name": "MARS EXPRESS",
-               "type": "Mission",
+               "name": [
+                    "MARS EXPRESS"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.mars_express::1.0"
           },
           {
-               "name": "TRAVERSE GRAVIMETER",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "TRAVERSE GRAVIMETER"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:tg.a17l::1.0"
           },
           {
-               "name": "2002 CZ224",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2002 CZ224"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2002_cz224::1.0"
           },
           {
-               "name": "2005 JJ186",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2005 JJ186"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2005_jj186::1.0"
           },
           {
-               "name": "ROCK ABRASION TOOL",
-               "type": "REGOLITH PROPERTIES",
+               "name": [
+                    "ROCK ABRASION TOOL"
+               ],
+               "type": [
+                    "REGOLITH PROPERTIES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:rat.mer1::1.0"
           },
           {
-               "name": "(120061) 2003 CO1",
-               "type": "CENTAUR",
+               "name": [
+                    "(120061) 2003 CO1"
+               ],
+               "type": [
+                    "CENTAUR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:centaur.120061_2003_co1::1.0"
           },
           {
-               "name": "RADIO SCIENCE SUBSYSTEM",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "RADIO SCIENCE SUBSYSTEM"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:rss.lro::1.0"
           },
           {
-               "name": "B STAR TRACKER CAMERA",
-               "type": "IMAGER",
+               "name": [
+                    "B STAR TRACKER CAMERA"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:b-star.clem1::1.0"
           },
           {
-               "name": "762 PULCOVA",
-               "type": "ASTEROID",
+               "name": [
+                    "762 PULCOVA"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.762_pulcova::1.1"
           },
           {
-               "name": "(118379) 1999 HC12",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(118379) 1999 HC12"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.118379_1999_hc12::1.0"
           },
           {
-               "name": "2004 HC79",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2004 HC79"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2004_hc79::1.0"
           },
           {
-               "name": "(455502) 2003 UZ413",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(455502) 2003 UZ413"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.455502_2003_uz413::1.0"
           },
           {
-               "name": "APOLLO 14 COLD CATHODE ION GAGE EXPERIMENT",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "APOLLO 14 COLD CATHODE ION GAGE EXPERIMENT"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:ccig.a14a::1.0"
           },
           {
-               "name": "2006 SG109",
-               "type": "ASTEROID",
+               "name": [
+                    "2006 SG109"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.2006_sg109::1.0"
           },
           {
-               "name": "RADIO SCIENCE SUBSYSTEM",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "RADIO SCIENCE SUBSYSTEM"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:rss.mer2::1.0"
           },
           {
-               "name": "IAPETUS",
-               "type": "SATELLITE",
+               "name": [
+                    "IAPETUS"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.iapetus::1.1"
           },
           {
-               "name": "NEAR INFRARED SPECTROMETER 1",
-               "type": "SPECTROMETER",
+               "name": [
+                    "NEAR INFRARED SPECTROMETER 1"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:nsp1.lcross::1.0"
           },
           {
-               "name": "2003 QG91",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2003 QG91"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2003_qg91::1.0"
           },
           {
-               "name": "DUST IMPACT MASS ANALYZER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "DUST IMPACT MASS ANALYZER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:puma.vega2::1.0"
           },
           {
-               "name": "(300178) 2006 WV36",
-               "type": "ASTEROID",
+               "name": [
+                    "(300178) 2006 WV36"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300178_2006_wv36::1.0"
           },
           {
-               "name": "THERMAL EMISSION IMAGING SYSTEM",
-               "type": "IMAGER",
+               "name": [
+                    "THERMAL EMISSION IMAGING SYSTEM"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:themis.ody::1.0"
           },
           {
-               "name": "(300238) 2007 CM16",
-               "type": "ASTEROID",
+               "name": [
+                    "(300238) 2007 CM16"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300238_2007_cm16::1.0"
           },
           {
-               "name": "MARS SCIENCE LABORATORY",
-               "type": "Mission",
+               "name": [
+                    "MARS SCIENCE LABORATORY"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.mars_science_laboratory::1.0"
           },
           {
-               "name": "44P/REINMUTH 2",
-               "type": "COMET",
+               "name": [
+                    "44P/REINMUTH 2"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.44p_reinmuth_2::1.0"
           },
           {
-               "name": "PANDORA",
-               "type": "SATELLITE",
+               "name": [
+                    "PANDORA"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.pandora::1.1"
           },
           {
-               "name": "SHAPOTOU WIND TUNNEL, SHAPOTOU DESERT EXPERIMENTAL RESEARCH STATION, INSTITUTE OD DESERT RESEARCH, CHINESE ACADEMY",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "SHAPOTOU WIND TUNNEL, SHAPOTOU DESERT EXPERIMENTAL RESEARCH STATION, INSTITUTE OD DESERT RESEARCH, CHINESE ACADEMY"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:sders-china.shapotou_wt::1.0"
           },
           {
-               "name": "(385201) 1999 RN215",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(385201) 1999 RN215"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.385201_1999_rn215::1.0"
           },
           {
-               "name": "(181868) 1999 CG119",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(181868) 1999 CG119"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.181868_1999_cg119::1.0"
           },
           {
-               "name": "(300212) 2006 WZ153",
-               "type": "ASTEROID",
+               "name": [
+                    "(300212) 2006 WZ153"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300212_2006_wz153::1.0"
           },
           {
-               "name": "STIM LAMP",
-               "type": "CALIBRATOR",
+               "name": [
+                    "STIM LAMP"
+               ],
+               "type": [
+                    "CALIBRATOR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:calibrator.stim_lamp::1.0"
           },
           {
-               "name": "10123 FIDEOJA",
-               "type": "ASTEROID",
+               "name": [
+                    "10123 FIDEOJA"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.10123_fideoja::1.1"
           },
           {
-               "name": "RADIO AND PLASMA WAVE SCIENCE",
-               "type": "PLASMA WAVE SPECTROMETER",
+               "name": [
+                    "RADIO AND PLASMA WAVE SCIENCE"
+               ],
+               "type": [
+                    "PLASMA WAVE SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:rpws.co::1.0"
           },
           {
-               "name": "APOLLO 15",
-               "type": "Mission",
+               "name": [
+                    "APOLLO 15"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.apollo_15::1.1"
           },
           {
-               "name": "(119979) 2002 WC19",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(119979) 2002 WC19"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.119979_2002_wc19::1.0"
           },
           {
-               "name": "PARTICULATE IMPACT ANALYZER",
-               "type": "DUST",
+               "name": [
+                    "PARTICULATE IMPACT ANALYZER"
+               ],
+               "type": [
+                    "DUST"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:pia.gio::1.0"
           },
           {
-               "name": "(54520) 2000 PJ30",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(54520) 2000 PJ30"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.54520_2000_pj30::1.0"
           },
           {
-               "name": "(300197) 2006 WX99",
-               "type": "ASTEROID",
+               "name": [
+                    "(300197) 2006 WX99"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300197_2006_wx99::1.0"
           },
           {
-               "name": "2001 MARS ODYSSEY",
-               "type": "Spacecraft",
+               "name": [
+                    "2001 MARS ODYSSEY"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.ody::1.0"
           },
           {
-               "name": "RADIO SCIENCE SUBSYSTEM",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "RADIO SCIENCE SUBSYSTEM"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:rss.p12::1.0"
           },
           {
-               "name": "2004 VZ75",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2004 VZ75"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2004_vz75::1.0"
           },
           {
-               "name": "7066 NESSUS",
-               "type": "CENTAUR",
+               "name": [
+                    "7066 NESSUS"
+               ],
+               "type": [
+                    "CENTAUR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:centaur.7066_nessus::1.0"
           },
           {
-               "name": "SOLAR X-RAY/COSMIC GAMMA-RAY BURST INSTRUMENT",
-               "type": "RADIOMETER",
+               "name": [
+                    "SOLAR X-RAY/COSMIC GAMMA-RAY BURST INSTRUMENT"
+               ],
+               "type": [
+                    "RADIOMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:grb.uly::1.0"
           },
           {
-               "name": "(136120) 2003 LG7",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(136120) 2003 LG7"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.136120_2003_lg7::1.0"
           },
           {
-               "name": "2003 UN292",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2003 UN292"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2003_un292::1.0"
           },
           {
-               "name": "(470523) 2008 CS190",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(470523) 2008 CS190"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.470523_2008_cs190::1.0"
           },
           {
-               "name": "DUST PARTICLE DETECTOR",
-               "type": "DUST",
+               "name": [
+                    "DUST PARTICLE DETECTOR"
+               ],
+               "type": [
+                    "DUST"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:sp2.vega1::1.0"
           },
           {
-               "name": "JARNSAXA",
-               "type": "SATELLITE",
+               "name": [
+                    "JARNSAXA"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.jarnsaxa::1.1"
           },
           {
-               "name": "ACCELEROMETER",
-               "type": "ACCELEROMETER",
+               "name": [
+                    "ACCELEROMETER"
+               ],
+               "type": [
+                    "ACCELEROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:acc.maven::1.0"
           },
           {
-               "name": "2005 SF278",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2005 SF278"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2005_sf278::1.0"
           },
           {
-               "name": "(51336) 2000 NV26",
-               "type": "ASTEROID",
+               "name": [
+                    "(51336) 2000 NV26"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.51336_2000_nv26::1.0"
           },
           {
-               "name": "(120181) 2003 UR292",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(120181) 2003 UR292"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.120181_2003_ur292::1.0"
           },
           {
-               "name": "(450265) 2003 WU172",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(450265) 2003 WU172"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.450265_2003_wu172::1.0"
           },
           {
-               "name": "MARS OBSERVER",
-               "type": "Mission",
+               "name": [
+                    "MARS OBSERVER"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.mars_observer::1.0"
           },
           {
-               "name": "(15820) 1994 TB",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(15820) 1994 TB"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.15820_1994_tb::1.0"
           },
           {
-               "name": "2005 JA175",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2005 JA175"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2005_ja175::1.0"
           },
           {
-               "name": "(85633) 1998 KR65",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(85633) 1998 KR65"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.85633_1998_kr65::1.0"
           },
           {
-               "name": "2003 QR91",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2003 QR91"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2003_qr91::1.0"
           },
           {
-               "name": "SOLAR CORONA EXPERIMENT",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "SOLAR CORONA EXPERIMENT"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:sce.uly::1.0"
           },
           {
-               "name": "OCAMS",
-               "type": "IMAGER",
+               "name": [
+                    "OCAMS"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:ocams.orex::1.0"
           },
           {
-               "name": "LONG RANGE RECONNAISSANCE IMAGER",
-               "type": "IMAGER",
+               "name": [
+                    "LONG RANGE RECONNAISSANCE IMAGER"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:lorri.nh::1.0"
           },
           {
-               "name": "(69986) 1998 WW24",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(69986) 1998 WW24"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.69986_1998_ww24::1.0"
           },
           {
-               "name": "61P/SHAJN-SCHALDACH",
-               "type": "COMET",
+               "name": [
+                    "61P/SHAJN-SCHALDACH"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.61p_shajn-schaldach::1.0"
           },
           {
-               "name": "46P/WIRTANEN",
-               "type": "COMET",
+               "name": [
+                    "46P/WIRTANEN"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.46p_wirtanen::1.0"
           },
           {
-               "name": "RADIO SCIENCE SUBSYSTEM",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "RADIO SCIENCE SUBSYSTEM"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:rss.mgn::1.0"
           },
           {
-               "name": "(469361) 2001 HY65",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(469361) 2001 HY65"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.469361_2001_hy65::1.0"
           },
           {
-               "name": "ICE",
-               "type": "Spacecraft",
+               "name": [
+                    "ICE"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.ice::1.1"
           },
           {
-               "name": "FF LAMP",
-               "type": "CALIBRATOR",
+               "name": [
+                    "FF LAMP"
+               ],
+               "type": [
+                    "CALIBRATOR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:calibrator.ff_lamp::1.0"
           },
           {
-               "name": "DARWISH WIND TUNNEL AT TEXAS TECH UNIVERSITY, AGRICULTURAL ENGINEERING DEPARTMENT",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "DARWISH WIND TUNNEL AT TEXAS TECH UNIVERSITY, AGRICULTURAL ENGINEERING DEPARTMENT"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:ttu-ag_eng.darwish_wt::1.0"
           },
           {
-               "name": "APOLLO 15 PANORAMIC CAMERA",
-               "type": "IMAGER",
+               "name": [
+                    "APOLLO 15 PANORAMIC CAMERA"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:pancam.a15c::1.0"
           },
           {
-               "name": "(229762) 2007 UK126",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(229762) 2007 UK126"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.229762_2007_uk126::1.0"
           },
           {
-               "name": "SOLAR WIND ION ANALYZER",
-               "type": "ENERGETIC PARTICLE DETECTOR",
+               "name": [
+                    "SOLAR WIND ION ANALYZER"
+               ],
+               "type": [
+                    "ENERGETIC PARTICLE DETECTOR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:swia.maven::1.0"
           },
           {
-               "name": "2004 TT357",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2004 TT357"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2004_tt357::1.0"
           },
           {
-               "name": "MID INFRARED CAMERA 2",
-               "type": "IMAGER",
+               "name": [
+                    "MID INFRARED CAMERA 2"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:mir2.lcross::1.0"
           },
           {
-               "name": "1208 TROILUS",
-               "type": "ASTEROID",
+               "name": [
+                    "1208 TROILUS"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.1208_troilus::1.1"
           },
           {
-               "name": "MOON MINERALOGY MAPPER",
-               "type": "IMAGER",
+               "name": [
+                    "MOON MINERALOGY MAPPER"
+               ],
+               "type": [
+                    "IMAGER",
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:m3.ch1-orb::1.0"
           },
           {
-               "name": "(86177) 1999 RY215",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(86177) 1999 RY215"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.86177_1999_ry215::1.0"
           },
           {
-               "name": "17P/HOLMES",
-               "type": "COMET",
+               "name": [
+                    "17P/HOLMES"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.17p_holmes::1.0"
           },
           {
-               "name": "CALYPSO",
-               "type": "SATELLITE",
+               "name": [
+                    "CALYPSO"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.calypso::1.1"
           },
           {
-               "name": "(300233) 2006 YX8",
-               "type": "ASTEROID",
+               "name": [
+                    "(300233) 2006 YX8"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300233_2006_yx8::1.0"
           },
           {
-               "name": "2003 BF91",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2003 BF91"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2003_bf91::1.0"
           },
           {
-               "name": "(456781) 2007 TY170",
-               "type": "ASTEROID",
+               "name": [
+                    "(456781) 2007 TY170"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.456781_2007_ty170::1.0"
           },
           {
-               "name": "MARS ATMOSPHERIC WATER DETECTOR",
-               "type": "SPECTROMETER",
+               "name": [
+                    "MARS ATMOSPHERIC WATER DETECTOR"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:mawd.vo2::1.0"
           },
           {
-               "name": "1996 KV1",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "1996 KV1"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.1996_kv1::1.0"
           },
           {
-               "name": "C/1997 BA6 (SPACEWATCH)",
-               "type": "COMET",
+               "name": [
+                    "C/1997 BA6 (SPACEWATCH)"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.c1997_ba6_spacewatch::1.1"
           },
           {
-               "name": "593 TITANIA",
-               "type": "ASTEROID",
+               "name": [
+                    "593 TITANIA"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.593_titania::1.1"
           },
           {
-               "name": "GLL PCT",
-               "type": "CALIBRATOR",
+               "name": [
+                    "GLL PCT"
+               ],
+               "type": [
+                    "CALIBRATOR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:calibrator.gll_pct::1.0"
           },
           {
-               "name": "(28271) 1999 CK16",
-               "type": "ASTEROID",
+               "name": [
+                    "(28271) 1999 CK16"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.28271_1999_ck16::1.0"
           },
           {
-               "name": "21 LUTETIA",
-               "type": "ASTEROID",
+               "name": [
+                    "21 LUTETIA"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.21_lutetia::1.1"
           },
           {
-               "name": "MARS DESCENT IMAGER CAMERA",
-               "type": "IMAGER",
+               "name": [
+                    "MARS DESCENT IMAGER CAMERA"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:mardi.msl::1.0"
           },
           {
-               "name": "25143 ITOKAWA",
-               "type": "ASTEROID",
+               "name": [
+                    "25143 ITOKAWA"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.25143_itokawa::1.0"
           },
           {
-               "name": "14 IRENE",
-               "type": "ASTEROID",
+               "name": [
+                    "14 IRENE"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.14_irene::1.1"
           },
           {
-               "name": "(26181) 1996 GQ21",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(26181) 1996 GQ21"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.26181_1996_gq21::1.0"
           },
           {
-               "name": "2002 FX36",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2002 FX36"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2002_fx36::1.0"
           },
           {
-               "name": "52 EUROPA",
-               "type": "ASTEROID",
+               "name": [
+                    "52 EUROPA"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.52_europa::1.1"
           },
           {
-               "name": "MERCURY ATMOSPHERIC AND SURFACE COMPOSITION SPECTROMETER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "MERCURY ATMOSPHERIC AND SURFACE COMPOSITION SPECTROMETER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:mascs.mess::1.0"
           },
           {
-               "name": "CASSINI PLASMA SPECTROMETER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "CASSINI PLASMA SPECTROMETER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:caps.co::1.0"
           },
           {
-               "name": "HUYGENS PROBE",
-               "type": "Spacecraft",
+               "name": [
+                    "HUYGENS PROBE"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.hp::1.1"
           },
           {
-               "name": "2003 TH58",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2003 TH58"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2003_th58::1.0"
           },
           {
-               "name": "2014 OS393",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2014 OS393"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2014_os393::1.0"
           },
           {
-               "name": "VSK-FREGAT",
-               "type": "IMAGER",
+               "name": [
+                    "VSK-FREGAT"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:vsk.phb2::1.0"
           },
           {
-               "name": "FAR-INFRARED BEAMLINE AT THE CANADIAN LIGHT SOURCE FACILITY",
-               "type": "SPECTROMETER",
+               "name": [
+                    "FAR-INFRARED BEAMLINE AT THE CANADIAN LIGHT SOURCE FACILITY"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:cls.farir_beamline::1.0"
           },
           {
-               "name": "AARHUS WIND TUNNEL AWTSI 2004",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "AARHUS WIND TUNNEL AWTSI 2004"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:au-msl.awtsi-2004::1.0"
           },
           {
-               "name": "XI2 CETI",
-               "type": "STAR",
+               "name": [
+                    "XI2 CETI"
+               ],
+               "type": [
+                    "STAR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:star.ksi02_cet::1.0"
           },
           {
-               "name": "1999 TR11",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "1999 TR11"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.1999_tr11::1.0"
           },
           {
-               "name": "COOLED MID-INFRARED CAMERA AND SPECTROMETER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "COOLED MID-INFRARED CAMERA AND SPECTROMETER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:naoj-hawaii.subaru_8m2.comics::1.0"
           },
           {
-               "name": "(183595) 2003 TG58",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(183595) 2003 TG58"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.183595_2003_tg58::1.0"
           },
           {
-               "name": "11768 MERRILL",
-               "type": "ASTEROID",
+               "name": [
+                    "11768 MERRILL"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.11768_merrill::1.1"
           },
           {
-               "name": "(23622) 1996 RW29",
-               "type": "ASTEROID",
+               "name": [
+                    "(23622) 1996 RW29"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.23622_1996_rw29::1.0"
           },
           {
-               "name": "(32929) 1995 QY9",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(32929) 1995 QY9"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.32929_1995_qy9::1.0"
           },
           {
-               "name": "ANALYZER OF SPACE PLASMA AND ENERGETIC ATOMS (4TH VERSION)\n              ELECTRON SPECTROMETER",
-               "type": "PARTICLE DETECTOR",
-               "lidvid": "urn:nasa:pds:context:instrument:aspera4-els.vex::1.0"
-          },
-          {
-               "name": "JUPITER SUPPORT MONITORING",
-               "type": "Observing Campaign",
+               "name": [
+                    "JUPITER SUPPORT MONITORING"
+               ],
+               "type": [
+                    "Observing Campaign"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:observing_campaign.jupiter_support::1.0"
           },
           {
-               "name": "2003 UY413",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2003 UY413"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2003_uy413::1.0"
           },
           {
-               "name": "EURYDOME",
-               "type": "SATELLITE",
+               "name": [
+                    "EURYDOME"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.eurydome::1.1"
           },
           {
-               "name": "GAMMA-RAY AND NEUTRON DETECTOR",
-               "type": "SPECTROMETER",
+               "name": [
+                    "GAMMA-RAY AND NEUTRON DETECTOR"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:dawn.grand::1.0"
           },
           {
-               "name": "VIKING LANDER 1",
-               "type": "Spacecraft",
+               "name": [
+                    "VIKING LANDER 1"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.vl1::1.1"
           },
           {
-               "name": "SINOPE",
-               "type": "SATELLITE",
+               "name": [
+                    "SINOPE"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.sinope::1.1"
           },
           {
-               "name": "6 HEBE",
-               "type": "ASTEROID",
+               "name": [
+                    "6 HEBE"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.6_hebe::1.1"
           },
           {
-               "name": "(300220) 2006 WT191",
-               "type": "ASTEROID",
+               "name": [
+                    "(300220) 2006 WT191"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300220_2006_wt191::1.0"
           },
           {
-               "name": "7689 REINERSTOSS",
-               "type": "ASTEROID",
+               "name": [
+                    "7689 REINERSTOSS"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.7689_reinerstoss::1.1"
           },
           {
-               "name": "(385607) 2005 EO297",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(385607) 2005 EO297"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.385607_2005_eo297::1.0"
           },
           {
-               "name": "2003 QQ91",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2003 QQ91"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2003_qq91::1.0"
           },
           {
-               "name": "(145486) 2005 UJ438",
-               "type": "CENTAUR",
+               "name": [
+                    "(145486) 2005 UJ438"
+               ],
+               "type": [
+                    "CENTAUR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:centaur.145486_2005_uj438::1.0"
           },
           {
-               "name": "RISE",
-               "type": "RADIO-RADAR",
+               "name": [
+                    "RISE"
+               ],
+               "type": [
+                    "RADIO-RADAR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:rise.insight::1.0"
           },
           {
-               "name": "STARDUST",
-               "type": "Mission",
+               "name": [
+                    "STARDUST"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.stardust::1.1"
           },
           {
-               "name": "NGC 7027",
-               "type": "PLANETARY NEBULA",
+               "name": [
+                    "NGC 7027"
+               ],
+               "type": [
+                    "PLANETARY NEBULA"
+               ],
                "lidvid": "urn:nasa:pds:context:target:planetary_nebula.ngc_7027::1.0"
           },
           {
-               "name": "674 RACHELE",
-               "type": "ASTEROID",
+               "name": [
+                    "674 RACHELE"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.674_rachele::1.1"
           },
           {
-               "name": "(12842) 1997 GQ23",
-               "type": "ASTEROID",
+               "name": [
+                    "(12842) 1997 GQ23"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.12842_1997_gq23::1.0"
           },
           {
-               "name": "2000 QC226",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2000 QC226"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2000_qc226::1.0"
           },
           {
-               "name": "(300176) 2006 WG26",
-               "type": "ASTEROID",
+               "name": [
+                    "(300176) 2006 WG26"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300176_2006_wg26::1.0"
           },
           {
-               "name": "NAVIGATION CAMERA",
-               "type": "IMAGER",
+               "name": [
+                    "NAVIGATION CAMERA"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:navcam.ro::1.0"
           },
           {
-               "name": "LADEE",
-               "type": "Mission",
+               "name": [
+                    "LADEE"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.ladee::1.2"
           },
           {
-               "name": "52975 CYLLARUS",
-               "type": "CENTAUR",
+               "name": [
+                    "52975 CYLLARUS"
+               ],
+               "type": [
+                    "CENTAUR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:centaur.52975_cyllarus::1.0"
           },
           {
-               "name": "2003 YJ179",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2003 YJ179"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2003_yj179::1.0"
           },
           {
-               "name": "5335 DAMOCLES",
-               "type": "CENTAUR",
+               "name": [
+                    "5335 DAMOCLES"
+               ],
+               "type": [
+                    "CENTAUR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:centaur.5335_damocles::1.0"
           },
           {
-               "name": "5 ASTRAEA",
-               "type": "ASTEROID",
+               "name": [
+                    "5 ASTRAEA"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.5_astraea::1.1"
           },
           {
-               "name": "MICRO-IMAGING DUST ANALYSIS SYSTEM",
-               "type": "MICROSCOPE",
+               "name": [
+                    "MICRO-IMAGING DUST ANALYSIS SYSTEM"
+               ],
+               "type": [
+                    "MICROSCOPE"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:midas.ro::1.0"
           },
           {
-               "name": "AUTONOE",
-               "type": "SATELLITE",
+               "name": [
+                    "AUTONOE"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.autonoe::1.1"
           },
           {
-               "name": "STYX",
-               "type": "SATELLITE",
+               "name": [
+                    "STYX"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.134340_pluto.styx::1.1"
           },
           {
-               "name": "ULTRAVIOLET PHOTOMETER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "ULTRAVIOLET PHOTOMETER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:uv.p11::1.0"
           },
           {
-               "name": "2014 PN70",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2014 PN70"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2014_pn70::1.0"
           },
           {
-               "name": "2002 GV32",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2002 GV32"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2002_gv32::1.0"
           },
           {
-               "name": "(300186) 2006 WG64",
-               "type": "ASTEROID",
+               "name": [
+                    "(300186) 2006 WG64"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300186_2006_wg64::1.0"
           },
           {
-               "name": "APOLLO 17 PANORAMIC CAMERA",
-               "type": "IMAGER",
+               "name": [
+                    "APOLLO 17 PANORAMIC CAMERA"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:pancam.a17c::1.0"
           },
           {
-               "name": "C/2009 P1 (GARRADD)",
-               "type": "COMET",
+               "name": [
+                    "C/2009 P1 (GARRADD)"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.c2009_p1_garradd::1.1"
           },
           {
-               "name": "DYNAMIC ALBEDO OF NEUTRONS",
-               "type": "SPECTROMETER",
+               "name": [
+                    "DYNAMIC ALBEDO OF NEUTRONS"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:dan.msl::1.0"
           },
           {
-               "name": "(300170) 2006 VB151",
-               "type": "ASTEROID",
+               "name": [
+                    "(300170) 2006 VB151"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300170_2006_vb151::1.0"
           },
           {
-               "name": "(300214) 2006 WH174",
-               "type": "ASTEROID",
+               "name": [
+                    "(300214) 2006 WH174"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300214_2006_wh174::1.0"
           },
           {
-               "name": "(11372) 1998 QP41",
-               "type": "ASTEROID",
+               "name": [
+                    "(11372) 1998 QP41"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.11372_1998_qp41::1.0"
           },
           {
-               "name": "2003 WN188",
-               "type": "CENTAUR",
+               "name": [
+                    "2003 WN188"
+               ],
+               "type": [
+                    "CENTAUR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:centaur.2003_wn188::1.0"
           },
           {
-               "name": "SOLAR-WIND INSTRUMENT",
-               "type": "PARTICLE DETECTOR",
+               "name": [
+                    "SOLAR-WIND INSTRUMENT"
+               ],
+               "type": [
+                    "PARTICLE DETECTOR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:sow.sakig::1.0"
           },
           {
-               "name": "(136204) 2003 WL7",
-               "type": "CENTAUR",
+               "name": [
+                    "(136204) 2003 WL7"
+               ],
+               "type": [
+                    "CENTAUR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:centaur.136204_2003_wl7::1.0"
           },
           {
-               "name": "APOLLO 16 ORBITAL MASS SPECTROMETER (OMS) EXPERIMENT",
-               "type": "SPECTROMETER",
+               "name": [
+                    "APOLLO 16 ORBITAL MASS SPECTROMETER (OMS) EXPERIMENT"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:oms.a16c::1.0"
           },
           {
-               "name": "BETA CANIS MAJORIS",
-               "type": "STAR",
+               "name": [
+                    "BETA CANIS MAJORIS"
+               ],
+               "type": [
+                    "STAR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:star.bet_cma::1.0"
           },
           {
-               "name": "STARDUST",
-               "type": "Spacecraft",
+               "name": [
+                    "STARDUST"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.sdu::1.1"
           },
           {
-               "name": "2001 QQ322",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2001 QQ322"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2001_qq322::1.0"
           },
           {
-               "name": "(144897) 2004 UX10",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(144897) 2004 UX10"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.144897_2004_ux10::1.0"
           },
           {
-               "name": "COMETARY AND INTERSTELLAR DUST ANALYZER",
-               "type": "DUST",
+               "name": [
+                    "COMETARY AND INTERSTELLAR DUST ANALYZER"
+               ],
+               "type": [
+                    "DUST"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:cida.sdu::1.0"
           },
           {
-               "name": "NEAR LASER RANGEFINDER",
-               "type": "ALTIMETER",
+               "name": [
+                    "NEAR LASER RANGEFINDER"
+               ],
+               "type": [
+                    "ALTIMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:nlr.near::1.0"
           },
           {
-               "name": "NEAR INFRARED CAMERA",
-               "type": "IMAGER",
+               "name": [
+                    "NEAR INFRARED CAMERA"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:nir.clem1::1.0"
           },
           {
-               "name": "BIANCA",
-               "type": "SATELLITE",
+               "name": [
+                    "BIANCA"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.uranus.bianca::1.1"
           },
           {
-               "name": "2006 HW122",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2006 HW122"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2006_hw122::1.0"
           },
           {
-               "name": "ION PROPULSION SYSTEM DIAGNOSTIC SUBSYSTEM",
-               "type": "PLASMA WAVE SPECTROMETER",
+               "name": [
+                    "ION PROPULSION SYSTEM DIAGNOSTIC SUBSYSTEM"
+               ],
+               "type": [
+                    "PLASMA WAVE SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:ids.ds1::1.0"
           },
           {
-               "name": "2000 YX1",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2000 YX1"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2000_yx1::1.0"
           },
           {
-               "name": "385571 OTRERA",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "385571 OTRERA"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.385571_otrera::1.0"
           },
           {
-               "name": "(15789) 1993 SC",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(15789) 1993 SC"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.15789_1993_sc::1.0"
           },
           {
-               "name": "VISUAL IMAGING SUBSYSTEM - CAMERA B",
-               "type": "IMAGER",
+               "name": [
+                    "VISUAL IMAGING SUBSYSTEM - CAMERA B"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:visb.vo2::1.0"
           },
           {
-               "name": "(469705) 2005 EF298",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(469705) 2005 EF298"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.469705_2005_ef298::1.0"
           },
           {
-               "name": "2002 XH91",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2002 XH91"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2002_xh91::1.0"
           },
           {
-               "name": "SPATIAL INFRARED IMAGING TELESCOPE",
-               "type": "RADIOMETER",
+               "name": [
+                    "SPATIAL INFRARED IMAGING TELESCOPE"
+               ],
+               "type": [
+                    "RADIOMETER",
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:spirit3.msx::1.0"
           },
           {
-               "name": "5145 PHOLUS",
-               "type": "CENTAUR",
+               "name": [
+                    "5145 PHOLUS"
+               ],
+               "type": [
+                    "CENTAUR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:centaur.5145_pholus::1.0"
           },
           {
-               "name": "(469704) 2005 EZ296",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(469704) 2005 EZ296"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.469704_2005_ez296::1.0"
           },
           {
-               "name": "(300206) 2006 WW126",
-               "type": "ASTEROID",
+               "name": [
+                    "(300206) 2006 WW126"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300206_2006_ww126::1.0"
           },
           {
-               "name": "GAMMA RAY SPECTROMETER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "GAMMA RAY SPECTROMETER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:grs.near::1.0"
           },
           {
-               "name": "MAG",
-               "type": "EQUIPMENT",
+               "name": [
+                    "MAG"
+               ],
+               "type": [
+                    "EQUIPMENT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:equipment.mag::1.0"
           },
           {
-               "name": "THERMAL EVOLVED GAS ANALYZER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "THERMAL EVOLVED GAS ANALYZER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:tega.phx::1.0"
           },
           {
-               "name": "2003 UT292",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2003 UT292"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2003_ut292::1.0"
           },
           {
-               "name": "1999 XY143",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "1999 XY143"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.1999_xy143::1.0"
           },
           {
-               "name": "2001 QX322",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2001 QX322"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2001_qx322::1.0"
           },
           {
-               "name": "DUST PARTICLE DETECTOR",
-               "type": "DUST",
+               "name": [
+                    "DUST PARTICLE DETECTOR"
+               ],
+               "type": [
+                    "DUST"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:sp2.vega2::1.0"
           },
           {
-               "name": "63P/WILD 1",
-               "type": "COMET",
+               "name": [
+                    "63P/WILD 1"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.63p_wild_1::1.0"
           },
           {
-               "name": "DUST PARTICLE COUNTER AND MASS ANALYZER",
-               "type": "PARTICLE DETECTOR",
+               "name": [
+                    "DUST PARTICLE COUNTER AND MASS ANALYZER"
+               ],
+               "type": [
+                    "PARTICLE DETECTOR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:ducma.vega1::1.0"
           },
           {
-               "name": "PHOENIX",
-               "type": "Spacecraft",
+               "name": [
+                    "PHOENIX"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.phx::1.1"
           },
           {
-               "name": "1998 WX24",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "1998 WX24"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.1998_wx24::1.0"
           },
           {
-               "name": "CASSINI ORBITER",
-               "type": "Spacecraft",
+               "name": [
+                    "CASSINI ORBITER"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.co::1.1"
           },
           {
-               "name": "(69988) 1998 WA31",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(69988) 1998 WA31"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.69988_1998_wa31::1.0"
           },
           {
-               "name": "2002 PD155",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2002 PD155"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2002_pd155::1.0"
           },
           {
-               "name": "EUANTHE",
-               "type": "SATELLITE",
+               "name": [
+                    "EUANTHE"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.euanthe::1.1"
           },
           {
-               "name": "WINDSOCK",
-               "type": "EQUIPMENT",
+               "name": [
+                    "WINDSOCK"
+               ],
+               "type": [
+                    "EQUIPMENT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:equipment.windsock::1.0"
           },
           {
-               "name": "S/2003 J 23",
-               "type": "SATELLITE",
+               "name": [
+                    "S/2003 J 23"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.s2003j23::1.1"
           },
           {
-               "name": "(131318) 2001 FL194",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(131318) 2001 FL194"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.131318_2001_fl194::1.0"
           },
           {
-               "name": "CORDELIA",
-               "type": "SATELLITE",
+               "name": [
+                    "CORDELIA"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.uranus.cordelia::1.1"
           },
           {
-               "name": "CALIBAN",
-               "type": "SATELLITE",
+               "name": [
+                    "CALIBAN"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.uranus.caliban::1.1"
           },
           {
-               "name": "VIKING",
-               "type": "Mission",
+               "name": [
+                    "VIKING"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.viking::1.1"
           },
           {
-               "name": "LUNAR SELF-RECORDING PENETROMETER",
-               "type": "REGOLITH PROPERTIES",
+               "name": [
+                    "LUNAR SELF-RECORDING PENETROMETER"
+               ],
+               "type": [
+                    "REGOLITH PROPERTIES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:lsrp.a15l::1.0"
           },
           {
-               "name": "13185 AGASTHENES",
-               "type": "ASTEROID",
+               "name": [
+                    "13185 AGASTHENES"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.13185_agasthenes::1.1"
           },
           {
-               "name": "PLASMA ENERGY ANALYZER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "PLASMA ENERGY ANALYZER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:pm1.vega1::1.0"
           },
           {
-               "name": "RADIO SCIENCE SUBSYSTEM",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "RADIO SCIENCE SUBSYSTEM"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:rss.mer1::1.0"
           },
           {
-               "name": "PLASMA SCIENCE EXPERIMENT",
-               "type": "SPECTROMETER",
+               "name": [
+                    "PLASMA SCIENCE EXPERIMENT"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:pls.go::1.0"
           },
           {
-               "name": "SHALLOW RADAR",
-               "type": "RADIO-RADAR",
+               "name": [
+                    "SHALLOW RADAR"
+               ],
+               "type": [
+                    "RADIO-RADAR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:sharad.mro::1.0"
           },
           {
-               "name": "AOEDE",
-               "type": "SATELLITE",
+               "name": [
+                    "AOEDE"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.aoede::1.1"
           },
           {
-               "name": "2003 QB112",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2003 QB112"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2003_qb112::1.0"
           },
           {
-               "name": "ULYSSES",
-               "type": "Mission",
+               "name": [
+                    "ULYSSES"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.ulysses::1.0"
           },
           {
-               "name": "SURFACE SCIENCE PACKAGE",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "SURFACE SCIENCE PACKAGE"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:ssp.hp::1.0"
           },
           {
-               "name": "(300175) 2006 WV20",
-               "type": "ASTEROID",
+               "name": [
+                    "(300175) 2006 WV20"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300175_2006_wv20::1.0"
           },
           {
-               "name": "R.A. BAGNOLD, WOODEN WIND TUNNEL (C.1935)",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "R.A. BAGNOLD, WOODEN WIND TUNNEL (C.1935)"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:imperial_college-hydraulics.bagnold_wt::1.0"
           },
           {
-               "name": "RADIO SCIENCE SUBSYSTEM",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "RADIO SCIENCE SUBSYSTEM"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:rss.lp::1.0"
           },
           {
-               "name": "RADIOWAVE DETECTOR",
-               "type": "RADIOMETER",
+               "name": [
+                    "RADIOWAVE DETECTOR"
+               ],
+               "type": [
+                    "RADIOMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:radwav.ice::1.0"
           },
           {
-               "name": "MEGACLITE",
-               "type": "SATELLITE",
+               "name": [
+                    "MEGACLITE"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.megaclite::1.1"
           },
           {
-               "name": "2004 TF282",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2004 TF282"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2004_tf282::1.0"
           },
           {
-               "name": "LUNAR CRATER OBSERVATION AND SENSING SATELLITE",
-               "type": "Mission",
+               "name": [
+                    "LUNAR CRATER OBSERVATION AND SENSING SATELLITE"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.lunar_crater_observation_and_sensing_satellite::1.1"
           },
           {
-               "name": "9P/TEMPEL 1",
-               "type": "COMET",
+               "name": [
+                    "9P/TEMPEL 1"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.9p_tempel_1::1.0"
           },
           {
-               "name": "TITANIA",
-               "type": "SATELLITE",
+               "name": [
+                    "TITANIA"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.uranus.titania::1.1"
           },
           {
-               "name": "PALLENE",
-               "type": "SATELLITE",
+               "name": [
+                    "PALLENE"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.pallene::1.1"
           },
           {
-               "name": "(25820) 2000 DB56",
-               "type": "ASTEROID",
+               "name": [
+                    "(25820) 2000 DB56"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.25820_2000_db56::1.0"
           },
           {
-               "name": "(300169) 2006 VC146",
-               "type": "ASTEROID",
+               "name": [
+                    "(300169) 2006 VC146"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300169_2006_vc146::1.0"
           },
           {
-               "name": "MARINER 7 WIDE ANGLE CAMERA",
-               "type": "IMAGER",
+               "name": [
+                    "MARINER 7 WIDE ANGLE CAMERA"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:wac.mr7::1.0"
           },
           {
-               "name": "COSPIN-KIEL ELECTRON TELESCOPE",
-               "type": "PARTICLE DETECTOR",
+               "name": [
+                    "COSPIN-KIEL ELECTRON TELESCOPE"
+               ],
+               "type": [
+                    "PARTICLE DETECTOR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:cospin-ket.uly::1.0"
           },
           {
-               "name": "2001 KG76",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2001 KG76"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2001_kg76::1.0"
           },
           {
-               "name": "2000 KL4",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2000 KL4"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2000_kl4::1.0"
           },
           {
-               "name": "(88269) 2001 KF77",
-               "type": "CENTAUR",
+               "name": [
+                    "(88269) 2001 KF77"
+               ],
+               "type": [
+                    "CENTAUR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:centaur.88269_2001_kf77::1.0"
           },
           {
-               "name": "GRAVITATIONAL WAVE EXPERIMENT",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "GRAVITATIONAL WAVE EXPERIMENT"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:gwe.uly::1.0"
           },
           {
-               "name": "(95626) 2002 GZ32",
-               "type": "CENTAUR",
+               "name": [
+                    "(95626) 2002 GZ32"
+               ],
+               "type": [
+                    "CENTAUR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:centaur.95626_2002_gz32::1.0"
           },
           {
-               "name": "D/1993 F2-K (SHOEMAKER-LEVY 9-K)",
-               "type": "COMET",
+               "name": [
+                    "D/1993 F2-K (SHOEMAKER-LEVY 9-K)"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.d1993_f2-k_shoemaker-levy_9-k::1.0"
           },
           {
-               "name": "2004 OJ14",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2004 OJ14"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2004_oj14::1.0"
           },
           {
-               "name": "2004 HZ78",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2004 HZ78"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2004_hz78::1.0"
           },
           {
-               "name": "MECA THERMAL AND ELECTRICAL CONDUCTIVITY PROBE",
-               "type": "REGOLITH PROPERTIES",
+               "name": [
+                    "MECA THERMAL AND ELECTRICAL CONDUCTIVITY PROBE"
+               ],
+               "type": [
+                    "REGOLITH PROPERTIES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:meca_tecp.phx::1.0"
           },
           {
-               "name": "ROVER CAMERA LEFT",
-               "type": "IMAGER",
+               "name": [
+                    "ROVER CAMERA LEFT"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:rclt.mpfr::1.0"
           },
           {
-               "name": "(31806) 1999 NE11",
-               "type": "ASTEROID",
+               "name": [
+                    "(31806) 1999 NE11"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.31806_1999_ne11::1.0"
           },
           {
-               "name": "(300188) 2006 WD70",
-               "type": "ASTEROID",
+               "name": [
+                    "(300188) 2006 WD70"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300188_2006_wd70::1.0"
           },
           {
-               "name": "MARS RADIATION ENVIRONMENT EXPERIMENT",
-               "type": "PARTICLE DETECTOR",
+               "name": [
+                    "MARS RADIATION ENVIRONMENT EXPERIMENT"
+               ],
+               "type": [
+                    "PARTICLE DETECTOR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:mar.ody::1.0"
           },
           {
-               "name": "(119473) 2001 UO18",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(119473) 2001 UO18"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.119473_2001_uo18::1.0"
           },
           {
-               "name": "TUNDE-M ENERGETIC PARTICLE ANALYZER",
-               "type": "PARTICLE DETECTOR",
+               "name": [
+                    "TUNDE-M ENERGETIC PARTICLE ANALYZER"
+               ],
+               "type": [
+                    "PARTICLE DETECTOR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:tnm.vega1::1.0"
           },
           {
-               "name": "PLASMA WAVE RECEIVER",
-               "type": "PLASMA WAVE SPECTROMETER",
+               "name": [
+                    "PLASMA WAVE RECEIVER"
+               ],
+               "type": [
+                    "PLASMA WAVE SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:pws.go::1.0"
           },
           {
-               "name": "RADIO SCIENCE SUBSYSTEM",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "RADIO SCIENCE SUBSYSTEM"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:rss.co::1.0"
           },
           {
-               "name": "VEGA 2",
-               "type": "Mission",
+               "name": [
+                    "VEGA 2"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.vega_2::1.1"
           },
           {
-               "name": "2005 EZ300",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2005 EZ300"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2005_ez300::1.0"
           },
           {
-               "name": "NO SPECIFIC INVESTIGATION",
-               "type": "Individual Investigation",
+               "name": [
+                    "NO SPECIFIC INVESTIGATION"
+               ],
+               "type": [
+                    "Individual Investigation"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:individual.none::1.0"
           },
           {
-               "name": "CHEPIL WIND TUNNEL AT THE HIGH PLAINS WIND EROSION LABORATORY, KANSAS STATE UNIVERSITY",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "CHEPIL WIND TUNNEL AT THE HIGH PLAINS WIND EROSION LABORATORY, KANSAS STATE UNIVERSITY"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:ksu-hpwel.chepil_wt::1.0"
           },
           {
-               "name": "(300204) 2006 WR117",
-               "type": "ASTEROID",
+               "name": [
+                    "(300204) 2006 WR117"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300204_2006_wr117::1.0"
           },
           {
-               "name": "(163249) 2002 GT",
-               "type": "ASTEROID",
+               "name": [
+                    "(163249) 2002 GT"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.163249_2002_gt::1.0"
           },
           {
-               "name": "PLASMA SCIENCE EXPERIMENT",
-               "type": "SPECTROMETER",
+               "name": [
+                    "PLASMA SCIENCE EXPERIMENT"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:pls.vg2::1.0"
           },
           {
-               "name": "HAZARD AVOIDANCE CAMERA",
-               "type": "IMAGER",
+               "name": [
+                    "HAZARD AVOIDANCE CAMERA"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:hazcam.mer1::1.0"
           },
           {
-               "name": "APOLLO 16 LUNAR MODULE",
-               "type": "Spacecraft",
+               "name": [
+                    "APOLLO 14 SUPRATHERMAL ION DETECTOR EXPERIMENT"
+               ],
+               "type": [
+                    "PARTICLE DETECTOR"
+               ],
+               "lidvid": "urn:nasa:pds:context:instrument:side.a14a::1.0"
+          },
+          {
+               "name": [
+                    "APOLLO 16 LUNAR MODULE"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.a16l::1.1"
           },
           {
-               "name": "CRESSIDA",
-               "type": "SATELLITE",
+               "name": [
+                    "CRESSIDA"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.uranus.cressida::1.1"
           },
           {
-               "name": "(13383) 1998 XS31",
-               "type": "ASTEROID",
+               "name": [
+                    "(13383) 1998 XS31"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.13383_1998_xs31::1.0"
           },
           {
-               "name": "SIGMA SAGITTARII",
-               "type": "STAR",
+               "name": [
+                    "SIGMA SAGITTARII"
+               ],
+               "type": [
+                    "STAR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:star.sig_sgr::1.0"
           },
           {
-               "name": "VIKING METEOROLOGY INSTRUMENT SYSTEM",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "VIKING METEOROLOGY INSTRUMENT SYSTEM"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:met.vl2::1.0"
           },
           {
-               "name": "2000 ON67",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2000 ON67"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2000_on67::1.0"
           },
           {
-               "name": "Pioneer 9",
-               "type": "Spacecraft",
+               "name": [
+                    "Pioneer 9"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.p9::1.0"
           },
           {
-               "name": "2001 XR254",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2001 XR254"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2001_xr254::1.0"
           },
           {
-               "name": "ALPHA PARTICLE SPECTROMETER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "ALPHA PARTICLE SPECTROMETER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:aps.lp::1.0"
           },
           {
-               "name": "MERCURY DUAL IMAGING SYSTEM WIDE ANGLE CAMERA",
-               "type": "IMAGER",
+               "name": [
+                    "MERCURY DUAL IMAGING SYSTEM WIDE ANGLE CAMERA"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:mdis-wac.mess::1.0"
           },
           {
-               "name": "VENUS EXPRESS",
-               "type": "Spacecraft",
-               "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.vex::1.1"
-          },
-          {
-               "name": "APOLLO 16 LUNAR SURFACE MAGNETOMETER (LSM) EXPERIMENT",
-               "type": "MAGNETOMETER",
+               "name": [
+                    "APOLLO 16 LUNAR SURFACE MAGNETOMETER (LSM) EXPERIMENT"
+               ],
+               "type": [
+                    "MAGNETOMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:lsm.a16a::1.0"
           },
           {
-               "name": "(28306) 1999 CV79",
-               "type": "ASTEROID",
+               "name": [
+                    "(28306) 1999 CV79"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.28306_1999_cv79::1.0"
           },
           {
-               "name": "(503858) 1998 HQ151",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(503858) 1998 HQ151"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.503858_1998_hq151::1.0"
           },
           {
-               "name": "CHARGED PARTICLE INSTRUMENT",
-               "type": "PARTICLE DETECTOR",
+               "name": [
+                    "CHARGED PARTICLE INSTRUMENT"
+               ],
+               "type": [
+                    "PARTICLE DETECTOR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:cpi.p11::1.0"
           },
           {
-               "name": "INSIGHT DEPLOYMENT CAMERA",
-               "type": "IMAGER",
+               "name": [
+                    "INSIGHT DEPLOYMENT CAMERA"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:idc.insight::1.0"
           },
           {
-               "name": "2000 WL183",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2000 WL183"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2000_wl183::1.0"
           },
           {
-               "name": "1998 UU43",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "1998 UU43"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.1998_uu43::1.0"
           },
           {
-               "name": "D/1993 F2-Q2 (SHOEMAKER-LEVY 9-Q2)",
-               "type": "COMET",
+               "name": [
+                    "D/1993 F2-Q2 (SHOEMAKER-LEVY 9-Q2)"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.d1993_f2-q2_shoemaker-levy_9-q2::1.0"
           },
           {
-               "name": "1998 XY95",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "1998 XY95"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.1998_xy95::1.0"
           },
           {
-               "name": "(47932) 2000 GN171",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(47932) 2000 GN171"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.47932_2000_gn171::1.0"
           },
           {
-               "name": "PIONEER",
-               "type": "Mission",
+               "name": [
+                    "PIONEER"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.pioneer::1.0"
           },
           {
-               "name": "2000 CO105",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2000 CO105"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2000_co105::1.0"
           },
           {
-               "name": "(275809) 2001 QY297",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(275809) 2001 QY297"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.275809_2001_qy297::1.0"
           },
           {
-               "name": "APOLLO 17 SURFACE ELECTRICAL PROPERTIES (SEP) EXPERIMENT",
-               "type": "REGOLITH PROPERTIES",
+               "name": [
+                    "APOLLO 17 SURFACE ELECTRICAL PROPERTIES (SEP) EXPERIMENT"
+               ],
+               "type": [
+                    "REGOLITH PROPERTIES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:sep.a17l::1.0"
           },
           {
-               "name": "SKYFLAT",
-               "type": "CALIBRATION FIELD",
+               "name": [
+                    "SKYFLAT"
+               ],
+               "type": [
+                    "CALIBRATION FIELD"
+               ],
                "lidvid": "urn:nasa:pds:context:target:calibration_field.skyflat::1.0"
           },
           {
-               "name": "2001 QX297",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2001 QX297"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2001_qx297::1.0"
           },
           {
-               "name": "VLT IMAGER AND SPECTROMETER FOR MID-INFRARED (VISIR)",
-               "type": "SPECTROMETER",
+               "name": [
+                    "VLT IMAGER AND SPECTROMETER FOR MID-INFRARED (VISIR)"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:eso-paranal.vlt_8m2.visir::1.0"
           },
           {
-               "name": "NAVIGATION CAMERA LEFT STRING B",
-               "type": "IMAGER",
+               "name": [
+                    "NAVIGATION CAMERA LEFT STRING B"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:nav_left_b.msl::1.0"
           },
           {
-               "name": "RADIO SCIENCE SUBSYSTEM",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "RADIO SCIENCE SUBSYSTEM"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:rss.go::1.0"
           },
           {
-               "name": "ATMOSPHERIC STRUCTURE EXPERIMENT",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "ATMOSPHERIC STRUCTURE EXPERIMENT"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:ase.phx::1.0"
           },
           {
-               "name": "TAU SCORPII",
-               "type": "STAR",
+               "name": [
+                    "TAU SCORPII"
+               ],
+               "type": [
+                    "STAR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:star.tau_sco::1.0"
           },
           {
-               "name": "(84522) 2002 TC302",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(84522) 2002 TC302"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.84522_2002_tc302::1.0"
           },
           {
-               "name": "29 AMPHITRITE",
-               "type": "ASTEROID",
+               "name": [
+                    "29 AMPHITRITE"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.29_amphitrite::1.1"
           },
           {
-               "name": "1999 KR18",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "1999 KR18"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.1999_kr18::1.0"
           },
           {
-               "name": "(15883) 1997 CR29",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(15883) 1997 CR29"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.15883_1997_cr29::1.0"
           },
           {
-               "name": "GALILEO ORBITER",
-               "type": "Spacecraft",
+               "name": [
+                    "GALILEO ORBITER"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.go::1.1"
           },
           {
-               "name": "1998 WY31",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "1998 WY31"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.1998_wy31::1.0"
           },
           {
-               "name": "10 HYGIEA",
-               "type": "ASTEROID",
+               "name": [
+                    "10 HYGIEA"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.10_hygiea::1.1"
           },
           {
-               "name": "15P/FINLAY",
-               "type": "COMET",
+               "name": [
+                    "15P/FINLAY"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.15p_finlay::1.0"
           },
           {
-               "name": "2005 CF81",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2005 CF81"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2005_cf81::1.0"
           },
           {
-               "name": "(26308) 1998 SM165",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(26308) 1998 SM165"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.26308_1998_sm165::1.0"
           },
           {
-               "name": "HAYABUSA",
-               "type": "Spacecraft",
+               "name": [
+                    "HAYABUSA"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.hay::1.1"
           },
           {
-               "name": "2003 YS179",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2003 YS179"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2003_ys179::1.0"
           },
           {
-               "name": "2003 QB91",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2003 QB91"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2003_qb91::1.0"
           },
           {
-               "name": "VEGA 1",
-               "type": "Spacecraft",
+               "name": [
+                    "VEGA 1"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.vega1::1.1"
           },
           {
-               "name": "(182933) 2002 GZ31",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(182933) 2002 GZ31"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.182933_2002_gz31::1.0"
           },
           {
-               "name": "1998 WW31",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "1998 WW31"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.1998_ww31::1.0"
           },
           {
-               "name": "(149560) 2003 QZ91",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(149560) 2003 QZ91"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.149560_2003_qz91::1.0"
           },
           {
-               "name": "2011 JW31",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2011 JW31"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2011_jw31::1.0"
           },
           {
-               "name": "JOHNSTONE PLASMA ANALYZER (JPA)",
-               "type": "SPECTROMETER",
+               "name": [
+                    "JOHNSTONE PLASMA ANALYZER (JPA)"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:jpa.gio::1.0"
           },
           {
-               "name": "112P/URATA-NIIJIMA",
-               "type": "COMET",
+               "name": [
+                    "112P/URATA-NIIJIMA"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.112p_urata-niijima::1.0"
           },
           {
-               "name": "5511 CLOANTHUS",
-               "type": "ASTEROID",
+               "name": [
+                    "5511 CLOANTHUS"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.5511_cloanthus::1.1"
           },
           {
-               "name": "(51068) 2000 GW156",
-               "type": "ASTEROID",
+               "name": [
+                    "(51068) 2000 GW156"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.51068_2000_gw156::1.0"
           },
           {
-               "name": "15760 ALBION",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "15760 ALBION"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.15760_albion::1.0"
           },
           {
-               "name": "(126719) 2002 CC249",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(126719) 2002 CC249"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.126719_2002_cc249::1.0"
           },
           {
-               "name": "DYNAMIC SCIENCE EXPERIMENT",
-               "type": "SMALL BODIES SCIENCES",
+               "name": [
+                    "DYNAMIC SCIENCE EXPERIMENT"
+               ],
+               "type": [
+                    "SMALL BODIES SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:dynsci.sdu::1.0"
           },
           {
-               "name": "(145480) 2005 TB190",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "ALDEBARAN"
+               ],
+               "type": [
+                    "STAR"
+               ],
+               "lidvid": "urn:nasa:pds:context:target:star.alf_tau::1.0"
+          },
+          {
+               "name": [
+                    "(145480) 2005 TB190"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.145480_2005_tb190::1.0"
           },
           {
-               "name": "MULTISPECTRAL VISIBLE IMAGING CAMERA",
-               "type": "IMAGER",
+               "name": [
+                    "MULTISPECTRAL VISIBLE IMAGING CAMERA"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:mvic.nh::1.0"
           },
           {
-               "name": "DESPINA",
-               "type": "SATELLITE",
+               "name": [
+                    "DESPINA"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.neptune.despina::1.1"
           },
           {
-               "name": "DEEP SPACE 1",
-               "type": "Mission",
+               "name": [
+                    "DEEP SPACE 1"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.deep_space_1::1.1"
           },
           {
-               "name": "HYDRA",
-               "type": "SATELLITE",
+               "name": [
+                    "HYDRA"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.134340_pluto.hydra::1.1"
           },
           {
-               "name": "50P/AREND",
-               "type": "COMET",
+               "name": [
+                    "50P/AREND"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.50p_arend::1.0"
           },
           {
-               "name": "MAGNETOMETER - ELECTRON REFLECTOMETER",
-               "type": "MAGNETOMETER",
+               "name": [
+                    "MAGNETOMETER - ELECTRON REFLECTOMETER"
+               ],
+               "type": [
+                    "MAGNETOMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:mager.lp::1.0"
           },
           {
-               "name": "CAL",
-               "type": "CALIBRATOR",
+               "name": [
+                    "CAL"
+               ],
+               "type": [
+                    "CALIBRATOR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:calibrator.cal::1.0"
           },
           {
-               "name": "90377 SEDNA",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "90377 SEDNA"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.90377_sedna::1.1"
           },
           {
-               "name": "(149348) 2002 VS130",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(149348) 2002 VS130"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.149348_2002_vs130::1.0"
           },
           {
-               "name": "2001 OZ108",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2001 OZ108"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2001_oz108::1.0"
           },
           {
-               "name": "2001 MARS ODYSSEY",
-               "type": "Mission",
+               "name": [
+                    "2001 MARS ODYSSEY"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.2001_mars_odyssey::1.0"
           },
           {
-               "name": "RADIO SCIENCE SUBSYSTEM",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "RADIO SCIENCE SUBSYSTEM"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:rss.vo2::1.0"
           },
           {
-               "name": "VIKING ORBITER 1",
-               "type": "Spacecraft",
+               "name": [
+                    "VIKING ORBITER 1"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.vo1::1.1"
           },
           {
-               "name": "LANDER",
-               "type": "EQUIPMENT",
+               "name": [
+                    "LANDER"
+               ],
+               "type": [
+                    "EQUIPMENT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:equipment.lander::1.0"
           },
           {
-               "name": "LUNAR GRAVITY RANGING SYSTEM A",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "LUNAR GRAVITY RANGING SYSTEM A"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:lgrs-a.grail-a::1.0"
           },
           {
-               "name": "(135742) 2002 PB171",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(135742) 2002 PB171"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.135742_2002_pb171::1.0"
           },
           {
-               "name": "SUISEI",
-               "type": "Spacecraft",
+               "name": [
+                    "SUISEI"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.suisei::1.1"
           },
           {
-               "name": "84P/GICLAS",
-               "type": "COMET",
+               "name": [
+                    "84P/GICLAS"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.84p_giclas::1.0"
           },
           {
-               "name": "2004 VS75",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2004 VS75"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2004_vs75::1.0"
           },
           {
-               "name": "(300246) 2007 EE96",
-               "type": "ASTEROID",
+               "name": [
+                    "(300246) 2007 EE96"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300246_2007_ee96::1.0"
           },
           {
-               "name": "ELECTRON REFLECTOMETER",
-               "type": "MAGNETOMETER",
+               "name": [
+                    "ELECTRON REFLECTOMETER"
+               ],
+               "type": [
+                    "MAGNETOMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:er.lp::1.0"
           },
           {
-               "name": "DAWN MISSION TO VESTA AND CERES",
-               "type": "Mission",
+               "name": [
+                    "DAWN MISSION TO VESTA AND CERES"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.dawn_mission_to_vesta_and_ceres::1.1"
           },
           {
-               "name": "(385266) 2001 QB298",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(385266) 2001 QB298"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.385266_2001_qb298::1.0"
           },
           {
-               "name": "SUTTUNGR",
-               "type": "SATELLITE",
+               "name": [
+                    "SUTTUNGR"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.suttungr::1.1"
           },
           {
-               "name": "434 HUNGARIA",
-               "type": "ASTEROID",
+               "name": [
+                    "434 HUNGARIA"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.434_hungaria::1.1"
           },
           {
-               "name": "(300207) 2006 WB137",
-               "type": "ASTEROID",
+               "name": [
+                    "MAGNETOMETER"
+               ],
+               "type": [
+                    "MAGNETOMETER"
+               ],
+               "lidvid": "urn:nasa:pds:context:instrument:vex.mag::1.0"
+          },
+          {
+               "name": [
+                    "(300207) 2006 WB137"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300207_2006_wb137::1.0"
           },
           {
-               "name": "(135024) 2001 KO76",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(135024) 2001 KO76"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.135024_2001_ko76::1.0"
           },
           {
-               "name": "121 HERMIONE",
-               "type": "ASTEROID",
+               "name": [
+                    "121 HERMIONE"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.121_hermione::1.1"
           },
           {
-               "name": "BIAS",
-               "type": "CALIBRATOR",
+               "name": [
+                    "BIAS"
+               ],
+               "type": [
+                    "CALIBRATOR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:calibrator.bias::1.0"
           },
           {
-               "name": "19P/BORRELLY",
-               "type": "COMET",
+               "name": [
+                    "19P/BORRELLY"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.19p_borrelly::1.0"
           },
           {
-               "name": "LAB.HYDROCARBON SPECTRA",
-               "type": "Individual Investigation",
+               "name": [
+                    "LAB.HYDROCARBON SPECTRA"
+               ],
+               "type": [
+                    "Individual Investigation"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:individual_investigation.lab.hydrocarbon_spectra::1.0"
           },
           {
-               "name": "4015 WILSON-HARRINGTON",
-               "type": "ASTEROID",
+               "name": [
+                    "4015 WILSON-HARRINGTON"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.4015_wilson-harrington::1.1"
           },
           {
-               "name": "IMAGING SCIENCE SUBSYSTEM - WIDE ANGLE",
-               "type": "IMAGER",
+               "name": [
+                    "IMAGING SCIENCE SUBSYSTEM - WIDE ANGLE"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:isswa.co::1.0"
           },
           {
-               "name": "MAGNETOMETER",
-               "type": "MAGNETOMETER",
+               "name": [
+                    "MAGNETOMETER"
+               ],
+               "type": [
+                    "MAGNETOMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:fgm.jno::1.0"
           },
           {
-               "name": "RADIO SCIENCE SUBSYSTEM",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "RADIO SCIENCE SUBSYSTEM"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:rss.ody::1.0"
           },
           {
-               "name": "TRIAXIAL FLUXGATE MAGNETOMETER",
-               "type": "MAGNETOMETER",
+               "name": [
+                    "TRIAXIAL FLUXGATE MAGNETOMETER"
+               ],
+               "type": [
+                    "MAGNETOMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:mag.vg2::1.0"
           },
           {
-               "name": "MARS RECONNAISSANCE ORBITER",
-               "type": "Spacecraft",
+               "name": [
+                    "MARS RECONNAISSANCE ORBITER"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.mro::1.0"
           },
           {
-               "name": "2005 EO304",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2005 EO304"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2005_eo304::1.0"
           },
           {
-               "name": "10199 CHARIKLO",
-               "type": "CENTAUR",
+               "name": [
+                    "10199 CHARIKLO"
+               ],
+               "type": [
+                    "CENTAUR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:centaur.10199_chariklo::1.0"
           },
           {
-               "name": "MARS EXPRESS ORBITER RADIO SCIENCE",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "MARS EXPRESS ORBITER RADIO SCIENCE"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:mrs.mex::1.0"
           },
           {
-               "name": "FOMALHAUT",
-               "type": "STAR",
+               "name": [
+                    "FOMALHAUT"
+               ],
+               "type": [
+                    "STAR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:star.alf_psa::1.0"
           },
           {
-               "name": "2002 PP149",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2002 PP149"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2002_pp149::1.0"
           },
           {
-               "name": "2014 MT69",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2014 MT69"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2014_mt69::1.0"
           },
           {
-               "name": "PIONEER VENUS ORBITER",
-               "type": "Spacecraft",
+               "name": [
+                    "PIONEER VENUS ORBITER"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.pvo::1.0"
           },
           {
-               "name": "86P/WILD 3",
-               "type": "COMET",
+               "name": [
+                    "86P/WILD 3"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.86p_wild_3::1.0"
           },
           {
-               "name": "(300195) 2006 WO96",
-               "type": "ASTEROID",
+               "name": [
+                    "(300195) 2006 WO96"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300195_2006_wo96::1.0"
           },
           {
-               "name": "SUN",
-               "type": "SUN",
+               "name": [
+                    "SUN"
+               ],
+               "type": [
+                    "SUN"
+               ],
                "lidvid": "urn:nasa:pds:context:target:sun.sun::1.2"
           },
           {
-               "name": "ELARA",
-               "type": "SATELLITE",
+               "name": [
+                    "ELARA"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.elara::1.1"
           },
           {
-               "name": "MARS ATMOSPHERIC WATER DETECTOR",
-               "type": "SPECTROMETER",
+               "name": [
+                    "MARS ATMOSPHERIC WATER DETECTOR"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:mawd.vo1::1.0"
           },
           {
-               "name": "13765 NANSMITH",
-               "type": "ASTEROID",
+               "name": [
+                    "13765 NANSMITH"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.13765_nansmith::1.1"
           },
           {
-               "name": "MARS OBSERVER",
-               "type": "Spacecraft",
+               "name": [
+                    "MARS OBSERVER"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.mo::1.0"
           },
           {
-               "name": "(385445) 2003 QH91",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(385445) 2003 QH91"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.385445_2003_qh91::1.0"
           },
           {
-               "name": "TETHYS",
-               "type": "SATELLITE",
+               "name": [
+                    "TETHYS"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.tethys::1.1"
           },
           {
-               "name": "10P/TEMPEL 2",
-               "type": "COMET",
+               "name": [
+                    "10P/TEMPEL 2"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.10p_tempel_2::1.0"
           },
           {
-               "name": "N/A",
-               "type": "Spacecraft",
+               "name": [
+                    "N/A"
+               ],
+               "type": [
+                    "N/A"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.maven::1.0"
           },
           {
-               "name": "148780 ALTJIRA",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "148780 ALTJIRA"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.148780_altjira::1.1"
           },
           {
-               "name": "D/1993 F2-U (SHOEMAKER-LEVY 9-U)",
-               "type": "COMET",
+               "name": [
+                    "D/1993 F2-U (SHOEMAKER-LEVY 9-U)"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.d1993_f2-u_shoemaker-levy_9-u::1.0"
           },
           {
-               "name": "CRS",
-               "type": "PARTICLE DETECTOR",
+               "name": [
+                    "CRS"
+               ],
+               "type": [
+                    "PARTICLE DETECTOR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:crs.p11::1.0"
           },
           {
-               "name": "(300254) 2007 GH36",
-               "type": "ASTEROID",
+               "name": [
+                    "(300254) 2007 GH36"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300254_2007_gh36::1.0"
           },
           {
-               "name": "2008 CT190",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2008 CT190"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2008_ct190::1.0"
           },
           {
-               "name": "2003 QY90",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2003 QY90"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2003_qy90::1.0"
           },
           {
-               "name": "COSMIC RAY SUBSYSTEM",
-               "type": "PARTICLE DETECTOR",
+               "name": [
+                    "COSMIC RAY SUBSYSTEM"
+               ],
+               "type": [
+                    "PARTICLE DETECTOR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:crs.vg2::1.0"
           },
           {
-               "name": "2006 QQ180",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2006 QQ180"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2006_qq180::1.0"
           },
           {
-               "name": "THALASSA",
-               "type": "SATELLITE",
+               "name": [
+                    "THALASSA"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.neptune.thalassa::1.1"
           },
           {
-               "name": "(300219) 2006 WN187",
-               "type": "ASTEROID",
+               "name": [
+                    "(300219) 2006 WN187"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300219_2006_wn187::1.0"
           },
           {
-               "name": "(486958) 2014 MU69",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(486958) 2014 MU69"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.486958_2014_mu69::1.0"
           },
           {
-               "name": "NON SCIENCE",
-               "type": "CALIBRATOR",
+               "name": [
+                    "NON SCIENCE"
+               ],
+               "type": [
+                    "CALIBRATOR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:calibrator.non_science::1.0"
           },
           {
-               "name": "CAMERA 2",
-               "type": "IMAGER",
+               "name": [
+                    "CAMERA 2"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:cam2.vl2::1.0"
           },
           {
-               "name": "1996 RQ20",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "1996 RQ20"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.1996_rq20::1.0"
           },
           {
-               "name": "2000 WW12",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2000 WW12"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2000_ww12::1.0"
           },
           {
-               "name": "PUCK",
-               "type": "SATELLITE",
+               "name": [
+                    "PUCK"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.uranus.puck::1.1"
           },
           {
-               "name": "VENERA 16",
-               "type": "Spacecraft",
+               "name": [
+                    "VENERA 16"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.v16::1.0"
           },
           {
-               "name": "S/2007 S 2",
-               "type": "SATELLITE",
+               "name": [
+                    "S/2007 S 2"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.s2007s2::1.1"
           },
           {
-               "name": "76P/WEST-KOHOUTEK-IKEMURA",
-               "type": "COMET",
+               "name": [
+                    "76P/WEST-KOHOUTEK-IKEMURA"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.76p_west-kohoutek-ikemura::1.0"
           },
           {
-               "name": "MINI-RF FORERUNNER",
-               "type": "RADIO-RADAR",
+               "name": [
+                    "MINI-RF FORERUNNER"
+               ],
+               "type": [
+                    "RADIO-RADAR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:mrffr.ch1-orb::1.0"
           },
           {
-               "name": "(15521) 1999 XH133",
-               "type": "ASTEROID",
+               "name": [
+                    "(15521) 1999 XH133"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.15521_1999_xh133::1.0"
           },
           {
-               "name": "31824 ELATUS",
-               "type": "CENTAUR",
+               "name": [
+                    "31824 ELATUS"
+               ],
+               "type": [
+                    "CENTAUR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:centaur.31824_elatus::1.0"
           },
           {
-               "name": "DIVINER LUNAR RADIOMETER EXPERIMENT",
-               "type": "RADIOMETER",
+               "name": [
+                    "DIVINER LUNAR RADIOMETER EXPERIMENT"
+               ],
+               "type": [
+                    "RADIOMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:dlre.lro::1.0"
           },
           {
-               "name": "24P/SCHAUMASSE",
-               "type": "COMET",
+               "name": [
+                    "24P/SCHAUMASSE"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.24p_schaumasse::1.0"
           },
           {
-               "name": "SAKIGAKE",
-               "type": "Mission",
+               "name": [
+                    "SAKIGAKE"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.sakigake::1.1"
           },
           {
-               "name": "D/1993 F2-A (SHOEMAKER-LEVY 9-A)",
-               "type": "COMET",
+               "name": [
+                    "D/1993 F2-A (SHOEMAKER-LEVY 9-A)"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.d1993_f2-a_shoemaker-levy_9-a::1.0"
           },
           {
-               "name": "IMAGING SCIENCE SUBSYSTEM - WIDE ANGLE",
-               "type": "IMAGER",
+               "name": [
+                    "IMAGING SCIENCE SUBSYSTEM - WIDE ANGLE"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:issw.vg2::1.0"
           },
           {
-               "name": "(24835) 1995 SM55",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(24835) 1995 SM55"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.24835_1995_sm55::1.0"
           },
           {
-               "name": "GRAVITY SCIENCE INSTRUMENT",
-               "type": "RADIO-RADAR",
+               "name": [
+                    "GRAVITY SCIENCE INSTRUMENT"
+               ],
+               "type": [
+                    "RADIO-RADAR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:grav.jno::1.0"
           },
           {
-               "name": "SOLAR-WIND EXPERIMENT",
-               "type": "PARTICLE DETECTOR",
+               "name": [
+                    "SOLAR-WIND EXPERIMENT"
+               ],
+               "type": [
+                    "PARTICLE DETECTOR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:esp.suisei::1.0"
           },
           {
-               "name": "ALPHA PAVONIS",
-               "type": "STAR",
+               "name": [
+                    "ALPHA PAVONIS"
+               ],
+               "type": [
+                    "STAR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:star.alf_pav::1.0"
           },
           {
-               "name": "(312645) 2010 EP65",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(312645) 2010 EP65"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.312645_2010_ep65::1.0"
           },
           {
-               "name": "5041 THEOTES",
-               "type": "ASTEROID",
+               "name": [
+                    "5041 THEOTES"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.5041_theotes::1.1"
           },
           {
-               "name": "(308379) 2005 RS43",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(308379) 2005 RS43"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.308379_2005_rs43::1.0"
           },
           {
-               "name": "2000 SR331",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2000 SR331"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2000_sr331::1.0"
           },
           {
-               "name": "619 TRIBERGA",
-               "type": "ASTEROID",
+               "name": [
+                    "619 TRIBERGA"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.619_triberga::1.1"
           },
           {
-               "name": "DESCENT IMAGER SPECTRAL RADIOMETER",
-               "type": "IMAGER",
+               "name": [
+                    "DESCENT IMAGER SPECTRAL RADIOMETER"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:disr.hp::1.0"
           },
           {
-               "name": "FORNJOT",
-               "type": "SATELLITE",
+               "name": [
+                    "FORNJOT"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.fornjot::1.1"
           },
           {
-               "name": "(137295) 1999 RB216",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(137295) 1999 RB216"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.137295_1999_rb216::1.0"
           },
           {
-               "name": "(300196) 2006 WZ96",
-               "type": "ASTEROID",
+               "name": [
+                    "(300196) 2006 WZ96"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300196_2006_wz96::1.0"
           },
           {
-               "name": "2003 TJ58",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2003 TJ58"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2003_tj58::1.0"
           },
           {
-               "name": "(63252) 2001 BL41",
-               "type": "CENTAUR",
+               "name": [
+                    "(63252) 2001 BL41"
+               ],
+               "type": [
+                    "CENTAUR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:centaur.63252_2001_bl41::1.0"
           },
           {
-               "name": "INTERNATIONAL ULTRAVIOLET EXPLORER",
-               "type": "Mission",
+               "name": [
+                    "INTERNATIONAL ULTRAVIOLET EXPLORER"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.international_ultraviolet_explorer::1.0"
           },
           {
-               "name": "(126155) 2001 YJ140",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(126155) 2001 YJ140"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.126155_2001_yj140::1.0"
           },
           {
-               "name": "MIDCOURSE SPACE EXPERIMENT",
-               "type": "Spacecraft",
+               "name": [
+                    "MIDCOURSE SPACE EXPERIMENT"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.msx::1.1"
           },
           {
-               "name": "(34312) 2000 QO188",
-               "type": "ASTEROID",
+               "name": [
+                    "(34312) 2000 QO188"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.34312_2000_qo188::1.0"
           },
           {
-               "name": "APOLLO 15 SUPRATHERMAL ION DETECTOR EXPERIMENT",
-               "type": "PARTICLE DETECTOR",
+               "name": [
+                    "APOLLO 15 SUPRATHERMAL ION DETECTOR EXPERIMENT"
+               ],
+               "type": [
+                    "PARTICLE DETECTOR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:side.a15a::1.0"
           },
           {
-               "name": "MAGNETOMETER",
-               "type": "MAGNETOMETER",
+               "name": [
+                    "MAGNETOMETER"
+               ],
+               "type": [
+                    "MAGNETOMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:mag.maven::1.0"
           },
           {
-               "name": "CHECKOUT",
-               "type": "CALIBRATOR",
+               "name": [
+                    "CHECKOUT"
+               ],
+               "type": [
+                    "CALIBRATOR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:calibrator.checkout::1.0"
           },
           {
-               "name": "4 VESTA",
-               "type": "ASTEROID",
+               "name": [
+                    "4 VESTA"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.4_vesta::1.1"
           },
           {
-               "name": "TRIAXIAL FLUXGATE MAGNETOMETER",
-               "type": "MAGNETOMETER",
+               "name": [
+                    "TRIAXIAL FLUXGATE MAGNETOMETER"
+               ],
+               "type": [
+                    "MAGNETOMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:mag.m10::1.0"
           },
           {
-               "name": "2003 QX91",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2003 QX91"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2003_qx91::1.0"
           },
           {
-               "name": "(300231) 2006 YV3",
-               "type": "ASTEROID",
+               "name": [
+                    "(300231) 2006 YV3"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300231_2006_yv3::1.0"
           },
           {
-               "name": "(307261) 2002 MS4",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(307261) 2002 MS4"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.307261_2002_ms4::1.0"
           },
           {
-               "name": "HIGH RATE DETECTOR",
-               "type": "DUST",
+               "name": [
+                    "HIGH RATE DETECTOR"
+               ],
+               "type": [
+                    "DUST"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:hrd.co::1.0"
           },
           {
-               "name": "AMALTHEA",
-               "type": "SATELLITE",
+               "name": [
+                    "AMALTHEA"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.amalthea::1.1"
           },
           {
-               "name": "(60621) 2000 FE8",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(60621) 2000 FE8"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.60621_2000_fe8::1.0"
           },
           {
-               "name": "DUST",
-               "type": "DUST",
+               "name": [
+                    "DUST"
+               ],
+               "type": [
+                    "DUST"
+               ],
                "lidvid": "urn:nasa:pds:context:target:dust.dust::1.0"
           },
           {
-               "name": "INTERSTELLAR MEDIUM",
-               "type": "PLASMA STREAM",
+               "name": [
+                    "INTERSTELLAR MEDIUM"
+               ],
+               "type": [
+                    "PLASMA STREAM"
+               ],
                "lidvid": "urn:nasa:pds:context:target:plasma_stream.interstellar_medium::1.0"
           },
           {
-               "name": "702 ALAUDA",
-               "type": "ASTEROID",
+               "name": [
+                    "702 ALAUDA"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.702_alauda::1.1"
           },
           {
-               "name": "UNK - INSTRUMENT ID (FTS)",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "UNK - INSTRUMENT ID (FTS)"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:fts.vl1::1.0"
           },
           {
-               "name": "SOLAR WIND OBSERVATIONS OVER THE POLES OF THE SUN",
-               "type": "PARTICLE DETECTOR",
+               "name": [
+                    "SOLAR WIND OBSERVATIONS OVER THE POLES OF THE SUN"
+               ],
+               "type": [
+                    "PARTICLE DETECTOR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:swoops.uly::1.0"
           },
           {
-               "name": "BETA CENTAURI",
-               "type": "STAR",
+               "name": [
+                    "BETA CENTAURI"
+               ],
+               "type": [
+                    "STAR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:star.bet_cen::1.0"
           },
           {
-               "name": "SCAT LIGHT",
-               "type": "CALIBRATION FIELD",
+               "name": [
+                    "SCAT LIGHT"
+               ],
+               "type": [
+                    "CALIBRATION FIELD"
+               ],
                "lidvid": "urn:nasa:pds:context:target:calibration_field.scat_light::1.0"
           },
           {
-               "name": "COSMIC RAY SUBSYSTEM",
-               "type": "PARTICLE DETECTOR",
+               "name": [
+                    "COSMIC RAY SUBSYSTEM"
+               ],
+               "type": [
+                    "PARTICLE DETECTOR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:crs.vg1::1.0"
           },
           {
-               "name": "(85627) 1998 HP151",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(85627) 1998 HP151"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.85627_1998_hp151::1.0"
           },
           {
-               "name": "144P/KUSHIDA",
-               "type": "COMET",
+               "name": [
+                    "144P/KUSHIDA"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.144p_kushida::1.0"
           },
           {
-               "name": "83982 CRANTOR",
-               "type": "CENTAUR",
+               "name": [
+                    "83982 CRANTOR"
+               ],
+               "type": [
+                    "CENTAUR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:centaur.83982_crantor::1.0"
           },
           {
-               "name": "TELEVISION SYSTEM",
-               "type": "IMAGER",
+               "name": [
+                    "TELEVISION SYSTEM"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:tvs.vega1::1.0"
           },
           {
-               "name": "S/2003 J 18",
-               "type": "SATELLITE",
+               "name": [
+                    "S/2003 J 18"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.s2003j18::1.1"
           },
           {
-               "name": "1999 RX214",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "1999 RX214"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.1999_rx214::1.0"
           },
           {
-               "name": "130 ELEKTRA",
-               "type": "ASTEROID",
+               "name": [
+                    "130 ELEKTRA"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.130_elektra::1.1"
           },
           {
-               "name": "(134568) 1999 RH215",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(134568) 1999 RH215"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.134568_1999_rh215::1.0"
           },
           {
-               "name": "(300199) 2006 WK100",
-               "type": "ASTEROID",
+               "name": [
+                    "(300199) 2006 WK100"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300199_2006_wk100::1.0"
           },
           {
-               "name": "2000 GX146",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2000 GX146"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2000_gx146::1.0"
           },
           {
-               "name": "(44594) 1999 OX3",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(44594) 1999 OX3"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.44594_1999_ox3::1.0"
           },
           {
-               "name": "ORBITER RADIO SCIENCE EXPERIMENT",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "ORBITER RADIO SCIENCE EXPERIMENT"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:orse.pvo::1.0"
           },
           {
-               "name": "2003 HF57",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2003 HF57"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2003_hf57::1.0"
           },
           {
-               "name": "ROVER",
-               "type": "EQUIPMENT",
+               "name": [
+                    "ROVER"
+               ],
+               "type": [
+                    "EQUIPMENT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:equipment.rover::1.0"
           },
           {
-               "name": "ACCELEROMETER",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "ACCELEROMETER"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:accel.msl::1.0"
           },
           {
-               "name": "D/1993 F2-T (SHOEMAKER-LEVY 9-T)",
-               "type": "COMET",
+               "name": [
+                    "D/1993 F2-T (SHOEMAKER-LEVY 9-T)"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.d1993_f2-t_shoemaker-levy_9-t::1.0"
           },
           {
-               "name": "(300255) 2007 GT47",
-               "type": "ASTEROID",
+               "name": [
+                    "(300255) 2007 GT47"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300255_2007_gt47::1.0"
           },
           {
-               "name": "(160091) 2000 OL67",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(160091) 2000 OL67"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.160091_2000_ol67::1.0"
           },
           {
-               "name": "2003 UB292",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2003 UB292"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2003_ub292::1.0"
           },
           {
-               "name": "67P/CHURYUMOV-GERASIMENKO",
-               "type": "COMET",
+               "name": [
+                    "67P/CHURYUMOV-GERASIMENKO"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.67p_churyumov-gerasimenko::1.0"
           },
           {
-               "name": "PHOBOS 2",
-               "type": "Mission",
+               "name": [
+                    "PHOBOS 2"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.phobos_2::1.1"
           },
           {
-               "name": "(300187) 2006 WK65",
-               "type": "ASTEROID",
+               "name": [
+                    "(300187) 2006 WK65"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300187_2006_wk65::1.0"
           },
           {
-               "name": "(385695) 2005 TO74",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(385695) 2005 TO74"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.385695_2005_to74::1.0"
           },
           {
-               "name": "APOLLO 17 METRIC (MAPPING) CAMERA",
-               "type": "IMAGER",
+               "name": [
+                    "APOLLO 17 METRIC (MAPPING) CAMERA"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:metriccam.a17c::1.0"
           },
           {
-               "name": "D/1993 F2-W (SHOEMAKER-LEVY 9-W)",
-               "type": "COMET",
+               "name": [
+                    "D/1993 F2-W (SHOEMAKER-LEVY 9-W)"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.d1993_f2-w_shoemaker-levy_9-w::1.0"
           },
           {
-               "name": "MINIATURE THERMAL EMISSION SPECTROMETER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "MINIATURE THERMAL EMISSION SPECTROMETER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:mini-tes.mer1::1.0"
           },
           {
-               "name": "(15649) 6317 P-L",
-               "type": "ASTEROID",
+               "name": [
+                    "(15649) 6317 P-L"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.15649_6317_p-l::1.0"
           },
           {
-               "name": "(43032) 1999 VR26",
-               "type": "ASTEROID",
+               "name": [
+                    "(43032) 1999 VR26"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.43032_1999_vr26::1.0"
           },
           {
-               "name": "(300179) 2006 WY36",
-               "type": "ASTEROID",
+               "name": [
+                    "(300179) 2006 WY36"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300179_2006_wy36::1.0"
           },
           {
-               "name": "114P/WISEMAN-SKIFF",
-               "type": "COMET",
+               "name": [
+                    "114P/WISEMAN-SKIFF"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.114p_wiseman-skiff::1.0"
           },
           {
-               "name": "(145452) 2005 RN43",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(145452) 2005 RN43"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.145452_2005_rn43::1.0"
           },
           {
-               "name": "(118698) 2000 OY51",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(118698) 2000 OY51"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.118698_2000_oy51::1.0"
           },
           {
-               "name": "59P/KEARNS-KWEE",
-               "type": "COMET",
+               "name": [
+                    "59P/KEARNS-KWEE"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.59p_kearns-kwee::1.0"
           },
           {
-               "name": "1998 WG24",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "1998 WG24"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.1998_wg24::1.0"
           },
           {
-               "name": "354P/LINEAR",
-               "type": "COMET",
+               "name": [
+                    "354P/LINEAR"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.354p_linear::1.0"
           },
           {
-               "name": "IJIRAQ",
-               "type": "SATELLITE",
+               "name": [
+                    "IJIRAQ"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.ijiraq::1.1"
           },
           {
-               "name": "ELECTRON TEMPERATURE PROBE",
-               "type": "PARTICLE DETECTOR",
+               "name": [
+                    "ELECTRON TEMPERATURE PROBE"
+               ],
+               "type": [
+                    "PARTICLE DETECTOR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:oetp.pvo::1.0"
           },
           {
-               "name": "10370 HYLONOME",
-               "type": "CENTAUR",
+               "name": [
+                    "10370 HYLONOME"
+               ],
+               "type": [
+                    "CENTAUR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:centaur.10370_hylonome::1.0"
           },
           {
-               "name": "MARS WIND TUNNEL",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "MARS WIND TUNNEL"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:pal.marswit::1.0"
           },
           {
-               "name": "BALLOON OBSERVATION PLATFORM FOR PLANETARY SCIENCE (BOPPS) - 2014 FLIGHT",
-               "type": "Mission",
+               "name": [
+                    "BALLOON OBSERVATION PLATFORM FOR PLANETARY SCIENCE (BOPPS) - 2014 FLIGHT"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.bopps::1.0"
           },
           {
-               "name": "(32625) 2001 RZ45",
-               "type": "ASTEROID",
+               "name": [
+                    "(32625) 2001 RZ45"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.32625_2001_rz45::1.0"
           },
           {
-               "name": "COMPACT RECONNAISSANCE IMAGING SPECTROMETER FOR MARS",
-               "type": "IMAGER",
+               "name": [
+                    "COMPACT RECONNAISSANCE IMAGING SPECTROMETER FOR MARS"
+               ],
+               "type": [
+                    "IMAGER",
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:crism.mro::1.0"
           },
           {
-               "name": "NEAR INFRARED SPECTROMETER 2",
-               "type": "SPECTROMETER",
+               "name": [
+                    "NEAR INFRARED SPECTROMETER 2"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:nsp2.lcross::1.0"
           },
           {
-               "name": "ION MASS SPECTROMETER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "ION MASS SPECTROMETER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:ims.gio::1.0"
           },
           {
-               "name": "XRAY SPECTROMETER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "XRAY SPECTROMETER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:xrs.near::1.0"
           },
           {
-               "name": "ROBOTIC ARM CAMERA",
-               "type": "IMAGER",
+               "name": [
+                    "ROBOTIC ARM CAMERA"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:rac.phx::1.0"
           },
           {
-               "name": "APOLLO 14 CHARGED PARTICLE LUNAR ENVIRONMENT EXPERIMENT",
-               "type": "PARTICLE DETECTOR",
+               "name": [
+                    "APOLLO 14 CHARGED PARTICLE LUNAR ENVIRONMENT EXPERIMENT"
+               ],
+               "type": [
+                    "PARTICLE DETECTOR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:cplee.a14a::1.0"
           },
           {
-               "name": "TRIAXIAL FLUXGATE MAGNETOMETER",
-               "type": "MAGNETOMETER",
+               "name": [
+                    "TRIAXIAL FLUXGATE MAGNETOMETER"
+               ],
+               "type": [
+                    "MAGNETOMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:mag.go::1.0"
           },
           {
-               "name": "METEOROLOGY SUITE, LIDAR",
-               "type": "ALTIMETER",
+               "name": [
+                    "METEOROLOGY SUITE, LIDAR"
+               ],
+               "type": [
+                    "ALTIMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:lidar.phx::1.0"
           },
           {
-               "name": "(300217) 2006 WK182",
-               "type": "ASTEROID",
+               "name": [
+                    "(300217) 2006 WK182"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300217_2006_wk182::1.0"
           },
           {
-               "name": "NEAR INFRARED SPECTROMETER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "NEAR INFRARED SPECTROMETER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:nis.near::1.0"
           },
           {
-               "name": "GALILEO PROBE",
-               "type": "Spacecraft",
+               "name": [
+                    "GALILEO PROBE"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.gp::1.0"
           },
           {
-               "name": "79360 SILA-NUNAM",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "79360 SILA-NUNAM"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.79360_sila-nunam::1.1"
           },
           {
-               "name": "(300228) 2006 XN54",
-               "type": "ASTEROID",
+               "name": [
+                    "(300228) 2006 XN54"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300228_2006_xn54::1.0"
           },
           {
-               "name": "(300210) 2006 WB152",
-               "type": "ASTEROID",
+               "name": [
+                    "(300210) 2006 WB152"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300210_2006_wb152::1.0"
           },
           {
-               "name": "ADVANCE CAMERA FOR SURVEYS",
-               "type": "IMAGER",
+               "name": [
+                    "ADVANCE CAMERA FOR SURVEYS"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:hstacs.hst::1.0"
           },
           {
-               "name": "(119956) 2002 PA149",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(119956) 2002 PA149"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.119956_2002_pa149::1.0"
           },
           {
-               "name": "ROSETTA RADIO SCIENCE INVESTIGATION",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "ROSETTA RADIO SCIENCE INVESTIGATION"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:rsi.ro::1.0"
           },
           {
-               "name": "110P/HARTLEY 3",
-               "type": "COMET",
+               "name": [
+                    "110P/HARTLEY 3"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.110p_hartley_3::1.0"
           },
           {
-               "name": "2001 QZ297",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2001 QZ297"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2001_qz297::1.0"
           },
           {
-               "name": "GALILEO PROBE MASS SPECTROMETER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "GALILEO PROBE MASS SPECTROMETER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:gpms.gp::1.0"
           },
           {
-               "name": "2003 FZ129",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2003 FZ129"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2003_fz129::1.0"
           },
           {
-               "name": "PVO ORBITER ION MASS SPECTROMETER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "PVO ORBITER ION MASS SPECTROMETER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:oims.pvo::1.0"
           },
           {
-               "name": "RADAR SYSTEM",
-               "type": "RADIOMETER",
+               "name": [
+                    "RADAR SYSTEM"
+               ],
+               "type": [
+                    "RADIOMETER",
+                    "ALTIMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:rdrs.mgn::1.0"
           },
           {
-               "name": "2000 CL104",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2000 CL104"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2000_cl104::1.0"
           },
           {
-               "name": "174567 VARDA",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "174567 VARDA"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.174567_varda::1.0"
           },
           {
-               "name": "(119951) 2002 KX14",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(119951) 2002 KX14"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.119951_2002_kx14::1.0"
           },
           {
-               "name": "N/A",
-               "type": "Individual Investigation",
+               "name": [
+                    "N/A"
+               ],
+               "type": [
+                    "N/A"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:individual.lab_shocked_feldspars::1.0"
           },
           {
-               "name": "PIETERSMA PORTABLE WIND TUNNEL",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "PIETERSMA PORTABLE WIND TUNNEL"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:no-host.pietersma-portable_wt::1.0"
           },
           {
-               "name": "MARS EXPLORATION ROVER",
-               "type": "Mission",
+               "name": [
+                    "MARS EXPLORATION ROVER"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.mars_exploration_rover::1.0"
           },
           {
-               "name": "PIONEER 8",
-               "type": "Mission",
+               "name": [
+                    "PIONEER 8"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.pioneer_8::1.0"
           },
           {
-               "name": "TITAN LABORATORY ANALOG",
-               "type": "LABORATORY ANALOG",
+               "name": [
+                    "TITAN LABORATORY ANALOG"
+               ],
+               "type": [
+                    "LABORATORY ANALOG"
+               ],
                "lidvid": "urn:nasa:pds:context:target:laboratory_analog.saturn.titan::1.0"
           },
           {
-               "name": "(90568) 2004 GV9",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(90568) 2004 GV9"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.90568_2004_gv9::1.0"
           },
           {
-               "name": "ALPHA CENTAURI",
-               "type": "STAR",
+               "name": [
+                    "ALPHA CENTAURI"
+               ],
+               "type": [
+                    "STAR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:star.alf_cen::1.0"
           },
           {
-               "name": "ROSETTA PLASMA CONSORTIUM - ION AND ELECTRON SENSOR",
-               "type": "PARTICLE DETECTOR",
+               "name": [
+                    "RADIO SCIENCE SUBSYSTEM"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
+               "lidvid": "urn:nasa:pds:context:instrument:vex.rss::1.0"
+          },
+          {
+               "name": [
+                    "ROSETTA PLASMA CONSORTIUM - ION AND ELECTRON SENSOR"
+               ],
+               "type": [
+                    "PARTICLE DETECTOR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:rpcies.ro::1.0"
           },
           {
-               "name": "2011 HF103",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2011 HF103"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2011_hf103::1.0"
           },
           {
-               "name": "SOLAR WIND SPECTROMETER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "SOLAR WIND SPECTROMETER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:sws.a12a::1.0"
           },
           {
-               "name": "2 PALLAS",
-               "type": "ASTEROID",
+               "name": [
+                    "2 PALLAS"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.2_pallas::1.1"
           },
           {
-               "name": "MINIATURE INTEGRATED CAMERA-SPECTROMETER",
-               "type": "IMAGER",
+               "name": [
+                    "MINIATURE INTEGRATED CAMERA-SPECTROMETER"
+               ],
+               "type": [
+                    "IMAGER",
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:micas.ds1::1.0"
           },
           {
-               "name": "PLASMA WAVE EXPERIMENT",
-               "type": "SPECTROMETER",
+               "name": [
+                    "PLASMA WAVE EXPERIMENT"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:plawav.ice::1.0"
           },
           {
-               "name": "2003 FJ127",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2003 FJ127"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2003_fj127::1.0"
           },
           {
-               "name": "NEUTRAL GAS AND ION MASS SPECTROMETER",
-               "type": "MASS SPECTROMETER",
+               "name": [
+                    "NEUTRAL GAS AND ION MASS SPECTROMETER"
+               ],
+               "type": [
+                    "MASS SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:ngims.maven::1.0"
           },
           {
-               "name": "2000 CF105",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2000 CF105"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2000_cf105::1.0"
           },
           {
-               "name": "RADIO SCIENCE SUBSYSTEM",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "RADIO SCIENCE SUBSYSTEM"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:rss.near::1.0"
           },
           {
-               "name": "ENERGETIC PARTICLES DETECTOR",
-               "type": "PARTICLE DETECTOR",
+               "name": [
+                    "ENERGETIC PARTICLES DETECTOR"
+               ],
+               "type": [
+                    "PARTICLE DETECTOR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:epd.go::1.0"
           },
           {
-               "name": "(91554) 1999 RZ215",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(91554) 1999 RZ215"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.91554_1999_rz215::1.0"
           },
           {
-               "name": "MAGNETOSPHERIC IMAGING INSTRUMENT",
-               "type": "PARTICLE DETECTOR",
+               "name": [
+                    "MAGNETOSPHERIC IMAGING INSTRUMENT"
+               ],
+               "type": [
+                    "PARTICLE DETECTOR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:mimi.co::1.0"
           },
           {
-               "name": "APOLLO 15 METRIC (MAPPING) CAMERA",
-               "type": "IMAGER",
+               "name": [
+                    "APOLLO 15 METRIC (MAPPING) CAMERA"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:metriccam.a15c::1.0"
           },
           {
-               "name": "144 VIBILIA",
-               "type": "ASTEROID",
+               "name": [
+                    "144 VIBILIA"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.144_vibilia::1.1"
           },
           {
-               "name": "SIARNAQ",
-               "type": "SATELLITE",
+               "name": [
+                    "SIARNAQ"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.siarnaq::1.1"
           },
           {
-               "name": "2002 CB225",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2002 CB225"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2002_cb225::1.0"
           },
           {
-               "name": "(35671) 1998 SN165",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(35671) 1998 SN165"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.35671_1998_sn165::1.0"
           },
           {
-               "name": "2003 SR317",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2003 SR317"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2003_sr317::1.0"
           },
           {
-               "name": "(24537) 2001 CB35",
-               "type": "ASTEROID",
+               "name": [
+                    "(24537) 2001 CB35"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.24537_2001_cb35::1.0"
           },
           {
-               "name": "(66452) 1999 OF4",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(66452) 1999 OF4"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.66452_1999_of4::1.0"
           },
           {
-               "name": "2867 STEINS",
-               "type": "ASTEROID",
+               "name": [
+                    "2867 STEINS"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.2867_steins::1.0"
           },
           {
-               "name": "(308933) 2006 SQ372",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(308933) 2006 SQ372"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.308933_2006_sq372::1.0"
           },
           {
-               "name": "GRAVITY SCIENCE INSTRUMENT",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "GRAVITY SCIENCE INSTRUMENT"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:dawn.rss::1.0"
           },
           {
-               "name": "(69990) 1998 WU31",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(69990) 1998 WU31"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.69990_1998_wu31::1.0"
           },
           {
-               "name": "OVIRS",
-               "type": "SPECTROMETER",
+               "name": [
+                    "OVIRS"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:ovirs.orex::1.0"
           },
           {
-               "name": "2002 PO149",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2002 PO149"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2002_po149::1.0"
           },
           {
-               "name": "OSIRIS-REx",
-               "type": "Spacecraft",
+               "name": [
+                    "OSIRIS-REx"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.orex::1.1"
           },
           {
-               "name": "ENERGETIC PARTICLE ANISOTROPY SPECTROMETER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "ENERGETIC PARTICLE ANISOTROPY SPECTROMETER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:epas.ice::1.0"
           },
           {
-               "name": "(82155) 2001 FZ173",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(82155) 2001 FZ173"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.82155_2001_fz173::1.0"
           },
           {
-               "name": "(168703) 2000 GP183",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(168703) 2000 GP183"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.168703_2000_gp183::1.0"
           },
           {
-               "name": "ORBITER RETARDING POTENTIAL ANALYZER",
-               "type": "PARTICLE DETECTOR",
+               "name": [
+                    "ORBITER RETARDING POTENTIAL ANALYZER"
+               ],
+               "type": [
+                    "PARTICLE DETECTOR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:orpa.pvo::1.0"
           },
           {
-               "name": "2000 CP104",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2000 CP104"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2000_cp104::1.0"
           },
           {
-               "name": "PLAQUE",
-               "type": "CALIBRATOR",
+               "name": [
+                    "PLAQUE"
+               ],
+               "type": [
+                    "CALIBRATOR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:calibrator.plaque::1.0"
           },
           {
-               "name": "DARK SKY",
-               "type": "CALIBRATION FIELD",
+               "name": [
+                    "ANALYZER OF SPACE PLASMA AND ENERGETIC ATOMS (4TH VERSION)\n              ELECTRON SPECTROMETER"
+               ],
+               "type": [
+                    "PARTICLE DETECTOR"
+               ],
+               "lidvid": "urn:nasa:pds:context:instrument:vex.aspera4-els::1.0"
+          },
+          {
+               "name": [
+                    "DARK SKY"
+               ],
+               "type": [
+                    "CALIBRATION FIELD"
+               ],
                "lidvid": "urn:nasa:pds:context:target:calibration_field.dark_sky::1.0"
           },
           {
-               "name": "(300216) 2006 WK180",
-               "type": "ASTEROID",
+               "name": [
+                    "(300216) 2006 WK180"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300216_2006_wk180::1.0"
           },
           {
-               "name": "VISUAL IMAGING SUBSYSTEM - CAMERA A",
-               "type": "IMAGER",
+               "name": [
+                    "VISUAL IMAGING SUBSYSTEM - CAMERA A"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:visa.vo1::1.0"
           },
           {
-               "name": "INSIGHT FLUXGATE MAGNETOMETER",
-               "type": "MAGNETOMETER",
+               "name": [
+                    "INSIGHT FLUXGATE MAGNETOMETER"
+               ],
+               "type": [
+                    "MAGNETOMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:apss-ifg.insight::1.0"
           },
           {
-               "name": "EARTH LABORATORY ANALOG",
-               "type": "LABORATORY ANALOG",
+               "name": [
+                    "EARTH LABORATORY ANALOG"
+               ],
+               "type": [
+                    "LABORATORY ANALOG"
+               ],
                "lidvid": "urn:nasa:pds:context:target:laboratory_analog.earth::1.0"
           },
           {
-               "name": "CALIBRATION",
-               "type": "CALIBRATOR",
+               "name": [
+                    "CALIBRATION"
+               ],
+               "type": [
+                    "CALIBRATOR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:calibrator.calibration::1.0"
           },
           {
-               "name": "LP ENGINEERING",
-               "type": "REGOLITH PROPERTIES",
+               "name": [
+                    "LP ENGINEERING"
+               ],
+               "type": [
+                    "REGOLITH PROPERTIES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:eng.lp::1.0"
           },
           {
-               "name": "C/1999 H1 (LEE)",
-               "type": "COMET",
+               "name": [
+                    "C/1999 H1 (LEE)"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.c1999_h1_lee::1.0"
           },
           {
-               "name": "2001 KL76",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2001 KL76"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2001_kl76::1.0"
           },
           {
-               "name": "CONTOUR DUST ANALYZER",
-               "type": "DUST",
+               "name": [
+                    "CONTOUR DUST ANALYZER"
+               ],
+               "type": [
+                    "DUST"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:cida.con::1.0"
           },
           {
-               "name": "(57735) 2001 UQ159",
-               "type": "ASTEROID",
+               "name": [
+                    "(57735) 2001 UQ159"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.57735_2001_uq159::1.0"
           },
           {
-               "name": "BETELGEUSE",
-               "type": "STAR",
+               "name": [
+                    "BETELGEUSE"
+               ],
+               "type": [
+                    "STAR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:star.alf_ori::1.0"
           },
           {
-               "name": "MAGNETOMETER",
-               "type": "MAGNETOMETER",
+               "name": [
+                    "MAGNETOMETER"
+               ],
+               "type": [
+                    "MAGNETOMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:mag.mess::1.0"
           },
           {
-               "name": "2004 TX357",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2004 TX357"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2004_tx357::1.0"
           },
           {
-               "name": "(51136) 2000 HQ44",
-               "type": "ASTEROID",
+               "name": [
+                    "(51136) 2000 HQ44"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.51136_2000_hq44::1.0"
           },
           {
-               "name": "(300171) 2006 VS151",
-               "type": "ASTEROID",
+               "name": [
+                    "(300171) 2006 VS151"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300171_2006_vs151::1.0"
           },
           {
-               "name": "TAGCAMS",
-               "type": "IMAGER",
+               "name": [
+                    "TAGCAMS"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:tagcams.orex::1.0"
           },
           {
-               "name": "LABELED RELEASE",
-               "type": "REGOLITH PROPERTIES",
+               "name": [
+                    "LABELED RELEASE"
+               ],
+               "type": [
+                    "REGOLITH PROPERTIES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:lr2.vl2::1.0"
           },
           {
-               "name": "(22672) 1998 QV37",
-               "type": "ASTEROID",
+               "name": [
+                    "(22672) 1998 QV37"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.22672_1998_qv37::1.0"
           },
           {
-               "name": "PIONEER 11",
-               "type": "Spacecraft",
+               "name": [
+                    "PIONEER 11"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.p11::1.0"
           },
           {
-               "name": "(300203) 2006 WE111",
-               "type": "ASTEROID",
+               "name": [
+                    "(300203) 2006 WE111"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300203_2006_we111::1.0"
           },
           {
-               "name": "C/2001 G1 (LONEOS)",
-               "type": "COMET",
+               "name": [
+                    "C/2001 G1 (LONEOS)"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.c2001_g1_loneos::1.0"
           },
           {
-               "name": "(36551) 2000 QR101",
-               "type": "ASTEROID",
+               "name": [
+                    "(36551) 2000 QR101"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.36551_2000_qr101::1.0"
           },
           {
-               "name": "2001 QD298",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2001 QD298"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2001_qd298::1.0"
           },
           {
-               "name": "(469615) 2004 PT107",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(469615) 2004 PT107"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.469615_2004_pt107::1.0"
           },
           {
-               "name": "VISUAL IMAGING SUBSYSTEM - CAMERA B",
-               "type": "IMAGER",
+               "name": [
+                    "VISUAL IMAGING SUBSYSTEM - CAMERA B"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:visb.vo1::1.0"
           },
           {
-               "name": "SOLAR WIND PLASMA EXPERIMENT",
-               "type": "PARTICLE DETECTOR",
+               "name": [
+                    "SOLAR WIND PLASMA EXPERIMENT"
+               ],
+               "type": [
+                    "PARTICLE DETECTOR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:swp.ice::1.0"
           },
           {
-               "name": "14P/WOLF",
-               "type": "COMET",
+               "name": [
+                    "14P/WOLF"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.14p_wolf::1.0"
           },
           {
-               "name": "HAT-P-4",
-               "type": "STAR",
+               "name": [
+                    "HAT-P-4"
+               ],
+               "type": [
+                    "STAR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:star.bd+36_2593::1.0"
           },
           {
-               "name": "(15875) 1996 TP66",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(15875) 1996 TP66"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.15875_1996_tp66::1.0"
           },
           {
-               "name": "INSIGHT WIND AND THERMAL SHIELD",
-               "type": "EQUIPMENT",
+               "name": [
+                    "INSIGHT WIND AND THERMAL SHIELD"
+               ],
+               "type": [
+                    "EQUIPMENT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:equipment.insight.wts::1.0"
           },
           {
-               "name": "PLASMA SCIENCE EXPERIMENT",
-               "type": "SPECTROMETER",
+               "name": [
+                    "PLASMA SCIENCE EXPERIMENT"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:pls.vg1::1.0"
           },
           {
-               "name": "PIONEER",
-               "type": "Spacecraft",
+               "name": [
+                    "PIONEER"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.p12::1.0"
           },
           {
-               "name": "D/1993 F2-E (SHOEMAKER-LEVY 9-E)",
-               "type": "COMET",
+               "name": [
+                    "D/1993 F2-E (SHOEMAKER-LEVY 9-E)"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.d1993_f2-e_shoemaker-levy_9-e::1.0"
           },
           {
-               "name": "106P/SCHUSTER",
-               "type": "COMET",
+               "name": [
+                    "106P/SCHUSTER"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.106p_schuster::1.0"
           },
           {
-               "name": "WASP-3",
-               "type": "STAR",
+               "name": [
+                    "WASP-3"
+               ],
+               "type": [
+                    "STAR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:star.wasp-3::1.0"
           },
           {
-               "name": "VISIBLE AND INFRARED THERMAL IMAGING SPECTROMETER",
-               "type": "IMAGER",
+               "name": [
+                    "VISIBLE AND INFRARED THERMAL IMAGING SPECTROMETER"
+               ],
+               "type": [
+                    "IMAGER",
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:virtis.ro::1.0"
           },
           {
-               "name": "532 HERCULINA",
-               "type": "ASTEROID",
+               "name": [
+                    "532 HERCULINA"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.532_herculina::1.1"
           },
           {
-               "name": "HEAT FLOW AND PHYSICAL PROPERTIES PACKAGE",
-               "type": "REGOLITH PROPERTIES",
+               "name": [
+                    "HEAT FLOW AND PHYSICAL PROPERTIES PACKAGE"
+               ],
+               "type": [
+                    "REGOLITH PROPERTIES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:hp3.insight::1.0"
           },
           {
-               "name": "CAMERA 1",
-               "type": "IMAGER",
+               "name": [
+                    "CAMERA 1"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:cam1.vl2::1.0"
           },
           {
-               "name": "ORBITING RADAR",
-               "type": "RADIO-RADAR",
+               "name": [
+                    "ORBITING RADAR"
+               ],
+               "type": [
+                    "RADIO-RADAR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:orad.p12::1.0"
           },
           {
-               "name": "2006 CH69",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2006 CH69"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2006_ch69::1.0"
           },
           {
-               "name": "MID-INFRARED ARRAY CAMERA",
-               "type": "IMAGER",
+               "name": [
+                    "MID-INFRARED ARRAY CAMERA"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:irtf.3m0.mirac2::1.0"
           },
           {
-               "name": "NGC 6543",
-               "type": "PLANETARY NEBULA",
+               "name": [
+                    "NGC 6543"
+               ],
+               "type": [
+                    "PLANETARY NEBULA"
+               ],
                "lidvid": "urn:nasa:pds:context:target:planetary_nebula.ngc_6543::1.0"
           },
           {
-               "name": "ALPHA PROTON X-RAY SPECTROMETER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "ALPHA PROTON X-RAY SPECTROMETER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:apxs.mpfr::1.0"
           },
           {
-               "name": "LUNAR GRAVITY RANGING SYSTEM B",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "LUNAR GRAVITY RANGING SYSTEM B"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:lgrs-b.grail-b::1.0"
           },
           {
-               "name": "INFRARED INTERFEROMETER SPECTROMETER AND RADIOMETER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "INFRARED INTERFEROMETER SPECTROMETER AND RADIOMETER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:iris.vg2::1.0"
           },
           {
-               "name": "2002 WL21",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2002 WL21"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2002_wl21::1.0"
           },
           {
-               "name": "INFRARED SPECTROMETER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "INFRARED SPECTROMETER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:iks.vega1::1.0"
           },
           {
-               "name": "SURFACE STEREO IMAGER",
-               "type": "IMAGER",
+               "name": [
+                    "SURFACE STEREO IMAGER"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:ssi.phx::1.0"
           },
           {
-               "name": "HELIUM ABUNDANCE DETECTOR",
-               "type": "SPECTROMETER",
+               "name": [
+                    "HELIUM ABUNDANCE DETECTOR"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:had.gp::1.0"
           },
           {
-               "name": "2004 PA112",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2004 PA112"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2004_pa112::1.0"
           },
           {
-               "name": "(300235) 2006 YT17",
-               "type": "ASTEROID",
+               "name": [
+                    "(300235) 2006 YT17"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300235_2006_yt17::1.0"
           },
           {
-               "name": "2002 CY248",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2002 CY248"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2002_cy248::1.0"
           },
           {
-               "name": "(43460) 2000 YM123",
-               "type": "ASTEROID",
+               "name": [
+                    "(43460) 2000 YM123"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.43460_2000_ym123::1.0"
           },
           {
-               "name": "APOLLO 16 PANORAMIC CAMERA",
-               "type": "IMAGER",
+               "name": [
+                    "APOLLO 16 PANORAMIC CAMERA"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:pancam.a16c::1.0"
           },
           {
-               "name": "ION COMPOSITION INSTRUMENT",
-               "type": "SPECTROMETER",
+               "name": [
+                    "ION COMPOSITION INSTRUMENT"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:ici.ice::1.0"
           },
           {
-               "name": "OPTICAL PROBE EXPERIMENT",
-               "type": "PHOTOMETER",
+               "name": [
+                    "OPTICAL PROBE EXPERIMENT"
+               ],
+               "type": [
+                    "PHOTOMETER",
+                    "POLARIMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:ope.gio::1.0"
           },
           {
-               "name": "(79213) 1994 EX",
-               "type": "ASTEROID",
+               "name": [
+                    "(79213) 1994 EX"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.79213_1994_ex::1.0"
           },
           {
-               "name": "(118702) 2000 OM67",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(118702) 2000 OM67"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.118702_2000_om67::1.0"
           },
           {
-               "name": "HEAVY ION COUNTER",
-               "type": "PARTICLE DETECTOR",
-               "lidvid": "urn:nasa:pds:context:instrument:hic.go::1.0"
-          },
-          {
-               "name": "(55638) 2002 VE95",
-               "type": "TRANS-NEPTUNIAN OBJECT",
-               "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.55638_2002_ve95::1.0"
-          },
-          {
-               "name": "ROSETTA PLASMA CONSORTIUM - ION COMPOSITION ANALYSER",
-               "type": "PARTICLE DETECTOR",
+               "name": [
+                    "ROSETTA PLASMA CONSORTIUM - ION COMPOSITION ANALYSER"
+               ],
+               "type": [
+                    "PARTICLE DETECTOR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:rpcica.ro::1.0"
           },
           {
-               "name": "(300166) 2006 VQ142",
-               "type": "ASTEROID",
+               "name": [
+                    "(300166) 2006 VQ142"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300166_2006_vq142::1.0"
           },
           {
-               "name": "VENERA 15",
-               "type": "Spacecraft",
+               "name": [
+                    "VENERA 15"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.v15::1.0"
           },
           {
-               "name": "SOLAR WIND ELECTRON ANALYZER",
-               "type": "ENERGETIC PARTICLE DETECTOR",
+               "name": [
+                    "SOLAR WIND ELECTRON ANALYZER"
+               ],
+               "type": [
+                    "ENERGETIC PARTICLE DETECTOR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:swea.maven::1.0"
           },
           {
-               "name": "(150642) 2001 CZ31",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(150642) 2001 CZ31"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.150642_2001_cz31::1.0"
           },
           {
-               "name": "1998 WV24",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "1998 WV24"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.1998_wv24::1.0"
           },
           {
-               "name": "2000 PH30",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2000 PH30"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2000_ph30::1.0"
           },
           {
-               "name": "2000 YF2",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2000 YF2"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2000_yf2::1.0"
           },
           {
-               "name": "1998 WS31",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "1998 WS31"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.1998_ws31::1.0"
           },
           {
-               "name": "RADIO SCIENCE SUBSYSTEM",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "RADIO SCIENCE SUBSYSTEM"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:rss.mro::1.0"
           },
           {
-               "name": "MID-INFRARED FACILITY CAMERA (MIRLIN)",
-               "type": "IMAGER",
+               "name": [
+                    "MID-INFRARED FACILITY CAMERA (MIRLIN)"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:irtf.3m0.mirlin::1.0"
           },
           {
-               "name": "ROVER CAMERA RIGHT",
-               "type": "IMAGER",
+               "name": [
+                    "ROVER CAMERA RIGHT"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:rcrt.mpfr::1.0"
           },
           {
-               "name": "2004 PW107",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2004 PW107"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2004_pw107::1.0"
           },
           {
-               "name": "1999 HJ12",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "1999 HJ12"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.1999_hj12::1.0"
           },
           {
-               "name": "IMAGING SCIENCE SUBSYSTEM - NARROW ANGLE",
-               "type": "IMAGER",
+               "name": [
+                    "IMAGING SCIENCE SUBSYSTEM - NARROW ANGLE"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:issn.vg1::1.0"
           },
           {
-               "name": "MOON",
-               "type": "SATELLITE",
+               "name": [
+                    "MOON"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.earth.moon::1.1"
           },
           {
-               "name": "EUKELADE",
-               "type": "SATELLITE",
+               "name": [
+                    "EUKELADE"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.eukelade::1.1"
           },
           {
-               "name": "136199 ERIS",
-               "type": "DWARF PLANET",
+               "name": [
+                    "136199 ERIS"
+               ],
+               "type": [
+                    "DWARF PLANET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:dwarf_planet.136199_eris::1.1"
           },
           {
-               "name": "PANORAMIC CAMERA",
-               "type": "IMAGER",
+               "name": [
+                    "PANORAMIC CAMERA"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:pancam.mer1::1.0"
           },
           {
-               "name": "NEUTRON SPECTROMETER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "NEUTRON SPECTROMETER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:ns.mess::1.1"
           },
           {
-               "name": "ERRIAPUS",
-               "type": "SATELLITE",
+               "name": [
+                    "ERRIAPUS"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.erriapus::1.2"
           },
           {
-               "name": "MAB",
-               "type": "SATELLITE",
+               "name": [
+                    "MAB"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.uranus.mab::1.1"
           },
           {
-               "name": "2000 QE226",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2000 QE226"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2000_qe226::1.0"
           },
           {
-               "name": "2004 HX78",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2004 HX78"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2004_hx78::1.0"
           },
           {
-               "name": "20 MASSALIA",
-               "type": "ASTEROID",
+               "name": [
+                    "20 MASSALIA"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.20_massalia::1.1"
           },
           {
-               "name": "(300190) 2006 WV75",
-               "type": "ASTEROID",
+               "name": [
+                    "(300190) 2006 WV75"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300190_2006_wv75::1.0"
           },
           {
-               "name": "GRAVITY RECOVERY AND INTERIOR LABORATORY A",
-               "type": "Spacecraft",
+               "name": [
+                    "GRAVITY RECOVERY AND INTERIOR LABORATORY A"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.grail-a::1.1"
           },
           {
-               "name": "MARGARET",
-               "type": "SATELLITE",
+               "name": [
+                    "MARGARET"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.uranus.margaret::1.1"
           },
           {
-               "name": "2001 QC298",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2001 QC298"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2001_qc298::1.0"
           },
           {
-               "name": "(41307) 1999 XA149",
-               "type": "ASTEROID",
+               "name": [
+                    "(41307) 1999 XA149"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.41307_1999_xa149::1.0"
           },
           {
-               "name": "ERINOME",
-               "type": "SATELLITE",
+               "name": [
+                    "ERINOME"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.erinome::1.1"
           },
           {
-               "name": "(208996) 2003 AZ84",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(208996) 2003 AZ84"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.208996_2003_az84::1.0"
           },
           {
-               "name": "(25192) 1998 SU124",
-               "type": "ASTEROID",
+               "name": [
+                    "(25192) 1998 SU124"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.25192_1998_su124::1.0"
           },
           {
-               "name": "2411 ZELLNER",
-               "type": "ASTEROID",
+               "name": [
+                    "2411 ZELLNER"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.2411_zellner::1.1"
           },
           {
-               "name": "APOLLO 14",
-               "type": "Mission",
+               "name": [
+                    "APOLLO 14"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.apollo_14::1.1"
           },
           {
-               "name": "CARME",
-               "type": "SATELLITE",
+               "name": [
+                    "CARME"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.carme::1.1"
           },
           {
-               "name": "2005 SD278",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2005 SD278"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2005_sd278::1.0"
           },
           {
-               "name": "AUXILIARY PAYLOAD SENSOR SUBSYSTEM PRESSURE SENSOR",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "AUXILIARY PAYLOAD SENSOR SUBSYSTEM PRESSURE SENSOR"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:apss-ps.insight::1.0"
           },
           {
-               "name": "1999 RC215",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "1999 RC215"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.1999_rc215::1.0"
           },
           {
-               "name": "OBERON",
-               "type": "SATELLITE",
+               "name": [
+                    "OBERON"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.uranus.oberon::1.1"
           },
           {
-               "name": "8 FLORA",
-               "type": "ASTEROID",
+               "name": [
+                    "8 FLORA"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.8_flora::1.1"
           },
           {
-               "name": "(123509) 2000 WK183",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(123509) 2000 WK183"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.123509_2000_wk183::1.0"
           },
           {
-               "name": "1999 CJ119",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "1999 CJ119"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.1999_cj119::1.0"
           },
           {
-               "name": "VENUS WIND TUNNEL",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "VENUS WIND TUNNEL"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:pal.vwt::1.0"
           },
           {
-               "name": "(470309) 2007 JK43",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(470309) 2007 JK43"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.470309_2007_jk43::1.0"
           },
           {
-               "name": "(181708) 1993 FW",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(181708) 1993 FW"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.181708_1993_fw::1.0"
           },
           {
-               "name": "2002 VV130",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2002 VV130"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2002_vv130::1.0"
           },
           {
-               "name": "PIONEER 8 COSMIC DUST DETECTOR",
-               "type": "DUST",
+               "name": [
+                    "PIONEER 8 COSMIC DUST DETECTOR"
+               ],
+               "type": [
+                    "DUST"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:cdd.pioneer_8::1.0"
           },
           {
-               "name": "2001 RW143",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2001 RW143"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2001_rw143::1.0"
           },
           {
-               "name": "APOLLO 15 LUNAR SURFACE EXPERIMENTS PACKAGE",
-               "type": "Spacecraft",
+               "name": [
+                    "APOLLO 15 LUNAR SURFACE EXPERIMENTS PACKAGE"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.a15a::1.1"
           },
           {
-               "name": "46 HESTIA",
-               "type": "ASTEROID",
+               "name": [
+                    "46 HESTIA"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.46_hestia::1.1"
           },
           {
-               "name": "HUBBLE SPACE TELESCOPE",
-               "type": "Spacecraft",
+               "name": [
+                    "HUBBLE SPACE TELESCOPE"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.hst::1.1"
           },
           {
-               "name": "LUNAR PROSPECTOR",
-               "type": "Mission",
+               "name": [
+                    "LUNAR PROSPECTOR"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.lunar_prospector::1.1"
           },
           {
-               "name": "2004 XR190",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2004 XR190"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2004_xr190::1.0"
           },
           {
-               "name": "S/2003 J 19",
-               "type": "SATELLITE",
+               "name": [
+                    "S/2003 J 19"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.s2003j19::1.1"
           },
           {
-               "name": "1999 OH4",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "1999 OH4"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.1999_oh4::1.0"
           },
           {
-               "name": "2004 QQ26",
-               "type": "CENTAUR",
+               "name": [
+                    "2004 QQ26"
+               ],
+               "type": [
+                    "CENTAUR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:centaur.2004_qq26::1.0"
           },
           {
-               "name": "15 EUNOMIA",
-               "type": "ASTEROID",
+               "name": [
+                    "15 EUNOMIA"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.15_eunomia::1.1"
           },
           {
-               "name": "CYLLENE",
-               "type": "SATELLITE",
+               "name": [
+                    "CYLLENE"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.cyllene::1.1"
           },
           {
-               "name": "AUXILIARY PAYLOAD SENSOR SUBSYSTEM TEMPERATURES AND WIND SENSOR FOR INSIGHT",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "AUXILIARY PAYLOAD SENSOR SUBSYSTEM TEMPERATURES AND WIND SENSOR FOR INSIGHT"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:apss-twins.insight::1.0"
           },
           {
-               "name": "VOYAGER 2",
-               "type": "Spacecraft",
+               "name": [
+                    "VOYAGER 2"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.vg2::1.1"
           },
           {
-               "name": "S/2003 J 4",
-               "type": "SATELLITE",
+               "name": [
+                    "S/2003 J 4"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.s2003j4::1.1"
           },
           {
-               "name": "ANTHE",
-               "type": "SATELLITE",
+               "name": [
+                    "ANTHE"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.anthe::1.1"
           },
           {
-               "name": "CUPID",
-               "type": "SATELLITE",
+               "name": [
+                    "CUPID"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.uranus.cupid::1.1"
           },
           {
-               "name": "288 GLAUKE",
-               "type": "ASTEROID",
+               "name": [
+                    "288 GLAUKE"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.288_glauke::1.1"
           },
           {
-               "name": "87P/BUS",
-               "type": "COMET",
+               "name": [
+                    "87P/BUS"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.87p_bus::1.0"
           },
           {
-               "name": "153P/IKEYA-ZHANG",
-               "type": "COMET",
+               "name": [
+                    "153P/IKEYA-ZHANG"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.153p_ikeya-zhang::1.0"
           },
           {
-               "name": "ATMOSPHERIC STRUCTURE INSTRUMENT / METEOROLOGY PACKAGE",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "ATMOSPHERIC STRUCTURE INSTRUMENT / METEOROLOGY PACKAGE"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:asimet.mpfl::1.0"
           },
           {
-               "name": "C/1987 F1 (TORRES)",
-               "type": "COMET",
+               "name": [
+                    "C/1987 F1 (TORRES)"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.c1987_f1_torres::1.1"
           },
           {
-               "name": "(300202) 2006 WE109",
-               "type": "ASTEROID",
+               "name": [
+                    "(300202) 2006 WE109"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300202_2006_we109::1.0"
           },
           {
-               "name": "C/2012 S1 (ISON)",
-               "type": "COMET",
+               "name": [
+                    "C/2012 S1 (ISON)"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.c2012_s1_ison::1.1"
           },
           {
-               "name": "BUTTERFIELD WIND TUNNEL, WHITEHEAD AERONAUTICAL LABORATORY, QUEEN MARY UNIVERSITY OF LONDON, UK",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "BUTTERFIELD WIND TUNNEL, WHITEHEAD AERONAUTICAL LABORATORY, QUEEN MARY UNIVERSITY OF LONDON, UK"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:qmu-wal.butterfield_wt::1.0"
           },
           {
-               "name": "SKY",
-               "type": "CALIBRATION FIELD",
+               "name": [
+                    "SKY"
+               ],
+               "type": [
+                    "CALIBRATION FIELD"
+               ],
                "lidvid": "urn:nasa:pds:context:target:calibration_field.sky::1.0"
           },
           {
-               "name": "ENERGETIC PARTICLE AND PLASMA SPECTROMETER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "ENERGETIC PARTICLE AND PLASMA SPECTROMETER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:epps.mess::1.0"
           },
           {
-               "name": "THERMAL-REGION CAMERA SPECTROGRAPH (T-RECS)",
-               "type": "IMAGER",
+               "name": [
+                    "THERMAL-REGION CAMERA SPECTROGRAPH (T-RECS)"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:gemini-south.8m1.t-recs::1.0"
           },
           {
-               "name": "(363330) 2002 PQ145",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(363330) 2002 PQ145"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.363330_2002_pq145::1.0"
           },
           {
-               "name": "(19308) 1996 TO66",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(19308) 1996 TO66"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.19308_1996_to66::1.0"
           },
           {
-               "name": "(427581) 2003 QB92",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(427581) 2003 QB92"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.427581_2003_qb92::1.0"
           },
           {
-               "name": "(13372) 1998 VU6",
-               "type": "ASTEROID",
+               "name": [
+                    "(13372) 1998 VU6"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.13372_1998_vu6::1.0"
           },
           {
-               "name": "THELXINOE",
-               "type": "SATELLITE",
+               "name": [
+                    "THELXINOE"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.thelxinoe::1.1"
           },
           {
-               "name": "METIS",
-               "type": "SATELLITE",
+               "name": [
+                    "METIS"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.metis::1.1"
           },
           {
-               "name": "APOLLO 15 LUNAR MODULE",
-               "type": "Spacecraft",
+               "name": [
+                    "APOLLO 15 LUNAR MODULE"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.a15l::1.1"
           },
           {
-               "name": "RHEA",
-               "type": "SATELLITE",
+               "name": [
+                    "RHEA"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.rhea::1.1"
           },
           {
-               "name": "APOLLO 16 SUBSATELLITE",
-               "type": "Spacecraft",
+               "name": [
+                    "APOLLO 16 SUBSATELLITE"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.a16s::1.1"
           },
           {
-               "name": "DUST IMPACT PLASMA DETECTOR",
-               "type": "PARTICLE DETECTOR",
+               "name": [
+                    "DUST IMPACT PLASMA DETECTOR"
+               ],
+               "type": [
+                    "PARTICLE DETECTOR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:sp1.vega1::1.0"
           },
           {
-               "name": "LOGIE WIND TUNNEL, LABORATORY OF EXPERIMENTAL GEOMORPHOLOGY, CATHOLIC UNIVERSITY, LEUVEN, BEGIUM",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "LOGIE WIND TUNNEL, LABORATORY OF EXPERIMENTAL GEOMORPHOLOGY, CATHOLIC UNIVERSITY, LEUVEN, BEGIUM"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:kuleuven-leg.logie_wt::1.0"
           },
           {
-               "name": "(131696) 2001 XT254",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(131696) 2001 XT254"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.131696_2001_xt254::1.0"
           },
           {
-               "name": "82P/GEHRELS 3",
-               "type": "COMET",
+               "name": [
+                    "82P/GEHRELS 3"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.82p_gehrels_3::1.0"
           },
           {
-               "name": "SAMPLE ANALYSIS AT MARS",
-               "type": "SPECTROMETER",
+               "name": [
+                    "SAMPLE ANALYSIS AT MARS"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:sam.msl::1.0"
           },
           {
-               "name": "GALILEO",
-               "type": "Mission",
+               "name": [
+                    "GALILEO"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.galileo::1.1"
           },
           {
-               "name": "(437915) 2002 GD32",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(437915) 2002 GD32"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.437915_2002_gd32::1.0"
           },
           {
-               "name": "49036 PELION",
-               "type": "CENTAUR",
+               "name": [
+                    "49036 PELION"
+               ],
+               "type": [
+                    "CENTAUR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:centaur.49036_pelion::1.0"
           },
           {
-               "name": "TARVOS",
-               "type": "SATELLITE",
+               "name": [
+                    "TARVOS"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.tarvos::1.1"
           },
           {
-               "name": "FLUXGATE MAGNETOMETER",
-               "type": "MAGNETOMETER",
+               "name": [
+                    "FLUXGATE MAGNETOMETER"
+               ],
+               "type": [
+                    "MAGNETOMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:mag.gio::1.0"
           },
           {
-               "name": "(469505) 2003 FE128",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(469505) 2003 FE128"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.469505_2003_fe128::1.0"
           },
           {
-               "name": "2010 LQ68",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2010 LQ68"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2010_lq68::1.0"
           },
           {
-               "name": "RADIO SCIENCE SUBSYSTEM",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "RADIO SCIENCE SUBSYSTEM"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:rss.mpfl::1.0"
           },
           {
-               "name": "2004 KD19",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2004 KD19"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2004_kd19::1.0"
           },
           {
-               "name": "1998 FS144",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "1998 FS144"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.1998_fs144::1.0"
           },
           {
-               "name": "2005 GV210",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2005 GV210"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2005_gv210::1.0"
           },
           {
-               "name": "LASER RANGEFINDER",
-               "type": "ALTIMETER",
+               "name": [
+                    "LASER RANGEFINDER"
+               ],
+               "type": [
+                    "ALTIMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:lidar.clem1::1.0"
           },
           {
-               "name": "NIX",
-               "type": "SATELLITE",
+               "name": [
+                    "NIX"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.134340_pluto.nix::1.1"
           },
           {
-               "name": "APOLLO 17 SUBSATELLITE",
-               "type": "Spacecraft",
+               "name": [
+                    "APOLLO 17 SUBSATELLITE"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.a17s::1.1"
           },
           {
-               "name": "(443843) 2001 FO185",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(443843) 2001 FO185"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.443843_2001_fo185::1.0"
           },
           {
-               "name": "S/2004 S 13",
-               "type": "SATELLITE",
+               "name": [
+                    "S/2004 S 13"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.s2004s13::1.1"
           },
           {
-               "name": "(182222) 2000 YU1",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(182222) 2000 YU1"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.182222_2000_yu1::1.0"
           },
           {
-               "name": "INSIGHT",
-               "type": "Mission",
+               "name": [
+                    "INSIGHT"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.insight::1.0"
           },
           {
-               "name": "PLASMA WAVE ANALYZER",
-               "type": "PLASMA WAVE SPECTROMETER",
+               "name": [
+                    "PLASMA WAVE ANALYZER"
+               ],
+               "type": [
+                    "PLASMA WAVE SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:oefd.pvo::1.0"
           },
           {
-               "name": "APOLLO 14 COMMAND AND SERVICE MODULE",
-               "type": "Spacecraft",
+               "name": [
+                    "APOLLO 14 COMMAND AND SERVICE MODULE"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.a14c::1.1"
           },
           {
-               "name": "70P/KOJIMA",
-               "type": "COMET",
+               "name": [
+                    "70P/KOJIMA"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.70p_kojima::1.0"
           },
           {
-               "name": "(59358) 1999 CL158",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(59358) 1999 CL158"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.59358_1999_cl158::1.0"
           },
           {
-               "name": "ELECTRON REFLECTOMETER",
-               "type": "PARTICLE DETECTOR",
+               "name": [
+                    "ELECTRON REFLECTOMETER"
+               ],
+               "type": [
+                    "PARTICLE DETECTOR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:er.mgs::1.0"
           },
           {
-               "name": "NEXT",
-               "type": "Mission",
+               "name": [
+                    "NEXT"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.next::1.1"
           },
           {
-               "name": "(438028) 2004 EH96",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(438028) 2004 EH96"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.438028_2004_eh96::1.0"
           },
           {
-               "name": "HELIKE",
-               "type": "SATELLITE",
+               "name": [
+                    "HELIKE"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.helike::1.1"
           },
           {
-               "name": "(60458) 2000 CM114",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(60458) 2000 CM114"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.60458_2000_cm114::1.0"
           },
           {
-               "name": "2001 VN71",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2001 VN71"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2001_vn71::1.0"
           },
           {
-               "name": "2001 RZ143",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2001 RZ143"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2001_rz143::1.0"
           },
           {
-               "name": "PRAXIDIKE",
-               "type": "SATELLITE",
+               "name": [
+                    "PRAXIDIKE"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.praxidike::1.1"
           },
           {
-               "name": "10664 PHEMIOS",
-               "type": "ASTEROID",
+               "name": [
+                    "10664 PHEMIOS"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.10664_phemios::1.1"
           },
           {
-               "name": "EUROPA",
-               "type": "SATELLITE",
+               "name": [
+                    "EUROPA"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.europa::1.1"
           },
           {
-               "name": "50000 QUAOAR",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "50000 QUAOAR"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.50000_quaoar::1.1"
           },
           {
-               "name": "APOLLO 16 LUNAR SURFACE EXPERIMENTS PACKAGE",
-               "type": "Spacecraft",
+               "name": [
+                    "APOLLO 16 LUNAR SURFACE EXPERIMENTS PACKAGE"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.a16a::1.1"
           },
           {
-               "name": "224 OCEANA",
-               "type": "ASTEROID",
+               "name": [
+                    "224 OCEANA"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.224_oceana::1.1"
           },
           {
-               "name": "2003 SQ317",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2003 SQ317"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2003_sq317::1.0"
           },
           {
-               "name": "(469421) 2001 XD255",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(469421) 2001 XD255"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.469421_2001_xd255::1.0"
           },
           {
-               "name": "INTERNATIONAL COMETARY EXPLORER",
-               "type": "Mission",
+               "name": [
+                    "INTERNATIONAL COMETARY EXPLORER"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.international_cometary_explorer::1.1"
           },
           {
-               "name": "(300222) 2006 XF6",
-               "type": "ASTEROID",
+               "name": [
+                    "(300222) 2006 XF6"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300222_2006_xf6::1.0"
           },
           {
-               "name": "(135571) 2002 GG32",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(135571) 2002 GG32"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.135571_2002_gg32::1.0"
           },
           {
-               "name": "PLANETARY RADIO ASTRONOMY RECEIVER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "PLANETARY RADIO ASTRONOMY RECEIVER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:pra.vg1::1.0"
           },
           {
-               "name": "899 JOKASTE",
-               "type": "ASTEROID",
+               "name": [
+                    "899 JOKASTE"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.899_jokaste::1.1"
           },
           {
-               "name": "ENCELADUS",
-               "type": "SATELLITE",
+               "name": [
+                    "ENCELADUS"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.enceladus::1.1"
           },
           {
-               "name": "2003 YU179",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2003 YU179"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2003_yu179::1.0"
           },
           {
-               "name": "HAT-P-7",
-               "type": "STAR",
+               "name": [
+                    "HAT-P-7"
+               ],
+               "type": [
+                    "STAR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:star.bd+47_2846::1.0"
           },
           {
-               "name": "SURTUR",
-               "type": "SATELLITE",
+               "name": [
+                    "SURTUR"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.surtur::1.1"
           },
           {
-               "name": "(300167) 2006 VM143",
-               "type": "ASTEROID",
+               "name": [
+                    "(300167) 2006 VM143"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300167_2006_vm143::1.0"
           },
           {
-               "name": "LUNAR RECONNAISSANCE ORBITER",
-               "type": "Spacecraft",
+               "name": [
+                    "LUNAR RECONNAISSANCE ORBITER"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.lro::1.1"
           },
           {
-               "name": "EPIMETHEUS",
-               "type": "SATELLITE",
+               "name": [
+                    "EPIMETHEUS"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.epimetheus::1.1"
           },
           {
-               "name": "54598 BIENOR",
-               "type": "CENTAUR",
+               "name": [
+                    "54598 BIENOR"
+               ],
+               "type": [
+                    "CENTAUR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:centaur.54598_bienor::1.0"
           },
           {
-               "name": "1999 CL119",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "1999 CL119"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.1999_cl119::1.0"
           },
           {
-               "name": "(144908) 2004 YH32",
-               "type": "CENTAUR",
+               "name": [
+                    "(144908) 2004 YH32"
+               ],
+               "type": [
+                    "CENTAUR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:centaur.144908_2004_yh32::1.0"
           },
           {
-               "name": "APOLLO 15 SUBSATELLITE",
-               "type": "Spacecraft",
+               "name": [
+                    "APOLLO 15 SUBSATELLITE"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.a15s::1.1"
           },
           {
-               "name": "CHANDRAYAAN-1 ORBITER",
-               "type": "Spacecraft",
+               "name": [
+                    "CHANDRAYAAN-1 ORBITER"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.ch1-orb::1.1"
           },
           {
-               "name": "VIKING METEOROLOGY INSTRUMENT SYSTEM",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "VIKING METEOROLOGY INSTRUMENT SYSTEM"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:met.vl1::1.0"
           },
           {
-               "name": "66652 BORASISI",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "66652 BORASISI"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.66652_borasisi::1.1"
           },
           {
-               "name": "GRAVITY RECOVERY AND INTERIOR LABORATORY B",
-               "type": "Spacecraft",
+               "name": [
+                    "GRAVITY RECOVERY AND INTERIOR LABORATORY B"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.grail-b::1.1"
           },
           {
-               "name": "ALICE ULTRAVIOLET IMAGING SPECTROGRAPH",
-               "type": "SPECTROGRAPH",
+               "name": [
+                    "ALICE ULTRAVIOLET IMAGING SPECTROGRAPH"
+               ],
+               "type": [
+                    "SPECTROGRAPH"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:alice.nh::1.0"
           },
           {
-               "name": "101955 BENNU",
-               "type": "ASTEROID",
+               "name": [
+                    "101955 BENNU"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.101955_bennu::1.1"
           },
           {
-               "name": "1996 TK66",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "1996 TK66"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.1996_tk66::1.0"
           },
           {
-               "name": "(385437) 2003 GH55",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(385437) 2003 GH55"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.385437_2003_gh55::1.0"
           },
           {
-               "name": "APOLLO 16 COMMAND AND SERVICE MODULE",
-               "type": "Spacecraft",
+               "name": [
+                    "APOLLO 16 COMMAND AND SERVICE MODULE"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.a16c::1.1"
           },
           {
-               "name": "617 PATROCLUS",
-               "type": "ASTEROID",
+               "name": [
+                    "617 PATROCLUS"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.617_patroclus::1.1"
           },
           {
-               "name": "88611 TEHARONHIAWAKO",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "88611 TEHARONHIAWAKO"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.88611_teharonhiawako::1.1"
           },
           {
-               "name": "(508823) 2001 RX143",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(508823) 2001 RX143"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.508823_2001_rx143::1.0"
           },
           {
-               "name": "DEEP IMPACT",
-               "type": "Mission",
+               "name": [
+                    "DEEP IMPACT"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.deep_impact::1.1"
           },
           {
-               "name": "(13379) 1998 WX9",
-               "type": "ASTEROID",
+               "name": [
+                    "(13379) 1998 WX9"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.13379_1998_wx9::1.0"
           },
           {
-               "name": "(20108) 1995 QZ9",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(20108) 1995 QZ9"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.20108_1995_qz9::1.0"
           },
           {
-               "name": "2006 RJ103",
-               "type": "CENTAUR",
+               "name": [
+                    "2006 RJ103"
+               ],
+               "type": [
+                    "CENTAUR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:centaur.2006_rj103::1.0"
           },
           {
-               "name": "42355 TYPHON",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "42355 TYPHON"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.42355_typhon::1.1"
           },
           {
-               "name": "CHEMISTRY AND MINERALOGY INSTRUMENT",
-               "type": "SPECTROMETER",
+               "name": [
+                    "CHEMISTRY AND MINERALOGY INSTRUMENT"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:chemin.msl::1.0"
           },
           {
-               "name": "SETEBOS",
-               "type": "SATELLITE",
+               "name": [
+                    "SETEBOS"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.uranus.setebos::1.1"
           },
           {
-               "name": "2003 YX179",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2003 YX179"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2003_yx179::1.0"
           },
           {
-               "name": "1999 OD4",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "1999 OD4"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.1999_od4::1.0"
           },
           {
-               "name": "(24952) 1997 QJ4",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(24952) 1997 QJ4"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.24952_1997_qj4::1.0"
           },
           {
-               "name": "PROMETHEUS",
-               "type": "SATELLITE",
+               "name": [
+                    "PROMETHEUS"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.prometheus::1.1"
           },
           {
-               "name": "PLANETARY FOURIER SPECTROMETER",
-               "type": "INTERFEROMETER",
+               "name": [
+                    "PLANETARY FOURIER SPECTROMETER"
+               ],
+               "type": [
+                    "INTERFEROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:pfs.mex::1.0"
           },
           {
-               "name": "HELENE",
-               "type": "SATELLITE",
+               "name": [
+                    "HELENE"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.helene::1.2"
           },
           {
-               "name": "JUPITER LABORATORY ANALOG",
-               "type": "LABORATORY ANALOG",
+               "name": [
+                    "JUPITER LABORATORY ANALOG"
+               ],
+               "type": [
+                    "LABORATORY ANALOG"
+               ],
                "lidvid": "urn:nasa:pds:context:target:laboratory_analog.jupiter::1.0"
           },
           {
-               "name": "ROSETTA PLASMA CONSORTIUM - FLUXGATE MAGNETOMETER",
-               "type": "MAGNETOMETER",
+               "name": [
+                    "ROSETTA PLASMA CONSORTIUM - FLUXGATE MAGNETOMETER"
+               ],
+               "type": [
+                    "MAGNETOMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:rpcmag.ro::1.0"
           },
           {
-               "name": "FRANCISCO",
-               "type": "SATELLITE",
+               "name": [
+                    "FRANCISCO"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.uranus.francisco::1.1"
           },
           {
-               "name": "(118378) 1999 HT11",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(118378) 1999 HT11"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.118378_1999_ht11::1.0"
           },
           {
-               "name": "PLASMA ENERGY ANALYZER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "PLASMA ENERGY ANALYZER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:pm1.vega2::1.0"
           },
           {
-               "name": "1998 WY24",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "1998 WY24"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.1998_wy24::1.0"
           },
           {
-               "name": "2001 RU143",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2001 RU143"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2001_ru143::1.0"
           },
           {
-               "name": "ANTARES",
-               "type": "STAR",
+               "name": [
+                    "ANTARES"
+               ],
+               "type": [
+                    "STAR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:star.alf_sco::1.0"
           },
           {
-               "name": "CALLISTO",
-               "type": "SATELLITE",
+               "name": [
+                    "CALLISTO"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.callisto::1.1"
           },
           {
-               "name": "PASIPHAE",
-               "type": "SATELLITE",
+               "name": [
+                    "PASIPHAE"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.pasiphae::1.1"
           },
           {
-               "name": "APOLLO 12 LUNAR SURFACE EXPERIMENTS PACKAGE",
-               "type": "Spacecraft",
+               "name": [
+                    "APOLLO 12 LUNAR SURFACE EXPERIMENTS PACKAGE"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.a12a::1.1"
           },
           {
-               "name": "RADAR",
-               "type": "RADIO-RADAR",
+               "name": [
+                    "RADAR"
+               ],
+               "type": [
+                    "RADIO-RADAR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:radar.co::1.0"
           },
           {
-               "name": "S/2003 J 5",
-               "type": "SATELLITE",
+               "name": [
+                    "S/2003 J 5"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.s2003j5::1.1"
           },
           {
-               "name": "5436 EUMELOS",
-               "type": "ASTEROID",
+               "name": [
+                    "5436 EUMELOS"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.5436_eumelos::1.1"
           },
           {
-               "name": "(300191) 2006 WQ86",
-               "type": "ASTEROID",
+               "name": [
+                    "(300191) 2006 WQ86"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300191_2006_wq86::1.0"
           },
           {
-               "name": "RADIO SCIENCE SUBSYSTEM",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "RADIO SCIENCE SUBSYSTEM"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:rss-vg2u.vg2::1.0"
           },
           {
-               "name": "C/1990 K1 (LEVY)",
-               "type": "COMET",
+               "name": [
+                    "C/1990 K1 (LEVY)"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.c1990_k1_levy::1.0"
           },
           {
-               "name": "COMET SL9/JUPITER COLLISION",
-               "type": "Mission",
+               "name": [
+                    "COMET SL9/JUPITER COLLISION"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.comet_sl9-jupiter_collision::1.1"
           },
           {
-               "name": "APOLLO 17 FAR-ULTRAVIOLET SPECTROMETER (FUVS)",
-               "type": "SPECTROMETER",
+               "name": [
+                    "APOLLO 17 FAR-ULTRAVIOLET SPECTROMETER (FUVS)"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:fuvs.a17c::1.0"
           },
           {
-               "name": "COSMIC RAY TELESCOPE FOR THE EFFECTS OF RADIATION",
-               "type": "PARTICLE DETECTOR",
+               "name": [
+                    "COSMIC RAY TELESCOPE FOR THE EFFECTS OF RADIATION"
+               ],
+               "type": [
+                    "PARTICLE DETECTOR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:crat.lro::1.0"
           },
           {
-               "name": "MAST CAMERA LEFT",
-               "type": "IMAGER",
+               "name": [
+                    "MAST CAMERA LEFT"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:mast_left.msl::1.0"
           },
           {
-               "name": "944 HIDALGO",
-               "type": "CENTAUR",
+               "name": [
+                    "944 HIDALGO"
+               ],
+               "type": [
+                    "CENTAUR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:centaur.944_hidalgo::1.0"
           },
           {
-               "name": "(303712) 2005 PR21",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(303712) 2005 PR21"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.303712_2005_pr21::1.0"
           },
           {
-               "name": "KERBEROS",
-               "type": "SATELLITE",
+               "name": [
+                    "KERBEROS"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.134340_pluto.kerberos::1.1"
           },
           {
-               "name": "73P/SCHWASSMANN-WACHMANN 3",
-               "type": "COMET",
+               "name": [
+                    "73P/SCHWASSMANN-WACHMANN 3"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.73p_schwassmann-wachmann_3::1.0"
           },
           {
-               "name": "XO-2",
-               "type": "STAR",
+               "name": [
+                    "XO-2"
+               ],
+               "type": [
+                    "STAR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:star.xo-2::1.0"
           },
           {
-               "name": "FRAMING CAMERA 2",
-               "type": "IMAGER",
+               "name": [
+                    "FRAMING CAMERA 2"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:dawn.fc2::1.0"
           },
           {
-               "name": "7968 ELST-PIZARRO",
-               "type": "ASTEROID",
+               "name": [
+                    "7968 ELST-PIZARRO"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.7968_elst-pizarro::1.1"
           },
           {
-               "name": "(12921) 1998 WZ5",
-               "type": "ASTEROID",
+               "name": [
+                    "(12921) 1998 WZ5"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.12921_1998_wz5::1.0"
           },
           {
-               "name": "JUNO",
-               "type": "Mission",
+               "name": [
+                    "JUNO"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.juno::2.1"
           },
           {
-               "name": "FLUXGATE MAGNETOMETER",
-               "type": "MAGNETOMETER",
+               "name": [
+                    "FLUXGATE MAGNETOMETER"
+               ],
+               "type": [
+                    "MAGNETOMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:fgm.p11::1.0"
           },
           {
-               "name": "S/2011 J 1",
-               "type": "SATELLITE",
+               "name": [
+                    "S/2011 J 1"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.s2011j1::1.1"
           },
           {
-               "name": "2007 RT15",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2007 RT15"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2007_rt15::1.0"
           },
           {
-               "name": "(181867) 1999 CV118",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(181867) 1999 CV118"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.181867_1999_cv118::1.0"
           },
           {
-               "name": "(82075) 2000 YW134",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(82075) 2000 YW134"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.82075_2000_yw134::1.0"
           },
           {
-               "name": "(308460) 2005 SC278",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(308460) 2005 SC278"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.308460_2005_sc278::1.0"
           },
           {
-               "name": "INFRARED ASTRONOMICAL SATELLITE",
-               "type": "Mission",
+               "name": [
+                    "INFRARED ASTRONOMICAL SATELLITE"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.infrared_astronomical_satellite::1.0"
           },
           {
-               "name": "OSIRIS - NARROW ANGLE CAMERA",
-               "type": "IMAGER",
+               "name": [
+                    "OSIRIS - NARROW ANGLE CAMERA"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:osinac.ro::1.0"
           },
           {
-               "name": "PI2 ORIONIS",
-               "type": "STAR",
+               "name": [
+                    "PI2 ORIONIS"
+               ],
+               "type": [
+                    "STAR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:star.pi.02_ori::1.0"
           },
           {
-               "name": "(27705) 1985 DU1",
-               "type": "ASTEROID",
+               "name": [
+                    "(27705) 1985 DU1"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.27705_1985_du1::1.0"
           },
           {
-               "name": "(300240) 2007 CP26",
-               "type": "ASTEROID",
+               "name": [
+                    "(300240) 2007 CP26"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300240_2007_cp26::1.0"
           },
           {
-               "name": "CHANDRAYAAN-1",
-               "type": "Mission",
+               "name": [
+                    "CHANDRAYAAN-1"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.chandrayaan-1::1.1"
           },
           {
-               "name": "MAGNETOMETER",
-               "type": "MAGNETOMETER",
+               "name": [
+                    "MAGNETOMETER"
+               ],
+               "type": [
+                    "MAGNETOMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:mag.near::1.0"
           },
           {
-               "name": "DESDEMONA",
-               "type": "SATELLITE",
+               "name": [
+                    "DESDEMONA"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.uranus.desdemona::1.1"
           },
           {
-               "name": "MOESSBAUER SPECTROMETER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "MOESSBAUER SPECTROMETER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:mb.mer1::1.0"
           },
           {
-               "name": "(469708) 2005 GE187",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(469708) 2005 GE187"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.469708_2005_ge187::1.0"
           },
           {
-               "name": "CONTEXT CAMERA",
-               "type": "IMAGER",
+               "name": [
+                    "CONTEXT CAMERA"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:ctx.mro::1.0"
           },
           {
-               "name": "(40804) 1999 TQ40",
-               "type": "ASTEROID",
+               "name": [
+                    "(40804) 1999 TQ40"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.40804_1999_tq40::1.0"
           },
           {
-               "name": "ROSETTA-LANDER",
-               "type": "Spacecraft",
+               "name": [
+                    "ROSETTA-LANDER"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.rl::1.1"
           },
           {
-               "name": "(143991) 2003 YO179",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(143991) 2003 YO179"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.143991_2003_yo179::1.0"
           },
           {
-               "name": "SPEX",
-               "type": "SPECTROMETER",
+               "name": [
+                    "SPEX"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:telescope.spex.irtf3m0::0.0"
           },
           {
-               "name": "(88267) 2001 KE76",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(88267) 2001 KE76"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.88267_2001_ke76::1.0"
           },
           {
-               "name": "COMET NUCLEUS TOUR",
-               "type": "Spacecraft",
+               "name": [
+                    "COMET NUCLEUS TOUR"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.con::1.0"
           },
           {
-               "name": "(22059) 2000 AD75",
-               "type": "ASTEROID",
+               "name": [
+                    "(22059) 2000 AD75"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.22059_2000_ad75::1.0"
           },
           {
-               "name": "(469333) 2000 PE30",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(469333) 2000 PE30"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.469333_2000_pe30::1.0"
           },
           {
-               "name": "APOLLO 17 LUNAR SURFACE GRAVIMETER (LSG) EXPERIMENT",
-               "type": "GRAVIMETER",
+               "name": [
+                    "APOLLO 17 LUNAR SURFACE GRAVIMETER (LSG) EXPERIMENT"
+               ],
+               "type": [
+                    "GRAVIMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:lsg.a17a::1.0"
           },
           {
-               "name": "SKOLL",
-               "type": "SATELLITE",
+               "name": [
+                    "SKOLL"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.skoll::1.1"
           },
           {
-               "name": "HAYABUSA",
-               "type": "Mission",
+               "name": [
+                    "HAYABUSA"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.hayabusa::1.1"
           },
           {
-               "name": "37117 NARCISSUS",
-               "type": "CENTAUR",
+               "name": [
+                    "37117 NARCISSUS"
+               ],
+               "type": [
+                    "CENTAUR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:centaur.37117_narcissus::1.0"
           },
           {
-               "name": "375 URSULA",
-               "type": "ASTEROID",
+               "name": [
+                    "375 URSULA"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.375_ursula::1.1"
           },
           {
-               "name": "ATLAS",
-               "type": "SATELLITE",
+               "name": [
+                    "ATLAS"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.atlas::1.1"
           },
           {
-               "name": "HYPERION",
-               "type": "SATELLITE",
+               "name": [
+                    "HYPERION"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.hyperion::1.1"
           },
           {
-               "name": "DUST IMPACT DETECTOR",
-               "type": "DUST",
+               "name": [
+                    "DUST IMPACT DETECTOR"
+               ],
+               "type": [
+                    "DUST"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:did.gio::1.0"
           },
           {
-               "name": "(300184) 2006 WK61",
-               "type": "ASTEROID",
+               "name": [
+                    "(300184) 2006 WK61"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300184_2006_wk61::1.0"
           },
           {
-               "name": "LONG WAVELENGTH INFRARED CAMERA",
-               "type": "IMAGER",
+               "name": [
+                    "LONG WAVELENGTH INFRARED CAMERA"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:lwir.clem1::1.0"
           },
           {
-               "name": "11 PARTHENOPE",
-               "type": "ASTEROID",
+               "name": [
+                    "11 PARTHENOPE"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.11_parthenope::1.1"
           },
           {
-               "name": "THRYMR",
-               "type": "SATELLITE",
+               "name": [
+                    "THRYMR"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.thrymr::1.1"
           },
           {
-               "name": "FRONT HAZARD AVOIDANCE CAMERA RIGHT STRING A",
-               "type": "IMAGER",
+               "name": [
+                    "FRONT HAZARD AVOIDANCE CAMERA RIGHT STRING A"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:fhaz_right_a.msl::1.0"
           },
           {
-               "name": "(82780) 2001 QF18",
-               "type": "ASTEROID",
+               "name": [
+                    "(82780) 2001 QF18"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.82780_2001_qf18::1.0"
           },
           {
-               "name": "SAMPLE RETURN CAPSULE",
-               "type": "DUST",
+               "name": [
+                    "SAMPLE RETURN CAPSULE"
+               ],
+               "type": [
+                    "DUST"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:src.sdu::1.0"
           },
           {
-               "name": "(300173) 2006 WT",
-               "type": "ASTEROID",
+               "name": [
+                    "(300173) 2006 WT"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300173_2006_wt::1.0"
           },
           {
-               "name": "HEAT FLOW EXPERIMENT",
-               "type": "REGOLITH PROPERTIES",
+               "name": [
+                    "HEAT FLOW EXPERIMENT"
+               ],
+               "type": [
+                    "REGOLITH PROPERTIES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:hfe.a17a::1.0"
           },
           {
-               "name": "2000 OP67",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2000 OP67"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2000_op67::1.0"
           },
           {
-               "name": "2004 TE282",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2004 TE282"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2004_te282::1.0"
           },
           {
-               "name": "SOLAR WIND",
-               "type": "PLASMA STREAM",
+               "name": [
+                    "SOLAR WIND"
+               ],
+               "type": [
+                    "PLASMA STREAM"
+               ],
                "lidvid": "urn:nasa:pds:context:target:plasma_stream.solar_wind::1.0"
           },
           {
-               "name": "PLASMA SCIENCE EXPERIMENT",
-               "type": "SPECTROMETER",
+               "name": [
+                    "PLASMA SCIENCE EXPERIMENT"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:pls.m10::1.0"
           },
           {
-               "name": "INTERNATIONAL ROSETTA MISSION",
-               "type": "Mission",
+               "name": [
+                    "INTERNATIONAL ROSETTA MISSION"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.international_rosetta_mission::1.1"
           },
           {
-               "name": "253 MATHILDE",
-               "type": "ASTEROID",
+               "name": [
+                    "253 MATHILDE"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.253_mathilde::1.0"
           },
           {
-               "name": "45 EUGENIA",
-               "type": "ASTEROID",
+               "name": [
+                    "45 EUGENIA"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.45_eugenia::1.1"
           },
           {
-               "name": "VOYAGER",
-               "type": "Mission",
+               "name": [
+                    "VOYAGER"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.voyager::1.1"
           },
           {
-               "name": "GEIGER TUBE TELESCOPE",
-               "type": "PARTICLE DETECTOR",
+               "name": [
+                    "GEIGER TUBE TELESCOPE"
+               ],
+               "type": [
+                    "PARTICLE DETECTOR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:gtt.p11::1.0"
           },
           {
-               "name": "1 CERES",
-               "type": "DWARF PLANET",
+               "name": [
+                    "1 CERES"
+               ],
+               "type": [
+                    "DWARF PLANET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:dwarf_planet.1_ceres::1.1"
           },
           {
-               "name": "(308193) 2005 CB79",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(308193) 2005 CB79"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.308193_2005_cb79::1.0"
           },
           {
-               "name": "SUISEI",
-               "type": "Mission",
+               "name": [
+                    "SUISEI"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.suisei::1.1"
           },
           {
-               "name": "PPR RCT",
-               "type": "CALIBRATOR",
+               "name": [
+                    "PPR RCT"
+               ],
+               "type": [
+                    "CALIBRATOR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:calibrator.ppr_rct::1.0"
           },
           {
-               "name": "THYONE",
-               "type": "SATELLITE",
+               "name": [
+                    "THYONE"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.thyone::1.1"
           },
           {
-               "name": "22899 ALCONRAD",
-               "type": "ASTEROID",
+               "name": [
+                    "22899 ALCONRAD"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.22899_alconrad::1.0"
           },
           {
-               "name": "7696 LIEBE",
-               "type": "ASTEROID",
+               "name": [
+                    "7696 LIEBE"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.7696_liebe::1.1"
           },
           {
-               "name": "2004 DA62",
-               "type": "CENTAUR",
+               "name": [
+                    "2004 DA62"
+               ],
+               "type": [
+                    "CENTAUR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:centaur.2004_da62::1.0"
           },
           {
-               "name": "LEDA",
-               "type": "SATELLITE",
+               "name": [
+                    "LEDA"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.leda::1.1"
           },
           {
-               "name": "(22669) 1998 QX32",
-               "type": "ASTEROID",
+               "name": [
+                    "(22669) 1998 QX32"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.22669_1998_qx32::1.0"
           },
           {
-               "name": "51 NEMAUSA",
-               "type": "ASTEROID",
+               "name": [
+                    "51 NEMAUSA"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.51_nemausa::1.1"
           },
           {
-               "name": "IMAGING SCIENCE SUBSYSTEM - WIDE ANGLE",
-               "type": "IMAGER",
+               "name": [
+                    "IMAGING SCIENCE SUBSYSTEM - WIDE ANGLE"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:issw.vg1::1.0"
           },
           {
-               "name": "ALPHA PARTICLE X-RAY SPECTROMETER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "ALPHA PARTICLE X-RAY SPECTROMETER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:apxs.msl::1.0"
           },
           {
-               "name": "IMAGING ULTRAVIOLET SPECTROGRAPH",
-               "type": "ULTRAVIOLET SPECTROMETER",
+               "name": [
+                    "IMAGING ULTRAVIOLET SPECTROGRAPH"
+               ],
+               "type": [
+                    "ULTRAVIOLET SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:iuvs.maven::1.0"
           },
           {
-               "name": "APOLLO 15 ORBITAL MASS SPECTROMETER (OMS) EXPERIMENT",
-               "type": "SPECTROMETER",
+               "name": [
+                    "APOLLO 15 ORBITAL MASS SPECTROMETER (OMS) EXPERIMENT"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:oms.a15c::1.0"
           },
           {
-               "name": "120347 SALACIA",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "120347 SALACIA"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.120347_salacia::1.1"
           },
           {
-               "name": "(119976) 2002 VR130",
-               "type": "CENTAUR",
+               "name": [
+                    "(119976) 2002 VR130"
+               ],
+               "type": [
+                    "CENTAUR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:centaur.119976_2002_vr130::1.0"
           },
           {
-               "name": "313P/GIBBS",
-               "type": "COMET",
+               "name": [
+                    "313P/GIBBS"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.313p_gibbs::1.0"
           },
           {
-               "name": "MIMAS",
-               "type": "SATELLITE",
+               "name": [
+                    "MIMAS"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.mimas::1.1"
           },
           {
-               "name": "8306 SHOKO",
-               "type": "ASTEROID",
+               "name": [
+                    "8306 SHOKO"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.8306_shoko::1.1"
           },
           {
-               "name": "HARPALYKE",
-               "type": "SATELLITE",
+               "name": [
+                    "HARPALYKE"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.harpalyke::1.1"
           },
           {
-               "name": "ADRASTEA",
-               "type": "SATELLITE",
+               "name": [
+                    "ADRASTEA"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.adrastea::1.1"
           },
           {
-               "name": "58534 LOGOS",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "58534 LOGOS"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.58534_logos::1.1"
           },
           {
-               "name": "D/1993 F2-P1 (SHOEMAKER-LEVY 9-P1)",
-               "type": "COMET",
+               "name": [
+                    "D/1993 F2-P1 (SHOEMAKER-LEVY 9-P1)"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.d1993_f2-p1_shoemaker-levy_9-p1::1.0"
           },
           {
-               "name": "3494 PURPLE MOUNTAIN",
-               "type": "ASTEROID",
+               "name": [
+                    "3494 PURPLE MOUNTAIN"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.3494_purple_mountain::1.1"
           },
           {
-               "name": "AEGAEON",
-               "type": "SATELLITE",
+               "name": [
+                    "AEGAEON"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.aegaeon::1.1"
           },
           {
-               "name": "MARS HAND LENS IMAGER CAMERA",
-               "type": "IMAGER",
+               "name": [
+                    "MARS HAND LENS IMAGER CAMERA"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:mahli.msl::1.0"
           },
           {
-               "name": "MECA OPTICAL MICROSCOPE",
-               "type": "IMAGER",
+               "name": [
+                    "MECA OPTICAL MICROSCOPE"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:om.phx::1.0"
           },
           {
-               "name": "(182934) 2002 GJ32",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(182934) 2002 GJ32"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.182934_2002_gj32::1.0"
           },
           {
-               "name": "MARINER 6",
-               "type": "Spacecraft",
+               "name": [
+                    "MARINER 6"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.mr6::1.1"
           },
           {
-               "name": "FENRIR",
-               "type": "SATELLITE",
+               "name": [
+                    "FENRIR"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.fenrir::1.1"
           },
           {
-               "name": "(55636) 2002 TX300",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(55636) 2002 TX300"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.55636_2002_tx300::1.0"
           },
           {
-               "name": "2001 KD77",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2001 KD77"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2001_kd77::1.0"
           },
           {
-               "name": "DESCENT CAMERA",
-               "type": "IMAGER",
+               "name": [
+                    "DESCENT CAMERA"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:descam.mer2::1.0"
           },
           {
-               "name": "AARHUS SLOPED WIND TUNNEL",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "AARHUS SLOPED WIND TUNNEL"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:au-msl.sloped_wt::1.0"
           },
           {
-               "name": "(55578) 2002 GK105",
-               "type": "ASTEROID",
+               "name": [
+                    "(55578) 2002 GK105"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.55578_2002_gk105::1.0"
           },
           {
-               "name": "MERCURY DUAL IMAGING SYSTEM NARROW ANGLE CAMERA",
-               "type": "IMAGER",
+               "name": [
+                    "MERCURY DUAL IMAGING SYSTEM NARROW ANGLE CAMERA"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:mdis-nac.mess::1.0"
           },
           {
-               "name": "VEGA 2",
-               "type": "Spacecraft",
+               "name": [
+                    "VEGA 2"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.vega2::1.1"
           },
           {
-               "name": "LANGMUIR PROBE AND WAVES INSTRUMENT",
-               "type": "PLASMA WAVE SPECTROMETER",
+               "name": [
+                    "LANGMUIR PROBE AND WAVES INSTRUMENT"
+               ],
+               "type": [
+                    "PLASMA WAVE SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:lpw.maven::1.0"
           },
           {
-               "name": "2011 JX31",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2011 JX31"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2011_jx31::1.0"
           },
           {
-               "name": "2002 GA32",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2002 GA32"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2002_ga32::1.0"
           },
           {
-               "name": "TRINCULO",
-               "type": "SATELLITE",
+               "name": [
+                    "TRINCULO"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.uranus.trinculo::1.1"
           },
           {
-               "name": "CAMERA 2",
-               "type": "IMAGER",
+               "name": [
+                    "CAMERA 2"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:cam2.vl1::1.0"
           },
           {
-               "name": "2003 HG57",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2003 HG57"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2003_hg57::1.0"
           },
           {
-               "name": "3200 PHAETHON",
-               "type": "ASTEROID",
+               "name": [
+                    "3200 PHAETHON"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.3200_phaethon::1.1"
           },
           {
-               "name": "RADIO SCIENCE SUBSYSTEM",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "RADIO SCIENCE SUBSYSTEM"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:rss.clem1::1.0"
           },
           {
-               "name": "SATURN SMALL SATELLITE ASTROMETRY",
-               "type": "Mission",
+               "name": [
+                    "SATURN SMALL SATELLITE ASTROMETRY"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.saturn_small_satellite_astrometry::1.1"
           },
           {
-               "name": "951 GASPRA",
-               "type": "ASTEROID",
+               "name": [
+                    "951 GASPRA"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.951_gaspra::1.0"
           },
           {
-               "name": "RADIO SCIENCE SUBSYSTEM",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "RADIO SCIENCE SUBSYSTEM"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:rss-vg1s.vg1::1.0"
           },
           {
-               "name": "2000 PW29",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2000 PW29"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2000_pw29::1.0"
           },
           {
-               "name": "63 AUSONIA",
-               "type": "ASTEROID",
+               "name": [
+                    "63 AUSONIA"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.63_ausonia::1.1"
           },
           {
-               "name": "ULTRAVIOLET SPECTROMETER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "ULTRAVIOLET SPECTROMETER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:uvs.vg2::1.0"
           },
           {
-               "name": "LAOMEDEIA",
-               "type": "SATELLITE",
+               "name": [
+                    "LAOMEDEIA"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.neptune.laomedeia::1.1"
           },
           {
-               "name": "COSPIN-LOW ENERGY TELESCOPE",
-               "type": "PARTICLE DETECTOR",
+               "name": [
+                    "COSPIN-LOW ENERGY TELESCOPE"
+               ],
+               "type": [
+                    "PARTICLE DETECTOR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:cospin-let.uly::1.0"
           },
           {
-               "name": "1995 DB2",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "1995 DB2"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.1995_db2::1.0"
           },
           {
-               "name": "2003 LA7",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2003 LA7"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2003_la7::1.0"
           },
           {
-               "name": "2000 AF255",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2000 AF255"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2000_af255::1.0"
           },
           {
-               "name": "2003 QZ111",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2003 QZ111"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2003_qz111::1.0"
           },
           {
-               "name": "POLYDEUCES",
-               "type": "SATELLITE",
+               "name": [
+                    "POLYDEUCES"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.polydeuces::1.1"
           },
           {
-               "name": "HERMIPPE",
-               "type": "SATELLITE",
+               "name": [
+                    "HERMIPPE"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.hermippe::1.1"
           },
           {
-               "name": "(300194) 2006 WC95",
-               "type": "ASTEROID",
+               "name": [
+                    "(300194) 2006 WC95"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300194_2006_wc95::1.0"
           },
           {
-               "name": "LONG-WAVELENGTH PRIME",
-               "type": "SPECTROGRAPH",
+               "name": [
+                    "LONG-WAVELENGTH PRIME"
+               ],
+               "type": [
+                    "SPECTROGRAPH"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:lwp.iue::1.0"
           },
           {
-               "name": "PHOENIX",
-               "type": "Mission",
+               "name": [
+                    "PHOENIX"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.phoenix::1.1"
           },
           {
-               "name": "S/2010 J 2",
-               "type": "SATELLITE",
+               "name": [
+                    "S/2010 J 2"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.s2010j2::1.1"
           },
           {
-               "name": "VENUS LABORATORY ANALOG",
-               "type": "LABORATORY ANALOG",
+               "name": [
+                    "VENUS LABORATORY ANALOG"
+               ],
+               "type": [
+                    "LABORATORY ANALOG"
+               ],
                "lidvid": "urn:nasa:pds:context:target:laboratory_analog.venus::1.0"
           },
           {
-               "name": "(87555) 2000 QB243",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(87555) 2000 QB243"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.87555_2000_qb243::1.0"
           },
           {
-               "name": "DARK",
-               "type": "CALIBRATION FIELD",
+               "name": [
+                    "DARK"
+               ],
+               "type": [
+                    "CALIBRATION FIELD"
+               ],
                "lidvid": "urn:nasa:pds:context:target:calibration_field.dark::1.0"
           },
           {
-               "name": "MUNDILFARI",
-               "type": "SATELLITE",
+               "name": [
+                    "MUNDILFARI"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.mundilfari::1.1"
           },
           {
-               "name": "TITAN WIND TUNNEL",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "TITAN WIND TUNNEL"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:pal.twt::1.0"
           },
           {
-               "name": "TERAHERTZ FAR-INFRARED BEAMLINE AT THE AUSTRALIAN SYNCHROTRON FACILITY",
-               "type": "SPECTROMETER",
+               "name": [
+                    "TERAHERTZ FAR-INFRARED BEAMLINE AT THE AUSTRALIAN SYNCHROTRON FACILITY"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:asf.thz_farir_beamline::1.0"
           },
           {
-               "name": "VEGA 1",
-               "type": "Mission",
+               "name": [
+                    "VEGA 1"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.vega_1::1.1"
           },
           {
-               "name": "D/1993 F2-P2 (SHOEMAKER-LEVY 9-P2)",
-               "type": "COMET",
+               "name": [
+                    "D/1993 F2-P2 (SHOEMAKER-LEVY 9-P2)"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.d1993_f2-p2_shoemaker-levy_9-p2::1.0"
           },
           {
-               "name": "(82158) 2001 FP185",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(82158) 2001 FP185"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.82158_2001_fp185::1.0"
           },
           {
-               "name": "596 SCHEILA",
-               "type": "ASTEROID",
+               "name": [
+                    "596 SCHEILA"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.596_scheila::1.1"
           },
           {
-               "name": "CHARON",
-               "type": "SATELLITE",
+               "name": [
+                    "CHARON"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.134340_pluto.charon::1.1"
           },
           {
-               "name": "CALLIRRHOE",
-               "type": "SATELLITE",
+               "name": [
+                    "CALLIRRHOE"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.callirrhoe::1.1"
           },
           {
-               "name": "9860 ARCHAEOPTERYX",
-               "type": "ASTEROID",
+               "name": [
+                    "9860 ARCHAEOPTERYX"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.9860_archaeopteryx::1.1"
           },
           {
-               "name": "GREIP",
-               "type": "SATELLITE",
+               "name": [
+                    "GREIP"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.greip::1.1"
           },
           {
-               "name": "(55565) 2002 AW197",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(55565) 2002 AW197"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.55565_2002_aw197::1.0"
           },
           {
-               "name": "SATELLITE",
-               "type": "SATELLITE",
+               "name": [
+                    "SATELLITE"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.satellite::1.0"
           },
           {
-               "name": "4P/FAYE",
-               "type": "COMET",
+               "name": [
+                    "4P/FAYE"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.4p_faye::1.0"
           },
           {
-               "name": "UNKNOWN",
-               "type": "CALIBRATOR",
+               "name": [
+                    "UNKNOWN"
+               ],
+               "type": [
+                    "CALIBRATOR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:calibrator.unk::1.0"
           },
           {
-               "name": "2004 PA108",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2004 PA108"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2004_pa108::1.0"
           },
           {
-               "name": "(300256) 2007 GV60",
-               "type": "ASTEROID",
+               "name": [
+                    "(300256) 2007 GV60"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300256_2007_gv60::1.0"
           },
           {
-               "name": "LUNAR PROSPECTOR",
-               "type": "Spacecraft",
+               "name": [
+                    "LUNAR PROSPECTOR"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.lp::1.1"
           },
           {
-               "name": "2000 PL30",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2000 PL30"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2000_pl30::1.0"
           },
           {
-               "name": "ULTRAVIOLET PHOTOMETER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "ULTRAVIOLET PHOTOMETER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:uv.p10::1.0"
           },
           {
-               "name": "PLASMA EXPERIMENT FOR PLANETARY EXPLORATION",
-               "type": "SPECTROMETER",
+               "name": [
+                    "PLASMA EXPERIMENT FOR PLANETARY EXPLORATION"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:pepe.ds1::1.0"
           },
           {
-               "name": "2002 PU170",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2002 PU170"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2002_pu170::1.0"
           },
           {
-               "name": "2007 TA418",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2007 TA418"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2007_ta418::1.0"
           },
           {
-               "name": "(145451) 2005 RM43",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(145451) 2005 RM43"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.145451_2005_rm43::1.0"
           },
           {
-               "name": "MARS PATHFINDER LANDER",
-               "type": "Spacecraft",
+               "name": [
+                    "MARS PATHFINDER LANDER"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.mpfl::1.1"
           },
           {
-               "name": "2000 PF30",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2000 PF30"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2000_pf30::1.0"
           },
           {
-               "name": "CARPO",
-               "type": "SATELLITE",
+               "name": [
+                    "CARPO"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.carpo::1.1"
           },
           {
-               "name": "APOLLO 17 COMMAND AND SERVICE MODULE",
-               "type": "Spacecraft",
+               "name": [
+                    "APOLLO 17 COMMAND AND SERVICE MODULE"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.a17c::1.1"
           },
           {
-               "name": "(300213) 2006 WC156",
-               "type": "ASTEROID",
+               "name": [
+                    "(300213) 2006 WC156"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300213_2006_wc156::1.0"
           },
           {
-               "name": "54 ALEXANDRA",
-               "type": "ASTEROID",
+               "name": [
+                    "54 ALEXANDRA"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.54_alexandra::1.1"
           },
           {
-               "name": "1997 CV29",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "1997 CV29"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.1997_cv29::1.0"
           },
           {
-               "name": "Juno",
-               "type": "Spacecraft",
+               "name": [
+                    "Juno"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.jno::2.1"
           },
           {
-               "name": "MARS PATHFINDER",
-               "type": "Mission",
+               "name": [
+                    "MARS PATHFINDER"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.mars_pathfinder::1.1"
           },
           {
-               "name": "PHOBOS",
-               "type": "SATELLITE",
+               "name": [
+                    "PHOBOS"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.mars.phobos::1.1"
           },
           {
-               "name": "2004 XX190",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2004 XX190"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2004_xx190::1.0"
           },
           {
-               "name": "MINI-RF LRO",
-               "type": "RADIO-RADAR",
+               "name": [
+                    "MINI-RF LRO"
+               ],
+               "type": [
+                    "RADIO-RADAR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:mrflro.lro::1.0"
           },
           {
-               "name": "7543 PRYLIS",
-               "type": "ASTEROID",
+               "name": [
+                    "7543 PRYLIS"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.7543_prylis::1.1"
           },
           {
-               "name": "MARINER71",
-               "type": "Mission",
+               "name": [
+                    "MARINER71"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.mariner71::1.0"
           },
           {
-               "name": "2004 KB19",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2004 KB19"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2004_kb19::1.0"
           },
           {
-               "name": "FERDINAND",
-               "type": "SATELLITE",
+               "name": [
+                    "FERDINAND"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.uranus.ferdinand::1.1"
           },
           {
-               "name": "SOLAR AND HELIOSPHERIC OBSERVATORY",
-               "type": "Spacecraft",
+               "name": [
+                    "SOLAR AND HELIOSPHERIC OBSERVATORY"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.soho::1.0"
           },
           {
-               "name": "DEEP SPACE",
-               "type": "CALIBRATION FIELD",
+               "name": [
+                    "DEEP SPACE"
+               ],
+               "type": [
+                    "CALIBRATION FIELD"
+               ],
                "lidvid": "urn:nasa:pds:context:target:calibration_field.deep_space::1.0"
           },
           {
-               "name": "2002 PV170",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2002 PV170"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2002_pv170::1.0"
           },
           {
-               "name": "(300239) 2007 CO25",
-               "type": "ASTEROID",
+               "name": [
+                    "(300239) 2007 CO25"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300239_2007_co25::1.0"
           },
           {
-               "name": "8P/TUTTLE",
-               "type": "COMET",
+               "name": [
+                    "8P/TUTTLE"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.8p_tuttle::1.0"
           },
           {
-               "name": "PHOBOS 2",
-               "type": "Spacecraft",
+               "name": [
+                    "PHOBOS 2"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.phb2::1.1"
           },
           {
-               "name": "2003 QV90",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2003 QV90"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2003_qv90::1.0"
           },
           {
-               "name": "2003 WA191",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2003 WA191"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2003_wa191::1.0"
           },
           {
-               "name": "ORBITER NEUTRAL MASS SPECTROMETER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "ORBITER NEUTRAL MASS SPECTROMETER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:onms.pvo::1.0"
           },
           {
-               "name": "SUPRA-THERMAL AND THERMAL ION COMPOSITION",
-               "type": "PLASMA ANALYZER",
+               "name": [
+                    "SUPRA-THERMAL AND THERMAL ION COMPOSITION"
+               ],
+               "type": [
+                    "PLASMA ANALYZER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:static.maven::1.0"
           },
           {
-               "name": "2002 VD130",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2002 VD130"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2002_vd130::1.0"
           },
           {
-               "name": "PASITHEE",
-               "type": "SATELLITE",
+               "name": [
+                    "PASITHEE"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.pasithee::1.1"
           },
           {
-               "name": "113 AMALTHEA",
-               "type": "ASTEROID",
+               "name": [
+                    "113 AMALTHEA"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.113_amalthea::1.1"
           },
           {
-               "name": "2001 OM109",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2001 OM109"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2001_om109::1.0"
           },
           {
-               "name": "(78799) 2002 XW93",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(78799) 2002 XW93"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.78799_2002_xw93::1.0"
           },
           {
-               "name": "APOLLO 17 LUNAR MODULE",
-               "type": "Spacecraft",
+               "name": [
+                    "APOLLO 17 LUNAR MODULE"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.a17l::1.1"
           },
           {
-               "name": "(307463) 2002 VU130",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(307463) 2002 VU130"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.307463_2002_vu130::1.0"
           },
           {
-               "name": "2003 QX113",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2003 QX113"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2003_qx113::1.0"
           },
           {
-               "name": "(16684) 1994 JQ1",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "ARCTURUS"
+               ],
+               "type": [
+                    "STAR"
+               ],
+               "lidvid": "urn:nasa:pds:context:target:star.alf_boo::1.0"
+          },
+          {
+               "name": [
+                    "(16684) 1994 JQ1"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.16684_1994_jq1::1.0"
           },
           {
-               "name": "DIA",
-               "type": "SATELLITE",
+               "name": [
+                    "DIA"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.dia::1.1"
           },
           {
-               "name": "GALILEO DUST DETECTION SYSTEM",
-               "type": "DUST",
+               "name": [
+                    "GALILEO DUST DETECTION SYSTEM"
+               ],
+               "type": [
+                    "DUST"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:gdds.go::1.0"
           },
           {
-               "name": "S/2003 J 2",
-               "type": "SATELLITE",
+               "name": [
+                    "S/2003 J 2"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.s2003j2::1.1"
           },
           {
-               "name": "1998 WV31",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "1998 WV31"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.1998_wv31::1.0"
           },
           {
-               "name": "DOPPLER WIND EXPERIMENT",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "DOPPLER WIND EXPERIMENT"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:dwe.gp::1.0"
           },
           {
-               "name": "NEUTRAL MASS SPECTROMETER",
-               "type": "MASS SPECTROMETER",
+               "name": [
+                    "NEUTRAL MASS SPECTROMETER"
+               ],
+               "type": [
+                    "MASS SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:instrument.nms__ladee::1.0"
           },
           {
-               "name": "65489 CETO",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "65489 CETO"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.65489_ceto::1.1"
           },
           {
-               "name": "(225088) 2007 OR10",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(225088) 2007 OR10"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.225088_2007_or10::1.0"
           },
           {
-               "name": "(300241) 2007 CQ60",
-               "type": "ASTEROID",
+               "name": [
+                    "(300241) 2007 CQ60"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300241_2007_cq60::1.0"
           },
           {
-               "name": "JUPITER",
-               "type": "PLANET",
+               "name": [
+                    "SIRIUS"
+               ],
+               "type": [
+                    "STAR"
+               ],
+               "lidvid": "urn:nasa:pds:context:target:star.alf_cma::1.0"
+          },
+          {
+               "name": [
+                    "JUPITER"
+               ],
+               "type": [
+                    "PLANET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:planet.jupiter::1.2"
           },
           {
-               "name": "MARS PATHFINDER IMP WINDSOCKS",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "MARS PATHFINDER IMP WINDSOCKS"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:windsock.mpfl::1.0"
           },
           {
-               "name": "(55637) 2002 UX25",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(55637) 2002 UX25"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.55637_2002_ux25::1.0"
           },
           {
-               "name": "CHEMISTRY CAMERA REMOTE MICRO-IMAGER",
-               "type": "IMAGER",
+               "name": [
+                    "CHEMISTRY CAMERA REMOTE MICRO-IMAGER"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:chemcam_rmi.msl::1.0"
           },
           {
-               "name": "(504555) 2008 SO266",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(504555) 2008 SO266"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.504555_2008_so266::1.0"
           },
           {
-               "name": "90482 ORCUS",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "90482 ORCUS"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.90482_orcus::1.1"
           },
           {
-               "name": "MAGNETOMETER",
-               "type": "MAGNETOMETER",
+               "name": [
+                    "MAGNETOMETER"
+               ],
+               "type": [
+                    "MAGNETOMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:mag.mgs::1.0"
           },
           {
-               "name": "2003 QA92",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2003 QA92"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2003_qa92::1.0"
           },
           {
-               "name": "ION AND NEUTRAL MASS SPECTROMETER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "ION AND NEUTRAL MASS SPECTROMETER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:inms.co::1.0"
           },
           {
-               "name": "(486959) 2014 NX1",
-               "type": "ASTEROID",
+               "name": [
+                    "(486959) 2014 NX1"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.486959_2014_nx1::1.0"
           },
           {
-               "name": "2007 UM126",
-               "type": "CENTAUR",
+               "name": [
+                    "2007 UM126"
+               ],
+               "type": [
+                    "CENTAUR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:centaur.2007_um126::1.0"
           },
           {
-               "name": "2006 QH181",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2006 QH181"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2006_qh181::1.0"
           },
           {
-               "name": "AEGIR",
-               "type": "SATELLITE",
+               "name": [
+                    "AEGIR"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.aegir::1.1"
           },
           {
-               "name": "ROCK ABRASION TOOL",
-               "type": "REGOLITH PROPERTIES",
+               "name": [
+                    "ROCK ABRASION TOOL"
+               ],
+               "type": [
+                    "REGOLITH PROPERTIES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:rat.mer2::1.0"
           },
           {
-               "name": "(138537) 2000 OK67",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(138537) 2000 OK67"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.138537_2000_ok67::1.0"
           },
           {
-               "name": "GEIGER TUBE TELESCOPE",
-               "type": "PARTICLE DETECTOR",
+               "name": [
+                    "GEIGER TUBE TELESCOPE"
+               ],
+               "type": [
+                    "PARTICLE DETECTOR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:gtt.p10::1.0"
           },
           {
-               "name": "MARINER 6 NARROW ANGLE CAMERA",
-               "type": "IMAGER",
+               "name": [
+                    "MARINER 6 NARROW ANGLE CAMERA"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:nac.mr6::1.0"
           },
           {
-               "name": "15651 TLEPOLEMOS",
-               "type": "ASTEROID",
+               "name": [
+                    "15651 TLEPOLEMOS"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.15651_tlepolemos::1.1"
           },
           {
-               "name": "PLASMA WAVE RECEIVER",
-               "type": "PLASMA WAVE SPECTROMETER",
+               "name": [
+                    "PLASMA WAVE RECEIVER"
+               ],
+               "type": [
+                    "PLASMA WAVE SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:pws.vg1::1.0"
           },
           {
-               "name": "31 LEONIS",
-               "type": "STAR",
+               "name": [
+                    "31 LEONIS"
+               ],
+               "type": [
+                    "STAR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:star.31_leo::1.0"
           },
           {
-               "name": "2201 OLJATO",
-               "type": "ASTEROID",
+               "name": [
+                    "2201 OLJATO"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.2201_oljato::1.1"
           },
           {
-               "name": "(300165) 2006 VW140",
-               "type": "ASTEROID",
+               "name": [
+                    "(300165) 2006 VW140"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300165_2006_vw140::1.0"
           },
           {
-               "name": "IOCASTE",
-               "type": "SATELLITE",
+               "name": [
+                    "IOCASTE"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.iocaste::1.1"
           },
           {
-               "name": "DEEP IMPACT MEDIUM RESOLUTION INSTRUMENT - VISIBLE CCD",
-               "type": "IMAGER",
+               "name": [
+                    "DEEP IMPACT MEDIUM RESOLUTION INSTRUMENT - VISIBLE CCD"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:mri.dif::1.0"
           },
           {
-               "name": "38628 HUYA",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "38628 HUYA"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.38628_huya::1.1"
           },
           {
-               "name": "MARS RECONNAISSANCE ORBITER",
-               "type": "Mission",
+               "name": [
+                    "MARS RECONNAISSANCE ORBITER"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.mars_reconnaissance_orbiter::1.0"
           },
           {
-               "name": "IMAGING SCIENCE SUBSYSTEM - NARROW ANGLE",
-               "type": "IMAGER",
+               "name": [
+                    "IMAGING SCIENCE SUBSYSTEM - NARROW ANGLE"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:issna.co::1.0"
           },
           {
-               "name": "3361 ORPHEUS",
-               "type": "ASTEROID",
+               "name": [
+                    "3361 ORPHEUS"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.3361_orpheus::1.1"
           },
           {
-               "name": "DUST IMPACT MASS ANALYZER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "DUST IMPACT MASS ANALYZER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:puma.vega1::1.0"
           },
           {
-               "name": "ELNATH",
-               "type": "STAR",
+               "name": [
+                    "ELNATH"
+               ],
+               "type": [
+                    "STAR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:star.bet_tau::1.0"
           },
           {
-               "name": "CLEMENTINE 1",
-               "type": "Spacecraft",
+               "name": [
+                    "CLEMENTINE 1"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.clem1::1.1"
           },
           {
-               "name": "S/2004 S 17",
-               "type": "SATELLITE",
+               "name": [
+                    "S/2004 S 17"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.s2004s17::1.1"
           },
           {
-               "name": "RADIO SCIENCE SUBSYSTEM",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "RADIO SCIENCE SUBSYSTEM"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:rss.mo::1.0"
           },
           {
-               "name": "2001 QE298",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2001 QE298"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2001_qe298::1.0"
           },
           {
-               "name": "2000 WV12",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2000 WV12"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2000_wv12::1.0"
           },
           {
-               "name": "5535 ANNEFRANK",
-               "type": "ASTEROID",
+               "name": [
+                    "5535 ANNEFRANK"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.5535_annefrank::1.0"
           },
           {
-               "name": "243 IDA",
-               "type": "ASTEROID",
+               "name": [
+                    "243 IDA"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.243_ida::1.1"
           },
           {
-               "name": "1999 CF119",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "1999 CF119"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.1999_cf119::1.0"
           },
           {
-               "name": "2003 YL179",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2003 YL179"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2003_yl179::1.0"
           },
           {
-               "name": "SAKIGAKE",
-               "type": "Spacecraft",
+               "name": [
+                    "SAKIGAKE"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.sakig::1.1"
           },
           {
-               "name": "2000 OU69",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2000 OU69"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2000_ou69::1.0"
           },
           {
-               "name": "26P/GRIGG-SKJELLERUP",
-               "type": "COMET",
+               "name": [
+                    "26P/GRIGG-SKJELLERUP"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.26p_grigg-skjellerup::1.0"
           },
           {
-               "name": "IO",
-               "type": "SATELLITE",
+               "name": [
+                    "IO"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.io::1.1"
           },
           {
-               "name": "2001 KH76",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2001 KH76"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2001_kh76::1.0"
           },
           {
-               "name": "ACCELEROMETER",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "ACCELEROMETER"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:accel.ody::1.0"
           },
           {
-               "name": "(508869) 2002 VT130",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(508869) 2002 VT130"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.508869_2002_vt130::1.0"
           },
           {
-               "name": "UMBRIEL",
-               "type": "SATELLITE",
+               "name": [
+                    "UMBRIEL"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.uranus.umbriel::1.1"
           },
           {
-               "name": "(300249) 2007 EE218",
-               "type": "ASTEROID",
+               "name": [
+                    "(300249) 2007 EE218"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300249_2007_ee218::1.0"
           },
           {
-               "name": "1999 OJ4",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "1999 OJ4"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.1999_oj4::1.0"
           },
           {
-               "name": "KRFM-COMBINED RADIOMETER SPECTROPHOTOMETER FOR MARS",
-               "type": "RADIOMETER",
+               "name": [
+                    "KRFM-COMBINED RADIOMETER SPECTROPHOTOMETER FOR MARS"
+               ],
+               "type": [
+                    "RADIOMETER",
+                    "PHOTOMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:krfm.phb2::1.0"
           },
           {
-               "name": "MAGNETOMETER",
-               "type": "MAGNETOMETER",
+               "name": [
+                    "MAGNETOMETER"
+               ],
+               "type": [
+                    "MAGNETOMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:mag.lp::1.0"
           },
           {
-               "name": "D/1993 F2-B (SHOEMAKER-LEVY 9-B)",
-               "type": "COMET",
+               "name": [
+                    "D/1993 F2-B (SHOEMAKER-LEVY 9-B)"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.d1993_f2-b_shoemaker-levy_9-b::1.0"
           },
           {
-               "name": "GALATEA",
-               "type": "SATELLITE",
+               "name": [
+                    "GALATEA"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.neptune.galatea::1.1"
           },
           {
-               "name": "(181855) 1998 WT31",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(181855) 1998 WT31"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.181855_1998_wt31::1.0"
           },
           {
-               "name": "THETA CRATERIS",
-               "type": "STAR",
+               "name": [
+                    "THETA CRATERIS"
+               ],
+               "type": [
+                    "STAR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:star.tet_crt::1.0"
           },
           {
-               "name": "19521 CHAOS",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "19521 CHAOS"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.19521_chaos::1.1"
           },
           {
-               "name": "IMAGING SCIENCE SUBSYSTEM",
-               "type": "IMAGER",
+               "name": [
+                    "IMAGING SCIENCE SUBSYSTEM"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:iss.mr9::1.0"
           },
           {
-               "name": "MULTI-SPECTRAL IMAGER",
-               "type": "IMAGER",
+               "name": [
+                    "MULTI-SPECTRAL IMAGER"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:msi.near::1.0"
           },
           {
-               "name": "(160427) 2005 RL43",
-               "type": "CENTAUR",
+               "name": [
+                    "(160427) 2005 RL43"
+               ],
+               "type": [
+                    "CENTAUR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:centaur.160427_2005_rl43::1.0"
           },
           {
-               "name": "(477410) 2009 VG86",
-               "type": "ASTEROID",
+               "name": [
+                    "(477410) 2009 VG86"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.477410_2009_vg86::1.0"
           },
           {
-               "name": "2003 CC22",
-               "type": "CENTAUR",
+               "name": [
+                    "2003 CC22"
+               ],
+               "type": [
+                    "CENTAUR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:centaur.2003_cc22::1.0"
           },
           {
-               "name": "7126 CUREAU",
-               "type": "ASTEROID",
+               "name": [
+                    "7126 CUREAU"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.7126_cureau::1.1"
           },
           {
-               "name": "15810 ARAWN",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "15810 ARAWN"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.15810_arawn::1.1"
           },
           {
-               "name": "47P/ASHBROOK-JACKSON",
-               "type": "COMET",
+               "name": [
+                    "47P/ASHBROOK-JACKSON"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.47p_ashbrook-jackson::1.0"
           },
           {
-               "name": "OB STAR",
-               "type": "CALIBRATION FIELD",
+               "name": [
+                    "OB STAR"
+               ],
+               "type": [
+                    "CALIBRATION FIELD"
+               ],
                "lidvid": "urn:nasa:pds:context:target:calibration_field.ob_star::1.0"
           },
           {
-               "name": "GRAVITY RECOVERY AND INTERIOR LABORATORY",
-               "type": "Mission",
+               "name": [
+                    "GRAVITY RECOVERY AND INTERIOR LABORATORY"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.gravity_recovery_and_interior_laboratory::1.1"
           },
           {
-               "name": "(29481) 1997 VJ3",
-               "type": "ASTEROID",
+               "name": [
+                    "(29481) 1997 VJ3"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.29481_1997_vj3::1.0"
           },
           {
-               "name": "(137294) 1999 RE215",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(137294) 1999 RE215"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.137294_1999_re215::1.0"
           },
           {
-               "name": "DEIMOS",
-               "type": "SATELLITE",
+               "name": [
+                    "DEIMOS"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.mars.deimos::1.1"
           },
           {
-               "name": "VOYAGER 1",
-               "type": "Spacecraft",
+               "name": [
+                    "VOYAGER 1"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.vg1::1.1"
           },
           {
-               "name": "MESSENGER",
-               "type": "Mission",
+               "name": [
+                    "MESSENGER"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.messenger::1.1"
           },
           {
-               "name": "(307251) 2002 KW14",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(307251) 2002 KW14"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.307251_2002_kw14::1.0"
           },
           {
-               "name": "CONTOUR MISSION",
-               "type": "Mission",
+               "name": [
+                    "CONTOUR MISSION"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.contour_mission::1.0"
           },
           {
-               "name": "CONTOUR REMOTE IMAGING SPECTROGRAPH - IMAGER",
-               "type": "IMAGER",
+               "name": [
+                    "CONTOUR REMOTE IMAGING SPECTROGRAPH - IMAGER"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:crispimag.con::1.0"
           },
           {
-               "name": "HELIUM VECTOR MAGNETOMETER",
-               "type": "MAGNETOMETER",
+               "name": [
+                    "HELIUM VECTOR MAGNETOMETER"
+               ],
+               "type": [
+                    "MAGNETOMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:hvm.p10::1.0"
           },
           {
-               "name": "CALIMG",
-               "type": "CALIBRATOR",
+               "name": [
+                    "CALIMG"
+               ],
+               "type": [
+                    "CALIBRATOR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:calibrator.calimg::1.0"
           },
           {
-               "name": "2005 JP179",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2005 JP179"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2005_jp179::1.0"
           },
           {
-               "name": "(385191) 1997 RT5",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(385191) 1997 RT5"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.385191_1997_rt5::1.0"
           },
           {
-               "name": "103P/HARTLEY 2",
-               "type": "COMET",
+               "name": [
+                    "103P/HARTLEY 2"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.103p_hartley_2::1.1"
           },
           {
-               "name": "BOPPS INFRARED CAMERA (BIRC)",
-               "type": "IMAGER",
+               "name": [
+                    "BOPPS INFRARED CAMERA (BIRC)"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:telescope.birc.sto::1.0"
           },
           {
-               "name": "(13331) 1998 SU52",
-               "type": "ASTEROID",
+               "name": [
+                    "(13331) 1998 SU52"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.13331_1998_su52::1.0"
           },
           {
-               "name": "1999 CX131",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "1999 CX131"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.1999_cx131::1.0"
           },
           {
-               "name": "NEAR-INFRARED SPECTROMETER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "NEAR-INFRARED SPECTROMETER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:nirs.hay::1.0"
           },
           {
-               "name": "AEROSOL COLLECTOR PYROLYSER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "AEROSOL COLLECTOR PYROLYSER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:acp.hp::1.0"
           },
           {
-               "name": "2001 QP297",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2001 QP297"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2001_qp297::1.0"
           },
           {
-               "name": "108P/CIFFREO",
-               "type": "COMET",
+               "name": [
+                    "108P/CIFFREO"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.108p_ciffreo::1.0"
           },
           {
-               "name": "GIOTTO RADIOSCIENCE EXPERIMENT",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "GIOTTO RADIOSCIENCE EXPERIMENT"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:gre.gio::1.0"
           },
           {
-               "name": "1906 NAEF",
-               "type": "ASTEROID",
+               "name": [
+                    "1906 NAEF"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.1906_naef::1.1"
           },
           {
-               "name": "LOW ENERGY CHARGED PARTICLE",
-               "type": "PARTICLE DETECTOR",
+               "name": [
+                    "LOW ENERGY CHARGED PARTICLE"
+               ],
+               "type": [
+                    "PARTICLE DETECTOR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:lecp.vg2::1.0"
           },
           {
-               "name": "DEEP IMPACT IMPACTOR TARGETING SENSOR - VISIBLE CCD",
-               "type": "IMAGER",
+               "name": [
+                    "DEEP IMPACT IMPACTOR TARGETING SENSOR - VISIBLE CCD"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:its.dii::1.0"
           },
           {
-               "name": "(5025) 1986 TS6",
-               "type": "ASTEROID",
+               "name": [
+                    "(5025) 1986 TS6"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.5025_1986_ts6::1.0"
           },
           {
-               "name": "(300251) 2007 FX26",
-               "type": "ASTEROID",
+               "name": [
+                    "(300251) 2007 FX26"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300251_2007_fx26::1.0"
           },
           {
-               "name": "3659 BELLINGSHAUSEN",
-               "type": "ASTEROID",
+               "name": [
+                    "3659 BELLINGSHAUSEN"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.3659_bellingshausen::1.1"
           },
           {
-               "name": "MARS GLOBAL SURVEYOR",
-               "type": "Spacecraft",
+               "name": [
+                    "MARS GLOBAL SURVEYOR"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.mgs::1.1"
           },
           {
-               "name": "ARCHE",
-               "type": "SATELLITE",
+               "name": [
+                    "ARCHE"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.arche::1.1"
           },
           {
-               "name": "(385458) 2003 SP317",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(385458) 2003 SP317"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.385458_2003_sp317::1.0"
           },
           {
-               "name": "2005 GD187",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2005 GD187"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2005_gd187::1.0"
           },
           {
-               "name": "32532 THEREUS",
-               "type": "CENTAUR",
+               "name": [
+                    "32532 THEREUS"
+               ],
+               "type": [
+                    "CENTAUR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:centaur.32532_thereus::1.0"
           },
           {
-               "name": "MICROWAVE INSTRUMENT FOR THE ROSETTA ORBITER",
-               "type": "RADIOMETER",
+               "name": [
+                    "MICROWAVE INSTRUMENT FOR THE ROSETTA ORBITER"
+               ],
+               "type": [
+                    "RADIOMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:miro.ro::1.0"
           },
           {
-               "name": "LINEAR ETALON IMAGING SPECTRAL ARRAY",
-               "type": "SPECTROMETER",
+               "name": [
+                    "LINEAR ETALON IMAGING SPECTRAL ARRAY"
+               ],
+               "type": [
+                    "SPECTROMETER",
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:leisa.nh::1.0"
           },
           {
-               "name": "22 KALLIOPE",
-               "type": "ASTEROID",
+               "name": [
+                    "22 KALLIOPE"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.22_kalliope::1.1"
           },
           {
-               "name": "(168700) 2000 GE147",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(168700) 2000 GE147"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.168700_2000_ge147::1.0"
           },
           {
-               "name": "(24403) 2000 AX193",
-               "type": "ASTEROID",
+               "name": [
+                    "(24403) 2000 AX193"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.24403_2000_ax193::1.0"
           },
           {
-               "name": "(148209) 2000 CR105",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(148209) 2000 CR105"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.148209_2000_cr105::1.0"
           },
           {
-               "name": "65 CYBELE",
-               "type": "ASTEROID",
+               "name": [
+                    "65 CYBELE"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.65_cybele::1.1"
           },
           {
-               "name": "(408832) 2001 QJ298",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(408832) 2001 QJ298"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.408832_2001_qj298::1.0"
           },
           {
-               "name": "OPHELIA",
-               "type": "SATELLITE",
+               "name": [
+                    "OPHELIA"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.uranus.ophelia::1.1"
           },
           {
-               "name": "C/2014 Q2 (LOVEJOY)",
-               "type": "COMET",
+               "name": [
+                    "C/2014 Q2 (LOVEJOY)"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.c2014_q2_lovejoy::1.0"
           },
           {
-               "name": "(506496) 2003 UZ377",
-               "type": "ASTEROID",
+               "name": [
+                    "(506496) 2003 UZ377"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.506496_2003_uz377::1.0"
           },
           {
-               "name": "107 CAMILLA",
-               "type": "ASTEROID",
+               "name": [
+                    "107 CAMILLA"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.107_camilla::1.1"
           },
           {
-               "name": "2000 CJ105",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2000 CJ105"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2000_cj105::1.0"
           },
           {
-               "name": "(385527) 2004 OK14",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(385527) 2004 OK14"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.385527_2004_ok14::1.0"
           },
           {
-               "name": "(87269) 2000 OO67",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(87269) 2000 OO67"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.87269_2000_oo67::1.0"
           },
           {
-               "name": "GANYMEDE",
-               "type": "SATELLITE",
+               "name": [
+                    "GANYMEDE"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.ganymede::1.1"
           },
           {
-               "name": "2007 VL305",
-               "type": "CENTAUR",
+               "name": [
+                    "2007 VL305"
+               ],
+               "type": [
+                    "CENTAUR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:centaur.2007_vl305::1.0"
           },
           {
-               "name": "(300237) 2006 YD45",
-               "type": "ASTEROID",
+               "name": [
+                    "(300237) 2006 YD45"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300237_2006_yd45::1.0"
           },
           {
-               "name": "DEEP IMPACT HIGH RESOLUTION INSTRUMENT - IR SPECTROMETER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "DEEP IMPACT HIGH RESOLUTION INSTRUMENT - IR SPECTROMETER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:hrii.dif::1.0"
           },
           {
-               "name": "2002 XV93",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2002 XV93"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2002_xv93::1.0"
           },
           {
-               "name": "45P/HONDA-MRKOS-PAJDUSAKOVA",
-               "type": "COMET",
+               "name": [
+                    "45P/HONDA-MRKOS-PAJDUSAKOVA"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.45p_honda-mrkos-pajdusakova::1.0"
           },
           {
-               "name": "2005 EF304",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2005 EF304"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2005_ef304::1.0"
           },
           {
-               "name": "NARVI",
-               "type": "SATELLITE",
+               "name": [
+                    "NARVI"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.narvi::1.1"
           },
           {
-               "name": "52872 OKYRHOE",
-               "type": "CENTAUR",
+               "name": [
+                    "52872 OKYRHOE"
+               ],
+               "type": [
+                    "CENTAUR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:centaur.52872_okyrhoe::1.0"
           },
           {
-               "name": "NEAR EARTH ASTEROID RENDEZVOUS",
-               "type": "Spacecraft",
+               "name": [
+                    "NEAR EARTH ASTEROID RENDEZVOUS"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.near::1.1"
           },
           {
-               "name": "2001 XU254",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2001 XU254"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2001_xu254::1.0"
           },
           {
-               "name": "TRAPPED RADIATION DETECTOR",
-               "type": "PARTICLE DETECTOR",
+               "name": [
+                    "TRAPPED RADIATION DETECTOR"
+               ],
+               "type": [
+                    "PARTICLE DETECTOR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:trd.p10::1.0"
           },
           {
-               "name": "A STAR TRACKER CAMERA",
-               "type": "IMAGER",
+               "name": [
+                    "A STAR TRACKER CAMERA"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:a-star.clem1::1.0"
           },
           {
-               "name": "CONTOUR REMOTE IMAGING SPECTROGRAPH - SPECTROMETER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "CONTOUR REMOTE IMAGING SPECTROGRAPH - SPECTROMETER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:crispspec.con::1.0"
           },
           {
-               "name": "STEPHANO",
-               "type": "SATELLITE",
+               "name": [
+                    "STEPHANO"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.uranus.stephano::1.1"
           },
           {
-               "name": "(119878) 2002 CY224",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(119878) 2002 CY224"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.119878_2002_cy224::1.0"
           },
           {
-               "name": "2003 QW113",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2003 QW113"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2003_qw113::1.0"
           },
           {
-               "name": "(45590) 2000 CU101",
-               "type": "ASTEROID",
+               "name": [
+                    "(45590) 2000 CU101"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.45590_2000_cu101::1.0"
           },
           {
-               "name": "74P/SMIRNOVA-CHERNYKH",
-               "type": "COMET",
+               "name": [
+                    "74P/SMIRNOVA-CHERNYKH"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.74p_smirnova-chernykh::1.0"
           },
           {
-               "name": "APOLLO 15 COLD CATHODE ION GAGE EXPERIMENT",
-               "type": "PARTICLE DETECTOR",
+               "name": [
+                    "APOLLO 15 COLD CATHODE ION GAGE EXPERIMENT"
+               ],
+               "type": [
+                    "PARTICLE DETECTOR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:ccig.a15a::2.0"
           },
           {
-               "name": "INTERNATIONAL CENTRE FOR EREMOLOGY WIND TUNNEL, GHENT UNIVERSITY, BELGIUM",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "INTERNATIONAL CENTRE FOR EREMOLOGY WIND TUNNEL, GHENT UNIVERSITY, BELGIUM"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:ghent-ice.ice_wt::1.0"
           },
           {
-               "name": "SKATHI",
-               "type": "SATELLITE",
+               "name": [
+                    "SKATHI"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.skathi::1.1"
           },
           {
-               "name": "(119066) 2001 KJ76",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(119066) 2001 KJ76"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.119066_2001_kj76::1.0"
           },
           {
-               "name": "EUPORIE",
-               "type": "SATELLITE",
+               "name": [
+                    "EUPORIE"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.euporie::1.1"
           },
           {
-               "name": "D/1993 F2-V (SHOEMAKER-LEVY 9-V)",
-               "type": "COMET",
+               "name": [
+                    "D/1993 F2-V (SHOEMAKER-LEVY 9-V)"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.d1993_f2-v_shoemaker-levy_9-v::1.0"
           },
           {
-               "name": "(469362) 2001 KB77",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(469362) 2001 KB77"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.469362_2001_kb77::1.0"
           },
           {
-               "name": "PROSPERO",
-               "type": "SATELLITE",
+               "name": [
+                    "PROSPERO"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.uranus.prospero::1.1"
           },
           {
-               "name": "S/2003 J 12",
-               "type": "SATELLITE",
+               "name": [
+                    "S/2003 J 12"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.s2003j12::1.1"
           },
           {
-               "name": "PLASMA WAVE RECEIVER",
-               "type": "PLASMA WAVE SPECTROMETER",
+               "name": [
+                    "PLASMA WAVE RECEIVER"
+               ],
+               "type": [
+                    "PLASMA WAVE SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:pws.vg2::1.0"
           },
           {
-               "name": "X-RAY SPECTROMETER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "X-RAY SPECTROMETER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:xrs.mess::1.1"
           },
           {
-               "name": "GAS CHROMATOGRAPH MASS SPECTROMETER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "GAS CHROMATOGRAPH MASS SPECTROMETER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:gcms.hp::1.0"
           },
           {
-               "name": "1999 CM158",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "1999 CM158"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.1999_cm158::1.0"
           },
           {
-               "name": "(119067) 2001 KP76",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(119067) 2001 KP76"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.119067_2001_kp76::1.0"
           },
           {
-               "name": "(120216) 2004 EW95",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(120216) 2004 EW95"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.120216_2004_ew95::1.0"
           },
           {
-               "name": "CAL LAMPS",
-               "type": "CALIBRATOR",
+               "name": [
+                    "CAL LAMPS"
+               ],
+               "type": [
+                    "CALIBRATOR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:calibrator.cal_lamps::1.0"
           },
           {
-               "name": "RADIOMETER",
-               "type": "RADIOMETER",
+               "name": [
+                    "RADIOMETER"
+               ],
+               "type": [
+                    "RADIOMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:radiometer.insight::1.0"
           },
           {
-               "name": "2005 VA123",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2005 VA123"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2005_va123::1.0"
           },
           {
-               "name": "(300225) 2006 XN44",
-               "type": "ASTEROID",
+               "name": [
+                    "(300225) 2006 XN44"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300225_2006_xn44::1.0"
           },
           {
-               "name": "(13230) 1997 VG1",
-               "type": "ASTEROID",
+               "name": [
+                    "(13230) 1997 VG1"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.13230_1997_vg1::1.0"
           },
           {
-               "name": "(300226) 2006 XK51",
-               "type": "ASTEROID",
+               "name": [
+                    "(300226) 2006 XK51"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300226_2006_xk51::1.0"
           },
           {
-               "name": "SOLAR AND HELIOSPHERIC OBSERVATORY",
-               "type": "Mission",
+               "name": [
+                    "SOLAR AND HELIOSPHERIC OBSERVATORY"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.solar_and_heliospheric_observatory::1.0"
           },
           {
-               "name": "121725 APHIDAS",
-               "type": "CENTAUR",
+               "name": [
+                    "121725 APHIDAS"
+               ],
+               "type": [
+                    "CENTAUR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:centaur.121725_aphidas::1.0"
           },
           {
-               "name": "2012 HE85",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2012 HE85"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2012_he85::1.0"
           },
           {
-               "name": "2685 MASURSKY",
-               "type": "ASTEROID",
+               "name": [
+                    "2685 MASURSKY"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.2685_masursky::1.0"
           },
           {
-               "name": "NAIAD",
-               "type": "SATELLITE",
+               "name": [
+                    "NAIAD"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.neptune.naiad::1.1"
           },
           {
-               "name": "C/1996 B2 (HYAKUTAKE)",
-               "type": "COMET",
+               "name": [
+                    "C/1996 B2 (HYAKUTAKE)"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.c1996_b2_hyakutake::1.1"
           },
           {
-               "name": "NEW HORIZONS",
-               "type": "Spacecraft",
+               "name": [
+                    "NEW HORIZONS"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.nh::1.1"
           },
           {
-               "name": "ROVER CAMERA REAR",
-               "type": "IMAGER",
+               "name": [
+                    "ROVER CAMERA REAR"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:rcrr.mpfr::1.0"
           },
           {
-               "name": "(82157) 2001 FM185",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(82157) 2001 FM185"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.82157_2001_fm185::1.0"
           },
           {
-               "name": "FARBAUTI",
-               "type": "SATELLITE",
+               "name": [
+                    "FARBAUTI"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.farbauti::1.1"
           },
           {
-               "name": "(84922) 2003 VS2",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(84922) 2003 VS2"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.84922_2003_vs2::1.0"
           },
           {
-               "name": "2002 CW224",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2002 CW224"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2002_cw224::1.0"
           },
           {
-               "name": "2005 GF187",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2005 GF187"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2005_gf187::1.0"
           },
           {
-               "name": "283 EMMA",
-               "type": "ASTEROID",
+               "name": [
+                    "283 EMMA"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.283_emma::1.1"
           },
           {
-               "name": "GUELPH WIND TUNNEL AT WIND EROSION LABORATORY, DEPARTMENT OF GEOGRAPHY, UNIVERSITY OF GUELPH, ONTARIO, CANADA",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "GUELPH WIND TUNNEL AT WIND EROSION LABORATORY, DEPARTMENT OF GEOGRAPHY, UNIVERSITY OF GUELPH, ONTARIO, CANADA"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:guelph-wel.guelph_wt::1.0"
           },
           {
-               "name": "MARS",
-               "type": "PLANET",
+               "name": [
+                    "MARS"
+               ],
+               "type": [
+                    "PLANET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:planet.mars::1.2"
           },
           {
-               "name": "(300189) 2006 WU71",
-               "type": "ASTEROID",
+               "name": [
+                    "(300189) 2006 WU71"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300189_2006_wu71::1.0"
           },
           {
-               "name": "(385447) 2003 QF113",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(385447) 2003 QF113"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.385447_2003_qf113::1.0"
           },
           {
-               "name": "1998 WX31",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "1998 WX31"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.1998_wx31::1.0"
           },
           {
-               "name": "KALE",
-               "type": "SATELLITE",
+               "name": [
+                    "KALE"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.kale::1.1"
           },
           {
-               "name": "2003 UZ291",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2003 UZ291"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2003_uz291::1.0"
           },
           {
-               "name": "(300215) 2006 WC180",
-               "type": "ASTEROID",
+               "name": [
+                    "(300215) 2006 WC180"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300215_2006_wc180::1.0"
           },
           {
-               "name": "(52747) 1998 HM151",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(52747) 1998 HM151"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.52747_1998_hm151::1.0"
           },
           {
-               "name": "(469306) 1999 CD158",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(469306) 1999 CD158"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.469306_1999_cd158::1.0"
           },
           {
-               "name": "MARINER 7 NARROW ANGLE CAMERA",
-               "type": "IMAGER",
+               "name": [
+                    "MARINER 7 NARROW ANGLE CAMERA"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:nac.mr7::1.0"
           },
           {
-               "name": "TELESTO",
-               "type": "SATELLITE",
+               "name": [
+                    "TELESTO"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.telesto::1.1"
           },
           {
-               "name": "2005 EB299",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2005 EB299"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2005_eb299::1.0"
           },
           {
-               "name": "MAVEN",
-               "type": "Mission",
+               "name": [
+                    "MAVEN"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.maven::1.0"
           },
           {
-               "name": "(300201) 2006 WG101",
-               "type": "ASTEROID",
+               "name": [
+                    "(300201) 2006 WG101"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300201_2006_wg101::1.0"
           },
           {
-               "name": "LADEE",
-               "type": "Spacecraft",
+               "name": [
+                    "LADEE"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.ladee::1.0"
           },
           {
-               "name": "2011 HK103",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2011 HK103"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2011_hk103::1.0"
           },
           {
-               "name": "(38084) 1999 HB12",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(38084) 1999 HB12"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.38084_1999_hb12::1.0"
           },
           {
-               "name": "MARS GLOBAL SURVEYOR",
-               "type": "Mission",
+               "name": [
+                    "MARS GLOBAL SURVEYOR"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.mars_global_surveyor::1.1"
           },
           {
-               "name": "GAMMA RAY SPECTROMETER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "GAMMA RAY SPECTROMETER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:grs.mess::1.1"
           },
           {
-               "name": "MIDCOURSE SPACE EXPERIMENT",
-               "type": "Mission",
+               "name": [
+                    "MIDCOURSE SPACE EXPERIMENT"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.midcourse_space_experiment::1.1"
           },
           {
-               "name": "S/2016 J 1",
-               "type": "SATELLITE",
+               "name": [
+                    "S/2016 J 1"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.s2016j1::1.1"
           },
           {
-               "name": "S/2003 J 3",
-               "type": "SATELLITE",
+               "name": [
+                    "S/2003 J 3"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.s2003j3::1.1"
           },
           {
-               "name": "ROSETTA ORBITER SPECTROMETER FOR ION AND NEUTRAL ANALYSIS",
-               "type": "SPECTROMETER",
+               "name": [
+                    "ROSETTA ORBITER SPECTROMETER FOR ION AND NEUTRAL ANALYSIS"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:rosina.ro::1.0"
           },
           {
-               "name": "(130391) 2000 JG81",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(130391) 2000 JG81"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.130391_2000_jg81::1.0"
           },
           {
-               "name": "2005 ER318",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2005 ER318"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2005_er318::1.0"
           },
           {
-               "name": "INTERNAL SOURCE",
-               "type": "CALIBRATOR",
+               "name": [
+                    "INTERNAL SOURCE"
+               ],
+               "type": [
+                    "CALIBRATOR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:calibrator.internal_source::1.0"
           },
           {
-               "name": "2000 WT169",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2000 WT169"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2000_wt169::1.0"
           },
           {
-               "name": "(300185) 2006 WB62",
-               "type": "ASTEROID",
+               "name": [
+                    "(300185) 2006 WB62"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300185_2006_wb62::1.0"
           },
           {
-               "name": "109 FELICITAS",
-               "type": "ASTEROID",
+               "name": [
+                    "109 FELICITAS"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.109_felicitas::1.1"
           },
           {
-               "name": "(23144) 2000 AY182",
-               "type": "ASTEROID",
+               "name": [
+                    "(23144) 2000 AY182"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.23144_2000_ay182::1.0"
           },
           {
-               "name": "FRONT HAZARD AVOIDANCE CAMERA LEFT STRING B",
-               "type": "IMAGER",
+               "name": [
+                    "FRONT HAZARD AVOIDANCE CAMERA LEFT STRING B"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:fhaz_left_b.msl::1.0"
           },
           {
-               "name": "(300232) 2006 YL5",
-               "type": "ASTEROID",
+               "name": [
+                    "(300232) 2006 YL5"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300232_2006_yl5::1.0"
           },
           {
-               "name": "2001 QR322",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2001 QR322"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2001_qr322::1.0"
           },
           {
-               "name": "UNIFIED RADIO AND PLASMA WAVE EXPERIMENT",
-               "type": "PLASMA WAVE SPECTROMETER",
+               "name": [
+                    "UNIFIED RADIO AND PLASMA WAVE EXPERIMENT"
+               ],
+               "type": [
+                    "PLASMA WAVE SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:urap.uly::1.0"
           },
           {
-               "name": "BLACK SKY",
-               "type": "CALIBRATION FIELD",
+               "name": [
+                    "BLACK SKY"
+               ],
+               "type": [
+                    "CALIBRATION FIELD"
+               ],
                "lidvid": "urn:nasa:pds:context:target:calibration_field.black_sky::1.0"
           },
           {
-               "name": "KALYKE",
-               "type": "SATELLITE",
+               "name": [
+                    "KALYKE"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.kalyke::1.1"
           },
           {
-               "name": "2003 UV292",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2003 UV292"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2003_uv292::1.0"
           },
           {
-               "name": "INTERPLANETARY MAGNETIC FIELD",
-               "type": "MAGNETIC FIELD",
+               "name": [
+                    "INTERPLANETARY MAGNETIC FIELD"
+               ],
+               "type": [
+                    "MAGNETIC FIELD"
+               ],
                "lidvid": "urn:nasa:pds:context:target:magnetic_field.interplanetary_magnetic_field::1.0"
           },
           {
-               "name": "13 EGERIA",
-               "type": "ASTEROID",
+               "name": [
+                    "13 EGERIA"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.13_egeria::1.1"
           },
           {
-               "name": "8624 KALEYCUOCO",
-               "type": "ASTEROID",
+               "name": [
+                    "8624 KALEYCUOCO"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.8624_kaleycuoco::1.0"
           },
           {
-               "name": "ROVER ENVIRONMENTAL MONITORING STATION",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "ROVER ENVIRONMENTAL MONITORING STATION"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:rems.msl::1.0"
           },
           {
-               "name": "DEEP SPACE 1",
-               "type": "Spacecraft",
+               "name": [
+                    "DEEP SPACE 1"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.ds1::1.1"
           },
           {
-               "name": "2005 SE278",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2005 SE278"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2005_se278::1.0"
           },
           {
-               "name": "ULTRAVIOLET-VISIBLE SPECTROMETER",
-               "type": "ULTRAVIOLET SPECTROMETER",
+               "name": [
+                    "ULTRAVIOLET-VISIBLE SPECTROMETER"
+               ],
+               "type": [
+                    "ULTRAVIOLET SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:instrument.uvs__ladee::1.0"
           },
           {
-               "name": "HALLEY MULTICOLOUR CAMERA",
-               "type": "IMAGER",
+               "name": [
+                    "HALLEY MULTICOLOUR CAMERA"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:hmc.gio::1.0"
           },
           {
-               "name": "167P/CINEOS",
-               "type": "COMET",
+               "name": [
+                    "167P/CINEOS"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.167p_cineos::1.0"
           },
           {
-               "name": "EPOXI",
-               "type": "Mission",
+               "name": [
+                    "EPOXI"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.epoxi::1.1"
           },
           {
-               "name": "EXTREME ULTRAVIOLET MONITOR",
-               "type": "ULTRAVIOLET SPECTROMETER",
+               "name": [
+                    "EXTREME ULTRAVIOLET MONITOR"
+               ],
+               "type": [
+                    "ULTRAVIOLET SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:euv.maven::1.0"
           },
           {
-               "name": "12658 PEIRAIOS",
-               "type": "ASTEROID",
+               "name": [
+                    "12658 PEIRAIOS"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.12658_peiraios::1.1"
           },
           {
-               "name": "(91205) 1998 US43",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(91205) 1998 US43"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.91205_1998_us43::1.0"
           },
           {
-               "name": "DAWN",
-               "type": "Spacecraft",
+               "name": [
+                    "DAWN"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.dawn::1.1"
           },
           {
-               "name": "(40782) 1999 TX26",
-               "type": "ASTEROID",
+               "name": [
+                    "(40782) 1999 TX26"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.40782_1999_tx26::1.0"
           },
           {
-               "name": "433 EROS",
-               "type": "ASTEROID",
+               "name": [
+                    "433 EROS"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.433_eros::1.1"
           },
           {
-               "name": "TARQEQ",
-               "type": "SATELLITE",
+               "name": [
+                    "TARQEQ"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.tarqeq::1.1"
           },
           {
-               "name": "DAPHNIS",
-               "type": "SATELLITE",
+               "name": [
+                    "DAPHNIS"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.daphnis::1.1"
           },
           {
-               "name": "2002 FW36",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2002 FW36"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2002_fw36::1.0"
           },
           {
-               "name": "9 METIS",
-               "type": "ASTEROID",
+               "name": [
+                    "9 METIS"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.9_metis::1.1"
           },
           {
-               "name": "55576 AMYCUS",
-               "type": "CENTAUR",
+               "name": [
+                    "55576 AMYCUS"
+               ],
+               "type": [
+                    "CENTAUR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:centaur.55576_amycus::1.0"
           },
           {
-               "name": "HIGH RESOLUTION STEREO CAMERA",
-               "type": "IMAGER",
+               "name": [
+                    "HIGH RESOLUTION STEREO CAMERA"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:hrsc.mex::1.0"
           },
           {
-               "name": "NAVIGATION CAMERA LEFT STRING A",
-               "type": "IMAGER",
+               "name": [
+                    "NAVIGATION CAMERA LEFT STRING A"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:nav_left_a.msl::1.0"
           },
           {
-               "name": "S/2004 S 7",
-               "type": "SATELLITE",
+               "name": [
+                    "S/2004 S 7"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.s2004s7::1.1"
           },
           {
-               "name": "(469372) 2001 QF298",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(469372) 2001 QF298"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.469372_2001_qf298::1.0"
           },
           {
-               "name": "HATI",
-               "type": "SATELLITE",
+               "name": [
+                    "HATI"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.hati::1.1"
           },
           {
-               "name": "LOGE",
-               "type": "SATELLITE",
+               "name": [
+                    "LOGE"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.loge::1.1"
           },
           {
-               "name": "(300163) 2006 VW139",
-               "type": "ASTEROID",
+               "name": [
+                    "(300163) 2006 VW139"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300163_2006_vw139::1.0"
           },
           {
-               "name": "GAS INSTRUMENT",
-               "type": "PARTICLE DETECTOR",
+               "name": [
+                    "GAS INSTRUMENT"
+               ],
+               "type": [
+                    "PARTICLE DETECTOR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:gas.uly::1.0"
           },
           {
-               "name": "7 IRIS",
-               "type": "ASTEROID",
+               "name": [
+                    "7 IRIS"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.7_iris::1.1"
           },
           {
-               "name": "INFRARED THERMAL MAPPER",
-               "type": "RADIOMETER",
+               "name": [
+                    "INFRARED THERMAL MAPPER"
+               ],
+               "type": [
+                    "RADIOMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:irtm.vo2::1.0"
           },
           {
-               "name": "TOTAL LUMINANCE PHOTOMETER",
-               "type": "PHOTOMETER",
+               "name": [
+                    "TOTAL LUMINANCE PHOTOMETER"
+               ],
+               "type": [
+                    "PHOTOMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:tlp.lcross::1.0"
           },
           {
-               "name": "LIGHTNING AND RADIO EMISSION DETECTOR",
-               "type": "PARTICLE DETECTOR",
+               "name": [
+                    "LIGHTNING AND RADIO EMISSION DETECTOR"
+               ],
+               "type": [
+                    "PARTICLE DETECTOR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:lrd.gp::1.0"
           },
           {
-               "name": "S/2003 J 9",
-               "type": "SATELLITE",
+               "name": [
+                    "S/2003 J 9"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.s2003j9::1.1"
           },
           {
-               "name": "(385199) 1999 OE4",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(385199) 1999 OE4"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.385199_1999_oe4::1.0"
           },
           {
-               "name": "ACCELEROMETER",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "ACCELEROMETER"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:accel.mro::1.0"
           },
           {
-               "name": "C/1999 J2 (SKIFF)",
-               "type": "COMET",
+               "name": [
+                    "C/1999 J2 (SKIFF)"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.c1999_j2_skiff::1.0"
           },
           {
-               "name": "WIDE FIELD PLANETARY CAMERA 2",
-               "type": "IMAGER",
+               "name": [
+                    "WIDE FIELD PLANETARY CAMERA 2"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:wfpc2.hst::1.0"
           },
           {
-               "name": "THEMISTO",
-               "type": "SATELLITE",
+               "name": [
+                    "THEMISTO"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.themisto::1.1"
           },
           {
-               "name": "87 SYLVIA",
-               "type": "ASTEROID",
+               "name": [
+                    "87 SYLVIA"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.87_sylvia::1.1"
           },
           {
-               "name": "1144 ODA",
-               "type": "ASTEROID",
+               "name": [
+                    "1144 ODA"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.1144_oda::1.1"
           },
           {
-               "name": "2002 CX224",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2002 CX224"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2002_cx224::1.0"
           },
           {
-               "name": "HEAT FLOW EXPERIMENT",
-               "type": "REGOLITH PROPERTIES",
+               "name": [
+                    "HEAT FLOW EXPERIMENT"
+               ],
+               "type": [
+                    "REGOLITH PROPERTIES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:hfe.a15a::1.0"
           },
           {
-               "name": "14792 THYESTES",
-               "type": "ASTEROID",
+               "name": [
+                    "14792 THYESTES"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.14792_thyestes::1.1"
           },
           {
-               "name": "NEW HORIZONS",
-               "type": "Mission",
+               "name": [
+                    "NEW HORIZONS"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.new_horizons::1.1"
           },
           {
-               "name": "MARS EXPLORATION ROVER 2",
-               "type": "Spacecraft",
+               "name": [
+                    "MARS EXPLORATION ROVER 2"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.mer2::1.0"
           },
           {
-               "name": "(145474) 2005 SA278",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(145474) 2005 SA278"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.145474_2005_sa278::1.0"
           },
           {
-               "name": "(300234) 2006 YH16",
-               "type": "ASTEROID",
+               "name": [
+                    "(300234) 2006 YH16"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300234_2006_yh16::1.0"
           },
           {
-               "name": "1998 KS65",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "1998 KS65"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.1998_ks65::1.0"
           },
           {
-               "name": "7119 HIERA",
-               "type": "ASTEROID",
+               "name": [
+                    "7119 HIERA"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.7119_hiera::1.1"
           },
           {
-               "name": "ATMOSPHERIC STRUCTURE INSTRUMENT",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "ATMOSPHERIC STRUCTURE INSTRUMENT"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:asi.gp::1.0"
           },
           {
-               "name": "(300192) 2006 WW87",
-               "type": "ASTEROID",
+               "name": [
+                    "(300192) 2006 WW87"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300192_2006_ww87::1.0"
           },
           {
-               "name": "(33340) 1998 VG44",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(33340) 1998 VG44"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.33340_1998_vg44::1.0"
           },
           {
-               "name": "NEAR INFRARED MAPPING SPECTROMETER",
-               "type": "IMAGER",
+               "name": [
+                    "NEAR INFRARED MAPPING SPECTROMETER"
+               ],
+               "type": [
+                    "IMAGER",
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:nims.go::1.0"
           },
           {
-               "name": "APOLLO 12 SUPRATHERMAL ION DETECTOR EXPERIMENT",
-               "type": "PARTICLE DETECTOR",
+               "name": [
+                    "APOLLO 12 SUPRATHERMAL ION DETECTOR EXPERIMENT"
+               ],
+               "type": [
+                    "PARTICLE DETECTOR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:side.a12a::1.0"
           },
           {
-               "name": "ALBIORIX",
-               "type": "SATELLITE",
+               "name": [
+                    "ALBIORIX"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.albiorix::1.1"
           },
           {
-               "name": "ULTRAVIOLET SPECTROMETER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "ULTRAVIOLET SPECTROMETER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:uvs.vg1::1.0"
           },
           {
-               "name": "D/1993 F2-L (SHOEMAKER-LEVY 9-L)",
-               "type": "COMET",
+               "name": [
+                    "D/1993 F2-L (SHOEMAKER-LEVY 9-L)"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.d1993_f2-l_shoemaker-levy_9-l::1.0"
           },
           {
-               "name": "AITNE",
-               "type": "SATELLITE",
+               "name": [
+                    "AITNE"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.aitne::1.1"
           },
           {
-               "name": "ROCK",
-               "type": "SATELLITE",
+               "name": [
+                    "ROCK"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.rock::1.0"
           },
           {
-               "name": "NET FLUX RADIOMETER",
-               "type": "RADIOMETER",
+               "name": [
+                    "NET FLUX RADIOMETER"
+               ],
+               "type": [
+                    "RADIOMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:nfr.gp::1.0"
           },
           {
-               "name": "TELLTALE",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "TELLTALE"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:tt.phx::1.0"
           },
           {
-               "name": "HYRROKKIN",
-               "type": "SATELLITE",
+               "name": [
+                    "HYRROKKIN"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.hyrrokkin::1.1"
           },
           {
-               "name": "709 FRINGILLA",
-               "type": "ASTEROID",
+               "name": [
+                    "709 FRINGILLA"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.709_fringilla::1.1"
           },
           {
-               "name": "INFRARED INTERFEROMETER SPECTROMETER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "INFRARED INTERFEROMETER SPECTROMETER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:iris.mr9::1.0"
           },
           {
-               "name": "90 ANTIOPE",
-               "type": "ASTEROID",
+               "name": [
+                    "90 ANTIOPE"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.90_antiope::1.1"
           },
           {
-               "name": "2148 EPEIOS",
-               "type": "ASTEROID",
+               "name": [
+                    "2148 EPEIOS"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.2148_epeios::1.1"
           },
           {
-               "name": "HUYGENS ATMOSPHERIC STRUCTURE INSTRUMENT",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "HUYGENS ATMOSPHERIC STRUCTURE INSTRUMENT"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:hasi.hp::1.0"
           },
           {
-               "name": "C/1999 S4 (LINEAR)",
-               "type": "COMET",
+               "name": [
+                    "C/1999 S4 (LINEAR)"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.c1999_s4_linear::1.1"
           },
           {
-               "name": "2002 GY32",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2002 GY32"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2002_gy32::1.0"
           },
           {
-               "name": "JANUS",
-               "type": "SATELLITE",
+               "name": [
+                    "JANUS"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.janus::1.1"
           },
           {
-               "name": "RADIO SCIENCE SUBSYSTEM",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "RADIO SCIENCE SUBSYSTEM"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:rss.mgs::1.0"
           },
           {
-               "name": "VIKING LANDER 2",
-               "type": "Spacecraft",
+               "name": [
+                    "VIKING LANDER 2"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.vl2::1.1"
           },
           {
-               "name": "ULTRAVIOLET SPECTROMETER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "ULTRAVIOLET SPECTROMETER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:uvs.go::1.0"
           },
           {
-               "name": "2004 PB108",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2004 PB108"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2004_pb108::1.0"
           },
           {
-               "name": "D/1993 F2-D (SHOEMAKER-LEVY 9-D)",
-               "type": "COMET",
+               "name": [
+                    "D/1993 F2-D (SHOEMAKER-LEVY 9-D)"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.d1993_f2-d_shoemaker-levy_9-d::1.0"
           },
           {
-               "name": "UNK - INSTRUMENT ID (FTS)",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "UNK - INSTRUMENT ID (FTS)"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:fts.vl2::1.0"
           },
           {
-               "name": "(23958) 1998 VD30",
-               "type": "ASTEROID",
+               "name": [
+                    "(23958) 1998 VD30"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.23958_1998_vd30::1.0"
           },
           {
-               "name": "(13782) 1998 UM18",
-               "type": "ASTEROID",
+               "name": [
+                    "(13782) 1998 UM18"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.13782_1998_um18::1.0"
           },
           {
-               "name": "146 LUCINA",
-               "type": "ASTEROID",
+               "name": [
+                    "146 LUCINA"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.146_lucina::1.1"
           },
           {
-               "name": "2000 QL251",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2000 QL251"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2000_ql251::1.0"
           },
           {
-               "name": "THEBE",
-               "type": "SATELLITE",
+               "name": [
+                    "THEBE"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.thebe::1.1"
           },
           {
-               "name": "D/1993 F2-R (SHOEMAKER-LEVY 9-R)",
-               "type": "COMET",
+               "name": [
+                    "D/1993 F2-R (SHOEMAKER-LEVY 9-R)"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.d1993_f2-r_shoemaker-levy_9-r::1.0"
           },
           {
-               "name": "FLUXGATE MAGNETOMETER",
-               "type": "MAGNETOMETER",
+               "name": [
+                    "FLUXGATE MAGNETOMETER"
+               ],
+               "type": [
+                    "MAGNETOMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:mischa.vega1::1.0"
           },
           {
-               "name": "DESCENT CAMERA",
-               "type": "IMAGER",
+               "name": [
+                    "DESCENT CAMERA"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:descam.mer1::1.0"
           },
           {
-               "name": "N/A",
-               "type": "Individual Investigation",
+               "name": [
+                    "N/A"
+               ],
+               "type": [
+                    "N/A"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:individual.greeley_field_amboycrater::1.0"
           },
           {
-               "name": "APOLLO 15 COMMAND AND SERVICE MODULE",
-               "type": "Spacecraft",
+               "name": [
+                    "APOLLO 15 COMMAND AND SERVICE MODULE"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.a15c::1.1"
           },
           {
-               "name": "D/1993 F2-C (SHOEMAKER-LEVY 9-C)",
-               "type": "COMET",
+               "name": [
+                    "D/1993 F2-C (SHOEMAKER-LEVY 9-C)"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.d1993_f2-c_shoemaker-levy_9-c::1.0"
           },
           {
-               "name": "JULIET",
-               "type": "SATELLITE",
+               "name": [
+                    "JULIET"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.uranus.juliet::1.1"
           },
           {
-               "name": "TITAN",
-               "type": "SATELLITE",
+               "name": [
+                    "TITAN"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.titan::1.0"
           },
           {
-               "name": "DIONE",
-               "type": "SATELLITE",
+               "name": [
+                    "DIONE"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.dione::1.1"
           },
           {
-               "name": "2004 TV357",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2004 TV357"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2004_tv357::1.0"
           },
           {
-               "name": "(31050) 1996 RA2",
-               "type": "ASTEROID",
+               "name": [
+                    "(31050) 1996 RA2"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.31050_1996_ra2::1.0"
           },
           {
-               "name": "ISONOE",
-               "type": "SATELLITE",
+               "name": [
+                    "ISONOE"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.isonoe::1.1"
           },
           {
-               "name": "ANALYZER OF SPACE PLASMA AND ENERGETIC ATOMS (3RD VERSION)",
-               "type": "PARTICLE DETECTOR",
+               "name": [
+                    "ANALYZER OF SPACE PLASMA AND ENERGETIC ATOMS (3RD VERSION)"
+               ],
+               "type": [
+                    "PARTICLE DETECTOR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:aspera-3.mex::1.0"
           },
           {
-               "name": "RADIO SCIENCE SUBSYSTEM",
-               "type": "ATMOSPHERIC SCIENCES",
-               "lidvid": "urn:nasa:pds:context:instrument:rss.vex::1.0"
-          },
-          {
-               "name": "2005 TN74",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2005 TN74"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2005_tn74::1.0"
           },
           {
-               "name": "(148975) 2001 XA255",
-               "type": "CENTAUR",
+               "name": [
+                    "(148975) 2001 XA255"
+               ],
+               "type": [
+                    "CENTAUR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:centaur.148975_2001_xa255::1.0"
           },
           {
-               "name": "1512 OULU",
-               "type": "ASTEROID",
+               "name": [
+                    "1512 OULU"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.1512_oulu::1.1"
           },
           {
-               "name": "43 ARIADNE",
-               "type": "ASTEROID",
+               "name": [
+                    "43 ARIADNE"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.43_ariadne::1.1"
           },
           {
-               "name": "INSIGHT CONTEXT CAMERA",
-               "type": "IMAGER",
+               "name": [
+                    "INSIGHT CONTEXT CAMERA"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:icc.insight::1.0"
           },
           {
-               "name": "VEGA",
-               "type": "STAR",
+               "name": [
+                    "VEGA"
+               ],
+               "type": [
+                    "STAR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:star.alf_lyr::1.0"
           },
           {
-               "name": "PORTIA",
-               "type": "SATELLITE",
+               "name": [
+                    "PORTIA"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.uranus.portia::1.1"
           },
           {
-               "name": "1996 RR20",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "1996 RR20"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.1996_rr20::1.0"
           },
           {
-               "name": "1999 RY214",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "1999 RY214"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.1999_ry214::1.0"
           },
           {
-               "name": "(471151) 2010 FD49",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(471151) 2010 FD49"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.471151_2010_fd49::1.0"
           },
           {
-               "name": "APXSSITE",
-               "type": "EQUIPMENT",
+               "name": [
+                    "APXSSITE"
+               ],
+               "type": [
+                    "EQUIPMENT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:equipment.apxssite::1.0"
           },
           {
-               "name": "832 KARIN",
-               "type": "ASTEROID",
+               "name": [
+                    "832 KARIN"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.832_karin::1.1"
           },
           {
-               "name": "2000 FS53",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2000 FS53"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2000_fs53::1.0"
           },
           {
-               "name": "2000 QN251",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2000 QN251"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2000_qn251::1.0"
           },
           {
-               "name": "MECA ATOMIC FORCE MICROSCOPE",
-               "type": "MICROSCOPE",
+               "name": [
+                    "MECA ATOMIC FORCE MICROSCOPE"
+               ],
+               "type": [
+                    "MICROSCOPE"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:meca_afm.phx::1.0"
           },
           {
-               "name": "(300242) 2007 DZ70",
-               "type": "ASTEROID",
+               "name": [
+                    "(300242) 2007 DZ70"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300242_2007_dz70::1.0"
           },
           {
-               "name": "2004 HY78",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2004 HY78"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2004_hy78::1.0"
           },
           {
-               "name": "REAR HAZARD AVOIDANCE CAMERA LEFT STRING A",
-               "type": "IMAGER",
+               "name": [
+                    "REAR HAZARD AVOIDANCE CAMERA LEFT STRING A"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:rhaz_left_a.msl::1.0"
           },
           {
-               "name": "KARI",
-               "type": "SATELLITE",
+               "name": [
+                    "KARI"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.kari::1.1"
           },
           {
-               "name": "METHONE",
-               "type": "SATELLITE",
+               "name": [
+                    "METHONE"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.methone::1.1"
           },
           {
-               "name": "(300257) 2007 GV75",
-               "type": "ASTEROID",
+               "name": [
+                    "(300257) 2007 GV75"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300257_2007_gv75::1.0"
           },
           {
-               "name": "D/1993 F2-N (SHOEMAKER-LEVY 9-N)",
-               "type": "COMET",
+               "name": [
+                    "D/1993 F2-N (SHOEMAKER-LEVY 9-N)"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.d1993_f2-n_shoemaker-levy_9-n::1.0"
           },
           {
-               "name": "LIDAR HIGH-RESOLUTION IMAGER",
-               "type": "IMAGER",
+               "name": [
+                    "LIDAR HIGH-RESOLUTION IMAGER"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:hires.clem1::1.0"
           },
           {
-               "name": "2000 CK105",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2000 CK105"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2000_ck105::1.0"
           },
           {
-               "name": "(24449) 2000 QL63",
-               "type": "ASTEROID",
+               "name": [
+                    "(24449) 2000 QL63"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.24449_2000_ql63::1.0"
           },
           {
-               "name": "HUYGENS PROBE HOUSEKEEPING",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "HUYGENS PROBE HOUSEKEEPING"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:huygens_hk.hp::1.0"
           },
           {
-               "name": "(90428) 2004 BL30",
-               "type": "ASTEROID",
+               "name": [
+                    "(90428) 2004 BL30"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.90428_2004_bl30::1.0"
           },
           {
-               "name": "FOCAL PLANE ARRAY",
-               "type": "IMAGER",
+               "name": [
+                    "FOCAL PLANE ARRAY"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:fpa.iras::1.0"
           },
           {
-               "name": "MARINER69",
-               "type": "Mission",
+               "name": [
+                    "MARINER69"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.mariner69::1.1"
           },
           {
-               "name": "DEEP IMPACT FLYBY SPACECRAFT",
-               "type": "Spacecraft",
+               "name": [
+                    "DEEP IMPACT FLYBY SPACECRAFT"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.dif::1.1"
           },
           {
-               "name": "APOLLO 12",
-               "type": "Mission",
+               "name": [
+                    "APOLLO 12"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.apollo_12::1.1"
           },
           {
-               "name": "2006 UZ184",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2006 UZ184"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2006_uz184::1.0"
           },
           {
-               "name": "CAROUSEL WIND TUNNEL",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "CAROUSEL WIND TUNNEL"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:pal.cwt::1.0"
           },
           {
-               "name": "2001 KY76",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2001 KY76"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2001_ky76::1.0"
           },
           {
-               "name": "2000 FC8",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2000 FC8"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2000_fc8::1.0"
           },
           {
-               "name": "(474640) 2004 VN112",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(474640) 2004 VN112"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.474640_2004_vn112::1.0"
           },
           {
-               "name": "ENERGETIC PARTICLE COMPOSITION INSTRUMENT",
-               "type": "PARTICLE DETECTOR",
+               "name": [
+                    "ENERGETIC PARTICLE COMPOSITION INSTRUMENT"
+               ],
+               "type": [
+                    "PARTICLE DETECTOR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:epac.uly::1.0"
           },
           {
-               "name": "2002 VX130",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2002 VX130"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2002_vx130::1.0"
           },
           {
-               "name": "QUADRISPHERICAL PLASMA ANALYZER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "QUADRISPHERICAL PLASMA ANALYZER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:pa.p10::1.0"
           },
           {
-               "name": "GIOTTO",
-               "type": "Spacecraft",
+               "name": [
+                    "GIOTTO"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.gio::1.1"
           },
           {
-               "name": "(469420) 2001 XP254",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(469420) 2001 XP254"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.469420_2001_xp254::1.0"
           },
           {
-               "name": "(300243) 2007 DE117",
-               "type": "ASTEROID",
+               "name": [
+                    "(300243) 2007 DE117"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300243_2007_de117::1.0"
           },
           {
-               "name": "2001 XQ254",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2001 XQ254"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2001_xq254::1.0"
           },
           {
-               "name": "S/2003 J 15",
-               "type": "SATELLITE",
+               "name": [
+                    "S/2003 J 15"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.s2003j15::1.1"
           },
           {
-               "name": "26970 ELIAS",
-               "type": "ASTEROID",
+               "name": [
+                    "26970 ELIAS"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.26970_elias::1.1"
           },
           {
-               "name": "PIONEER 10",
-               "type": "Mission",
+               "name": [
+                    "PIONEER 10"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.pioneer_10::1.0"
           },
           {
-               "name": "VISUAL IMAGING SUBSYSTEM - CAMERA A",
-               "type": "IMAGER",
+               "name": [
+                    "VISUAL IMAGING SUBSYSTEM - CAMERA A"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:visa.vo2::1.0"
           },
           {
-               "name": "KIVIUQ",
-               "type": "SATELLITE",
+               "name": [
+                    "KIVIUQ"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.kiviuq::1.1"
           },
           {
-               "name": "47171 LEMPO",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "47171 LEMPO"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.47171_lempo::1.0"
           },
           {
-               "name": "(300248) 2007 ED165",
-               "type": "ASTEROID",
+               "name": [
+                    "(300248) 2007 ED165"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300248_2007_ed165::1.0"
           },
           {
-               "name": "STUDENT DUST COUNTER",
-               "type": "DUST",
+               "name": [
+                    "STUDENT DUST COUNTER"
+               ],
+               "type": [
+                    "DUST"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:sdc.nh::1.0"
           },
           {
-               "name": "MARS ORBITER CAMERA",
-               "type": "IMAGER",
+               "name": [
+                    "MARS ORBITER CAMERA"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:moc.mgs::1.0"
           },
           {
-               "name": "DUST PARTICLE COUNTER AND MASS ANALYZER",
-               "type": "PARTICLE DETECTOR",
+               "name": [
+                    "DUST PARTICLE COUNTER AND MASS ANALYZER"
+               ],
+               "type": [
+                    "PARTICLE DETECTOR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:ducma.vega2::1.0"
           },
           {
-               "name": "COSMIC RAY TELESCOPE",
-               "type": "PARTICLE DETECTOR",
+               "name": [
+                    "COSMIC RAY TELESCOPE"
+               ],
+               "type": [
+                    "PARTICLE DETECTOR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:crt.p11::1.0"
           },
           {
-               "name": "2006 FV4",
-               "type": "CENTAUR",
+               "name": [
+                    "2006 FV4"
+               ],
+               "type": [
+                    "CENTAUR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:centaur.2006_fv4::1.0"
           },
           {
-               "name": "(300180) 2006 WX42",
-               "type": "ASTEROID",
+               "name": [
+                    "(300180) 2006 WX42"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300180_2006_wx42::1.0"
           },
           {
-               "name": "(300177) 2006 WD33",
-               "type": "ASTEROID",
+               "name": [
+                    "(300177) 2006 WD33"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300177_2006_wd33::1.0"
           },
           {
-               "name": "HEGEMONE",
-               "type": "SATELLITE",
+               "name": [
+                    "HEGEMONE"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.hegemone::1.1"
           },
           {
-               "name": "(181902) 1999 RD215",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(181902) 1999 RD215"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.181902_1999_rd215::1.0"
           },
           {
-               "name": "SATURN RING PLANE CROSSING 1995",
-               "type": "Mission",
+               "name": [
+                    "SATURN RING PLANE CROSSING 1995"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.saturn_ring_plane_crossing_1995::1.1"
           },
           {
-               "name": "NAVIGATION CAMERA",
-               "type": "IMAGER",
+               "name": [
+                    "NAVIGATION CAMERA"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:navcam.mer1::1.0"
           },
           {
-               "name": "MOA 2009-BLG-266",
-               "type": "STAR",
+               "name": [
+                    "MOA 2009-BLG-266"
+               ],
+               "type": [
+                    "STAR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:star.moa_2009-blg-266::1.0"
           },
           {
-               "name": "2000 PD30",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2000 PD30"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2000_pd30::1.0"
           },
           {
-               "name": "GIOTTO",
-               "type": "Mission",
+               "name": [
+                    "GIOTTO"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.giotto::1.1"
           },
           {
-               "name": "(26641) 2000 JT30",
-               "type": "ASTEROID",
+               "name": [
+                    "(26641) 2000 JT30"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.26641_2000_jt30::1.0"
           },
           {
-               "name": "BERGELMIR",
-               "type": "SATELLITE",
+               "name": [
+                    "BERGELMIR"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.bergelmir::1.1"
           },
           {
-               "name": "PANORAMIC CAMERA",
-               "type": "IMAGER",
+               "name": [
+                    "PANORAMIC CAMERA"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:pancam.mer2::1.0"
           },
           {
-               "name": "2001 PK47",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2001 PK47"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2001_pk47::1.0"
           },
           {
-               "name": "VENUS",
-               "type": "PLANET",
+               "name": [
+                    "VENUS"
+               ],
+               "type": [
+                    "PLANET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:planet.venus::1.2"
           },
           {
-               "name": "2003 BH91",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2003 BH91"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2003_bh91::1.0"
           },
           {
-               "name": "INFRARED THERMAL MAPPER",
-               "type": "RADIOMETER",
+               "name": [
+                    "INFRARED THERMAL MAPPER"
+               ],
+               "type": [
+                    "RADIOMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:irtm.vo1::1.0"
           },
           {
-               "name": "(29281) 1993 FJ38",
-               "type": "ASTEROID",
+               "name": [
+                    "(29281) 1993 FJ38"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.29281_1993_fj38::1.0"
           },
           {
-               "name": "(183964) 2004 DJ71",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(183964) 2004 DJ71"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.183964_2004_dj71::1.0"
           },
           {
-               "name": "(300193) 2006 WH92",
-               "type": "ASTEROID",
+               "name": [
+                    "(300193) 2006 WH92"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300193_2006_wh92::1.0"
           },
           {
-               "name": "TERMOSKAN",
-               "type": "RADIOMETER",
+               "name": [
+                    "TERMOSKAN"
+               ],
+               "type": [
+                    "RADIOMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:ts.phb2::1.0"
           },
           {
-               "name": "4179 TOUTATIS",
-               "type": "ASTEROID",
+               "name": [
+                    "4179 TOUTATIS"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.4179_toutatis::1.1"
           },
           {
-               "name": "(160148) 2001 KV76",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(160148) 2001 KV76"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.160148_2001_kv76::1.0"
           },
           {
-               "name": "NEUTRON SPECTROMETER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "NEUTRON SPECTROMETER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:ns.lp::1.0"
           },
           {
-               "name": "2000 CN105",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2000 CN105"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2000_cn105::1.0"
           },
           {
-               "name": "1997 CT29",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "1997 CT29"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.1997_ct29::1.0"
           },
           {
-               "name": "OSIRIS - WIDE ANGLE CAMERA",
-               "type": "IMAGER",
+               "name": [
+                    "OSIRIS - WIDE ANGLE CAMERA"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:osiwac.ro::1.0"
           },
           {
-               "name": "CAMERA 1",
-               "type": "IMAGER",
+               "name": [
+                    "CAMERA 1"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:cam1.vl1::1.0"
           },
           {
-               "name": "2003 YN179",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2003 YN179"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2003_yn179::1.0"
           },
           {
-               "name": "2001 OG109",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2001 OG109"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2001_og109::1.0"
           },
           {
-               "name": "28978 IXION",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "28978 IXION"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.28978_ixion::1.1"
           },
           {
-               "name": "(134340) PLUTO",
-               "type": "DWARF PLANET",
+               "name": [
+                    "(134340) PLUTO"
+               ],
+               "type": [
+                    "DWARF PLANET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:dwarf_planet.134340_pluto::1.1"
           },
           {
-               "name": "(300236) 2006 YM39",
-               "type": "ASTEROID",
+               "name": [
+                    "(300236) 2006 YM39"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300236_2006_ym39::1.0"
           },
           {
-               "name": "2002 GS32",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2002 GS32"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2002_gs32::1.0"
           },
           {
-               "name": "FLUXGATE MAGNETOMETER",
-               "type": "MAGNETOMETER",
+               "name": [
+                    "FLUXGATE MAGNETOMETER"
+               ],
+               "type": [
+                    "MAGNETOMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:omag.pvo::1.0"
           },
           {
-               "name": "GSC 03549-02811",
-               "type": "STAR",
+               "name": [
+                    "GSC 03549-02811"
+               ],
+               "type": [
+                    "STAR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:star.kepler-1::1.0"
           },
           {
-               "name": "PHOTOPOLARIMETER SUBSYSTEM",
-               "type": "PHOTOMETER",
+               "name": [
+                    "PHOTOPOLARIMETER SUBSYSTEM"
+               ],
+               "type": [
+                    "PHOTOMETER",
+                    "POLARIMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:pps.vg2::1.0"
           },
           {
-               "name": "(300183) 2006 WZ58",
-               "type": "ASTEROID",
+               "name": [
+                    "(300183) 2006 WZ58"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300183_2006_wz58::1.0"
           },
           {
-               "name": "(50715) 2000 EV136",
-               "type": "ASTEROID",
+               "name": [
+                    "(50715) 2000 EV136"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.50715_2000_ev136::1.0"
           },
           {
-               "name": "Pioneer 8",
-               "type": "Spacecraft",
+               "name": [
+                    "Pioneer 8"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.p8::1.0"
           },
           {
-               "name": "136472 MAKEMAKE",
-               "type": "DWARF PLANET",
+               "name": [
+                    "136472 MAKEMAKE"
+               ],
+               "type": [
+                    "DWARF PLANET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:dwarf_planet.136472_makemake::1.1"
           },
           {
-               "name": "2000 PN30",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2000 PN30"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2000_pn30::1.0"
           },
           {
-               "name": "PAALIAQ",
-               "type": "SATELLITE",
+               "name": [
+                    "PAALIAQ"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.paaliaq::1.1"
           },
           {
-               "name": "2002 VF130",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2002 VF130"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2002_vf130::1.0"
           },
           {
-               "name": "(79978) 1999 CC158",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(79978) 1999 CC158"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.79978_1999_cc158::1.0"
           },
           {
-               "name": "LOW ENERGY CHARGED PARTICLE",
-               "type": "PARTICLE DETECTOR",
+               "name": [
+                    "LOW ENERGY CHARGED PARTICLE"
+               ],
+               "type": [
+                    "PARTICLE DETECTOR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:lecp.vg1::1.0"
           },
           {
-               "name": "S/2007 S 3",
-               "type": "SATELLITE",
+               "name": [
+                    "S/2007 S 3"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.s2007s3::1.1"
           },
           {
-               "name": "BEBHIONN",
-               "type": "SATELLITE",
+               "name": [
+                    "BEBHIONN"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.bebhionn::1.1"
           },
           {
-               "name": "APOLLO 17 LUNAR SURFACE EXPERIMENTS PACKAGE",
-               "type": "Spacecraft",
+               "name": [
+                    "APOLLO 17 LUNAR SURFACE EXPERIMENTS PACKAGE"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.a17a::1.1"
           },
           {
-               "name": "APOLLO 14 LUNAR SURFACE EXPERIMENTS PACKAGE",
-               "type": "Spacecraft",
+               "name": [
+                    "APOLLO 14 LUNAR SURFACE EXPERIMENTS PACKAGE"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.a14a::1.2"
           },
           {
-               "name": "2001 QR297",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2001 QR297"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2001_qr297::1.0"
           },
           {
-               "name": "MARINER 10",
-               "type": "Mission",
+               "name": [
+                    "MARINER 10"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.mariner_10::1.0"
           },
           {
-               "name": "2000 CQ105",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2000 CQ105"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2000_cq105::1.0"
           },
           {
-               "name": "SEISMIC EXPERIMENT FOR INTERIOR STRUCTURE",
-               "type": "SEISMOMETER",
+               "name": [
+                    "SEISMIC EXPERIMENT FOR INTERIOR STRUCTURE"
+               ],
+               "type": [
+                    "SEISMOMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:seis.insight::1.0"
           },
           {
-               "name": "2001 KF76",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2001 KF76"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2001_kf76::1.0"
           },
           {
-               "name": "HALIMEDE",
-               "type": "SATELLITE",
+               "name": [
+                    "HALIMEDE"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.neptune.halimede::1.1"
           },
           {
-               "name": "300221 BRUCEBILLS",
-               "type": "ASTEROID",
+               "name": [
+                    "300221 BRUCEBILLS"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300221_brucebills::1.1"
           },
           {
-               "name": "SPICAM",
-               "type": "SPECTROMETER",
+               "name": [
+                    "SPICAM"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:spicam.mex::1.0"
           },
           {
-               "name": "(300200) 2006 WS100",
-               "type": "ASTEROID",
+               "name": [
+                    "(300200) 2006 WS100"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300200_2006_ws100::1.0"
           },
           {
-               "name": "LARISSA",
-               "type": "SATELLITE",
+               "name": [
+                    "LARISSA"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.neptune.larissa::1.2"
           },
           {
-               "name": "(469514) 2003 QA91",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(469514) 2003 QA91"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.469514_2003_qa91::1.0"
           },
           {
-               "name": "NEPTUNE",
-               "type": "PLANET",
+               "name": [
+                    "NEPTUNE"
+               ],
+               "type": [
+                    "PLANET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:planet.neptune::1.2"
           },
           {
-               "name": "(39264) 2000 YQ139",
-               "type": "ASTEROID",
+               "name": [
+                    "(39264) 2000 YQ139"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.39264_2000_yq139::1.0"
           },
           {
-               "name": "FLAT FIELD",
-               "type": "CALIBRATOR",
+               "name": [
+                    "FLAT FIELD"
+               ],
+               "type": [
+                    "CALIBRATOR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:calibrator.flat_field::1.0"
           },
           {
-               "name": "OTES",
-               "type": "SPECTROMETER",
+               "name": [
+                    "OTES"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:otes.orex::1.0"
           },
           {
-               "name": "RADIATION ASSESSMENT DETECTOR",
-               "type": "SPECTROMETER",
+               "name": [
+                    "RADIATION ASSESSMENT DETECTOR"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:rad.msl::1.0"
           },
           {
-               "name": "1995 HM5",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "1995 HM5"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.1995_hm5::1.0"
           },
           {
-               "name": "S/2003 J 10",
-               "type": "SATELLITE",
+               "name": [
+                    "S/2003 J 10"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.s2003j10::1.1"
           },
           {
-               "name": "(73480) 2002 PN34",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(73480) 2002 PN34"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.73480_2002_pn34::1.0"
           },
           {
-               "name": "MID-INFRARED ARRAY CAMERA",
-               "type": "IMAGER",
+               "name": [
+                    "MID-INFRARED ARRAY CAMERA"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:irtf.3m0.mirac::1.0"
           },
           {
-               "name": "PHOTOPOLARIMETER RADIOMETER",
-               "type": "RADIOMETER",
+               "name": [
+                    "PHOTOPOLARIMETER RADIOMETER"
+               ],
+               "type": [
+                    "RADIOMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:ppr.go::1.0"
           },
           {
-               "name": "INFRARED SPECTROMETER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "INFRARED SPECTROMETER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:irs.mr7::1.0"
           },
           {
-               "name": "INSTRUMENT DEPLOYMENT ARM",
-               "type": "SEISMOMETER",
+               "name": [
+                    "INSTRUMENT DEPLOYMENT ARM"
+               ],
+               "type": [
+                    "SEISMOMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:ida.insight::1.0"
           },
           {
-               "name": "23054 THOMASLYNCH",
-               "type": "ASTEROID",
+               "name": [
+                    "23054 THOMASLYNCH"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.23054_thomaslynch::1.1"
           },
           {
-               "name": "CHARGED PARTICLE INSTRUMENT",
-               "type": "PARTICLE DETECTOR",
+               "name": [
+                    "CHARGED PARTICLE INSTRUMENT"
+               ],
+               "type": [
+                    "PARTICLE DETECTOR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:cpi.p10::1.0"
           },
           {
-               "name": "LUNAR EXPLORATION NEUTRON DETECTOR",
-               "type": "SPECTROMETER",
+               "name": [
+                    "LUNAR EXPLORATION NEUTRON DETECTOR"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:lend.lro::1.0"
           },
           {
-               "name": "(134210) 2005 PQ21",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(134210) 2005 PQ21"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.134210_2005_pq21::1.0"
           },
           {
-               "name": "HERSE",
-               "type": "SATELLITE",
+               "name": [
+                    "HERSE"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.herse::1.1"
           },
           {
-               "name": "2004 VT75",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2004 VT75"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2004_vt75::1.0"
           },
           {
-               "name": "1999 HG12",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "1999 HG12"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.1999_hg12::1.0"
           },
           {
-               "name": "2000 OB51",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2000 OB51"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2000_ob51::1.0"
           },
           {
-               "name": "URANUS",
-               "type": "PLANET",
+               "name": [
+                    "URANUS"
+               ],
+               "type": [
+                    "PLANET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:planet.uranus::1.2"
           },
           {
-               "name": "PLUTO ENERGETIC PARTICLE SPECTROMETER SCIENCE INVESTIGATION",
-               "type": "SPECTROMETER",
+               "name": [
+                    "PLUTO ENERGETIC PARTICLE SPECTROMETER SCIENCE INVESTIGATION"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:pepssi.nh::1.0"
           },
           {
-               "name": "(24380) 2000 AA160",
-               "type": "ASTEROID",
+               "name": [
+                    "(24380) 2000 AA160"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.24380_2000_aa160::1.0"
           },
           {
-               "name": "SAO",
-               "type": "SATELLITE",
+               "name": [
+                    "SAO"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.neptune.sao::1.1"
           },
           {
-               "name": "C/1987 H1 (SHOEMAKER)",
-               "type": "COMET",
+               "name": [
+                    "C/1987 H1 (SHOEMAKER)"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.c1987_h1_shoemaker::1.0"
           },
           {
-               "name": "HST",
-               "type": "Mission",
+               "name": [
+                    "HST"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.hst::1.1"
           },
           {
-               "name": "JOVIAN INFRARED AURORAL MAPPER",
-               "type": "IMAGER",
+               "name": [
+                    "JOVIAN INFRARED AURORAL MAPPER"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:jiram.jno::1.0"
           },
           {
-               "name": "CHEMISTRY CAMERA STATE OF HEALTH",
-               "type": "SPECTROMETER",
+               "name": [
+                    "CHEMISTRY CAMERA STATE OF HEALTH"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:chemcam_soh.msl::1.0"
           },
           {
-               "name": "ALPHA PARTICLE X-RAY SPECTROMETER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "ALPHA PARTICLE X-RAY SPECTROMETER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:apxs.mer2::1.0"
           },
           {
-               "name": "DEEP IMPACT IMPACTOR SPACECRAFT",
-               "type": "Spacecraft",
+               "name": [
+                    "DEEP IMPACT IMPACTOR SPACECRAFT"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.dii::1.1"
           },
           {
-               "name": "2001 QS322",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2001 QS322"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2001_qs322::1.0"
           },
           {
-               "name": "93 MINERVA",
-               "type": "ASTEROID",
+               "name": [
+                    "93 MINERVA"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.93_minerva::1.1"
           },
           {
-               "name": "APOLLO 12 LUNAR MODULE",
-               "type": "Spacecraft",
+               "name": [
+                    "APOLLO 12 LUNAR MODULE"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.a12l::1.1"
           },
           {
-               "name": "SPICA",
-               "type": "STAR",
+               "name": [
+                    "SPICA"
+               ],
+               "type": [
+                    "STAR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:star.alf_vir::1.0"
           },
           {
-               "name": "(508788) 2000 CQ114",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "VENUS EXPRESS"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
+               "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.vex::1.1"
+          },
+          {
+               "name": [
+                    "(508788) 2000 CQ114"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.508788_2000_cq114::1.0"
           },
           {
-               "name": "365756 ISON",
-               "type": "CENTAUR",
+               "name": [
+                    "365756 ISON"
+               ],
+               "type": [
+                    "CENTAUR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:centaur.365756_ison::1.0"
           },
           {
-               "name": "MINIATURE THERMAL EMISSION SPECTROMETER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "MINIATURE THERMAL EMISSION SPECTROMETER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:mini-tes.mer2::1.0"
           },
           {
-               "name": "(39474) 1978 VC7",
-               "type": "ASTEROID",
+               "name": [
+                    "(39474) 1978 VC7"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.39474_1978_vc7::1.0"
           },
           {
-               "name": "1220 CROCUS",
-               "type": "ASTEROID",
+               "name": [
+                    "1220 CROCUS"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.1220_crocus::1.1"
           },
           {
-               "name": "(95625) 2002 GX32",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(95625) 2002 GX32"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.95625_2002_gx32::1.0"
           },
           {
-               "name": "2000 KK4",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2000 KK4"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2000_kk4::1.0"
           },
           {
-               "name": "C/2011 W3 (LOVEJOY)",
-               "type": "COMET",
+               "name": [
+                    "C/2011 W3 (LOVEJOY)"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.c2011_w3_lovejoy::1.0"
           },
           {
-               "name": "C/1995 O1 (HALE-BOPP)",
-               "type": "COMET",
+               "name": [
+                    "C/1995 O1 (HALE-BOPP)"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.c1995_o1_hale-bopp::1.0"
           },
           {
-               "name": "MOESSBAUER SPECTROMETER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "MOESSBAUER SPECTROMETER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:mb.mer2::1.0"
           },
           {
-               "name": "49 PALES",
-               "type": "ASTEROID",
+               "name": [
+                    "49 PALES"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.49_pales::1.1"
           },
           {
-               "name": "(23433) 1981 UU22",
-               "type": "ASTEROID",
+               "name": [
+                    "(23433) 1981 UU22"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.23433_1981_uu22::1.0"
           },
           {
-               "name": "(469584) 2003 YW179",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(469584) 2003 YW179"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.469584_2003_yw179::1.0"
           },
           {
-               "name": "RAMAN SPECTROMETER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "HEAVY ION COUNTER"
+               ],
+               "type": [
+                    "PARTICLE DETECTOR"
+               ],
+               "lidvid": "urn:nasa:pds:context:instrument:hic.go::1.0"
+          },
+          {
+               "name": [
+                    "(55638) 2002 VE95"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
+               "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.55638_2002_ve95::1.0"
+          },
+          {
+               "name": [
+                    "RAMAN SPECTROMETER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:sbu_cpex.raman::1.0"
           },
           {
-               "name": "(300168) 2006 VA144",
-               "type": "ASTEROID",
+               "name": [
+                    "(300168) 2006 VA144"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300168_2006_va144::1.0"
           },
           {
-               "name": "21P/GIACOBINI-ZINNER",
-               "type": "COMET",
+               "name": [
+                    "21P/GIACOBINI-ZINNER"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.21p_giacobini-zinner::1.0"
           },
           {
-               "name": "37P/FORBES",
-               "type": "COMET",
+               "name": [
+                    "37P/FORBES"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.37p_forbes::1.0"
           },
           {
-               "name": "APOLLO 16 METRIC (MAPPING) CAMERA",
-               "type": "IMAGER",
+               "name": [
+                    "APOLLO 16 METRIC (MAPPING) CAMERA"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:metriccam.a16c::1.0"
           },
           {
-               "name": "2000 GV146",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2000 GV146"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2000_gv146::1.0"
           },
           {
-               "name": "(300244) 2007 EY8",
-               "type": "ASTEROID",
+               "name": [
+                    "(300244) 2007 EY8"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300244_2007_ey8::1.0"
           },
           {
-               "name": "(118228) 1996 TQ66",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(118228) 1996 TQ66"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.118228_1996_tq66::1.0"
           },
           {
-               "name": "(45802) 2000 PV29",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(45802) 2000 PV29"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.45802_2000_pv29::1.0"
           },
           {
-               "name": "THERMAL EMISSION SPECTROMETER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "THERMAL EMISSION SPECTROMETER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:tes.mgs::1.0"
           },
           {
-               "name": "SPACE",
-               "type": "CALIBRATION FIELD",
+               "name": [
+                    "SPACE"
+               ],
+               "type": [
+                    "CALIBRATION FIELD"
+               ],
                "lidvid": "urn:nasa:pds:context:target:calibration_field.space::1.0"
           },
           {
-               "name": "(13537) 1991 SG",
-               "type": "ASTEROID",
+               "name": [
+                    "(13537) 1991 SG"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.13537_1991_sg::1.0"
           },
           {
-               "name": "2001 FL185",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2001 FL185"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2001_fl185::1.0"
           },
           {
-               "name": "HELIOSPHERIC INST-SPECTRA,COMPOSITION,ANISOTROPY AT LOW ENER",
-               "type": "PARTICLE DETECTOR",
+               "name": [
+                    "HELIOSPHERIC INST-SPECTRA,COMPOSITION,ANISOTROPY AT LOW ENER"
+               ],
+               "type": [
+                    "PARTICLE DETECTOR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:hiscale.uly::1.0"
           },
           {
-               "name": "MECA WET CHEMISTRY LABORATORY",
-               "type": "REGOLITH PROPERTIES",
+               "name": [
+                    "MECA WET CHEMISTRY LABORATORY"
+               ],
+               "type": [
+                    "REGOLITH PROPERTIES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:meca_wcl.phx::1.0"
           },
           {
-               "name": "CAPELLA",
-               "type": "STAR",
+               "name": [
+                    "CAPELLA"
+               ],
+               "type": [
+                    "STAR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:star.alf_aur::1.0"
           },
           {
-               "name": "C/1983 O1 (CERNIS)",
-               "type": "COMET",
+               "name": [
+                    "C/1983 O1 (CERNIS)"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.c1983_o1_cernis::1.0"
           },
           {
-               "name": "SOLAR WIND AROUND PLUTO",
-               "type": "PARTICLE DETECTOR",
+               "name": [
+                    "SOLAR WIND AROUND PLUTO"
+               ],
+               "type": [
+                    "PARTICLE DETECTOR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:swap.nh::1.0"
           },
           {
-               "name": "2001 OK108",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2001 OK108"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2001_ok108::1.0"
           },
           {
-               "name": "REAR HAZARD AVOIDANCE CAMERA LEFT STRING B",
-               "type": "IMAGER",
+               "name": [
+                    "REAR HAZARD AVOIDANCE CAMERA LEFT STRING B"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:rhaz_left_b.msl::1.0"
           },
           {
-               "name": "ALICE",
-               "type": "SPECTROMETER",
+               "name": [
+                    "ALICE"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:alice.ro::1.0"
           },
           {
-               "name": "(52551) 1997 AL",
-               "type": "ASTEROID",
+               "name": [
+                    "(52551) 1997 AL"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.52551_1997_al::1.0"
           },
           {
-               "name": "INFRARED INTERFEROMETER SPECTROMETER AND RADIOMETER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "INFRARED INTERFEROMETER SPECTROMETER AND RADIOMETER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:iris.vg1::1.0"
           },
           {
-               "name": "(7719) 1997 GT36",
-               "type": "ASTEROID",
+               "name": [
+                    "(7719) 1997 GT36"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.7719_1997_gt36::1.0"
           },
           {
-               "name": "2004 PZ107",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2004 PZ107"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2004_pz107::1.0"
           },
           {
-               "name": "(69987) 1998 WA25",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(69987) 1998 WA25"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.69987_1998_wa25::1.0"
           },
           {
-               "name": "TEST IMAGE",
-               "type": "CALIBRATOR",
+               "name": [
+                    "TEST IMAGE"
+               ],
+               "type": [
+                    "CALIBRATOR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:calibrator.test_image::1.0"
           },
           {
-               "name": "C/2003 O1 (LINEAR)",
-               "type": "COMET",
+               "name": [
+                    "C/2003 O1 (LINEAR)"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.c2003_o1_linear::1.0"
           },
           {
-               "name": "VISIBLE AND INFRARED SPECTROMETER",
-               "type": "IMAGER",
+               "name": [
+                    "VISIBLE AND INFRARED SPECTROMETER"
+               ],
+               "type": [
+                    "IMAGER",
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:dawn.vir::1.0"
           },
           {
-               "name": "(47640) 2000 CA30",
-               "type": "ASTEROID",
+               "name": [
+                    "(47640) 2000 CA30"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.47640_2000_ca30::1.0"
           },
           {
-               "name": "(119315) 2001 SQ73",
-               "type": "CENTAUR",
+               "name": [
+                    "(119315) 2001 SQ73"
+               ],
+               "type": [
+                    "CENTAUR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:centaur.119315_2001_sq73::1.0"
           },
           {
-               "name": "(60620) 2000 FD8",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(60620) 2000 FD8"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.60620_2000_fd8::1.0"
           },
           {
-               "name": "(127546) 2002 XU93",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(127546) 2002 XU93"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.127546_2002_xu93::1.0"
           },
           {
-               "name": "2006 SF369",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2006 SF369"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2006_sf369::1.0"
           },
           {
-               "name": "NAVIGATION CAMERA",
-               "type": "IMAGER",
+               "name": [
+                    "NAVIGATION CAMERA"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:navcam.mer2::1.0"
           },
           {
-               "name": "GLIESE 436",
-               "type": "STAR",
+               "name": [
+                    "GLIESE 436"
+               ],
+               "type": [
+                    "STAR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:star.ross_905::1.0"
           },
           {
-               "name": "(300209) 2006 WT151",
-               "type": "ASTEROID",
+               "name": [
+                    "(300209) 2006 WT151"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300209_2006_wt151::1.0"
           },
           {
-               "name": "(169071) 2001 FR185",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(169071) 2001 FR185"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.169071_2001_fr185::1.0"
           },
           {
-               "name": "1999 CQ133",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "1999 CQ133"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.1999_cq133::1.0"
           },
           {
-               "name": "MARINER 9",
-               "type": "Spacecraft",
+               "name": [
+                    "MARINER 9"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.mr9::1.0"
           },
           {
-               "name": "(79983) 1999 DF9",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(79983) 1999 DF9"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.79983_1999_df9::1.0"
           },
           {
-               "name": "1999 CH119",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "1999 CH119"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.1999_ch119::1.0"
           },
           {
-               "name": "2002 GB32",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2002 GB32"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2002_gb32::1.0"
           },
           {
-               "name": "SPACECRAFT DECK",
-               "type": "CALIBRATOR",
+               "name": [
+                    "SPACECRAFT DECK"
+               ],
+               "type": [
+                    "CALIBRATOR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:calibrator.spacecraft_deck::1.0"
           },
           {
-               "name": "2004 KC19",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2004 KC19"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2004_kc19::1.0"
           },
           {
-               "name": "1999 RT214",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "1999 RT214"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.1999_rt214::1.0"
           },
           {
-               "name": "ENERGETIC PARTICLE EXPERIMENT",
-               "type": "PARTICLE DETECTOR",
+               "name": [
+                    "ENERGETIC PARTICLE EXPERIMENT"
+               ],
+               "type": [
+                    "PARTICLE DETECTOR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:epa.gio::1.0"
           },
           {
-               "name": "(306792) 2001 KQ77",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(306792) 2001 KQ77"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.306792_2001_kq77::1.0"
           },
           {
-               "name": "1998 KY61",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "1998 KY61"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.1998_ky61::1.0"
           },
           {
-               "name": "InSight",
-               "type": "Lander",
+               "name": [
+                    "InSight"
+               ],
+               "type": [
+                    "Lander"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.insight::1.0"
           },
           {
-               "name": "(19299) 1996 SZ4",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(19299) 1996 SZ4"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.19299_1996_sz4::1.0"
           },
           {
-               "name": "2002 FW6",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2002 FW6"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2002_fw6::1.0"
           },
           {
-               "name": "BELLY WIND TUNNEL AT UC BERKELEY, RICHMOND FIELD STATION, BLDG. 276",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "BELLY WIND TUNNEL AT UC BERKELEY, RICHMOND FIELD STATION, BLDG. 276"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:ucberkeley-rfs.belly_wt::1.0"
           },
           {
-               "name": "C/1984 K1 (SHOEMAKER)",
-               "type": "COMET",
+               "name": [
+                    "C/1984 K1 (SHOEMAKER)"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.c1984_k1_shoemaker::1.0"
           },
           {
-               "name": "(300258) 2007 HT4",
-               "type": "ASTEROID",
+               "name": [
+                    "(300258) 2007 HT4"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300258_2007_ht4::1.0"
           },
           {
-               "name": "64P/SWIFT-GEHRELS",
-               "type": "COMET",
+               "name": [
+                    "64P/SWIFT-GEHRELS"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.64p_swift-gehrels::1.0"
           },
           {
-               "name": "(138628) 2000 QM251",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(138628) 2000 QM251"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.138628_2000_qm251::1.0"
           },
           {
-               "name": "(181874) 1999 HW11",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(181874) 1999 HW11"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.181874_1999_hw11::1.0"
           },
           {
-               "name": "(187661) 2007 JG43",
-               "type": "CENTAUR",
+               "name": [
+                    "(187661) 2007 JG43"
+               ],
+               "type": [
+                    "CENTAUR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:centaur.187661_2007_jg43::1.0"
           },
           {
-               "name": "DUST FLUX MONITOR INSTRUMENT",
-               "type": "DUST",
+               "name": [
+                    "DUST FLUX MONITOR INSTRUMENT"
+               ],
+               "type": [
+                    "DUST"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:dfmi.sdu::1.0"
           },
           {
-               "name": "(15836) 1995 DA2",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(15836) 1995 DA2"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.15836_1995_da2::1.0"
           },
           {
-               "name": "(41003) 1999 UZ12",
-               "type": "ASTEROID",
+               "name": [
+                    "(41003) 1999 UZ12"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.41003_1999_uz12::1.0"
           },
           {
-               "name": "2110 MOORE-SITTERLY",
-               "type": "ASTEROID",
+               "name": [
+                    "2110 MOORE-SITTERLY"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.2110_moore-sitterly::1.1"
           },
           {
-               "name": "81P/WILD 2",
-               "type": "COMET",
+               "name": [
+                    "81P/WILD 2"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.81p_wild_2::1.0"
           },
           {
-               "name": "2007 VK305",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2007 VK305"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2007_vk305::1.0"
           },
           {
-               "name": "NAVIGATION CAMERA",
-               "type": "IMAGER",
+               "name": [
+                    "NAVIGATION CAMERA"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:navcam.msl::1.0"
           },
           {
-               "name": "55P/TEMPEL-TUTTLE",
-               "type": "COMET",
+               "name": [
+                    "55P/TEMPEL-TUTTLE"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.55p_tempel-tuttle::1.0"
           },
           {
-               "name": "(84719) 2002 VR128",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(84719) 2002 VR128"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.84719_2002_vr128::1.0"
           },
           {
-               "name": "OLA",
-               "type": "ALTIMETER",
+               "name": [
+                    "OLA"
+               ],
+               "type": [
+                    "ALTIMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:ola.orex::1.0"
           },
           {
-               "name": "(149349) 2002 VA131",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(149349) 2002 VA131"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.149349_2002_va131::1.0"
           },
           {
-               "name": "DOPPLER WIND EXPERIMENT",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "DOPPLER WIND EXPERIMENT"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:dwe.hp::1.0"
           },
           {
-               "name": "(15535) 2000 AT177",
-               "type": "ASTEROID",
+               "name": [
+                    "(15535) 2000 AT177"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.15535_2000_at177::1.0"
           },
           {
-               "name": "60558 ECHECLUS",
-               "type": "CENTAUR",
+               "name": [
+                    "60558 ECHECLUS"
+               ],
+               "type": [
+                    "CENTAUR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:centaur.60558_echeclus::1.0"
           },
           {
-               "name": "2001 KA77",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2001 KA77"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2001_ka77::1.0"
           },
           {
-               "name": "2005 RP43",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2005 RP43"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2005_rp43::1.0"
           },
           {
-               "name": "SURFACE RADAR MAPPER",
-               "type": "RADIO-RADAR",
+               "name": [
+                    "SURFACE RADAR MAPPER"
+               ],
+               "type": [
+                    "RADIO-RADAR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:orad.pvo::1.0"
           },
           {
-               "name": "2000 JF81",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2000 JF81"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2000_jf81::1.0"
           },
           {
-               "name": "BRUKER IFS 125HR FOURIER TRANSFORM INFRARED SPECTROMETER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "BRUKER IFS 125HR FOURIER TRANSFORM INFRARED SPECTROMETER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:multi-host.brukifs125hr_ftspec::1.0"
           },
           {
-               "name": "XO-3",
-               "type": "STAR",
+               "name": [
+                    "XO-3"
+               ],
+               "type": [
+                    "STAR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:star.xo-3::1.0"
           },
           {
-               "name": "RADIO OCCULTATION EXPERIMENT",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "RADIO OCCULTATION EXPERIMENT"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:roe.v15::1.0"
           },
           {
-               "name": "LUNAR CRATER OBSERVATION AND SENSING SATELLITE",
-               "type": "Spacecraft",
+               "name": [
+                    "LUNAR CRATER OBSERVATION AND SENSING SATELLITE"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.lcross::1.1"
           },
           {
-               "name": "2005 TV189",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2005 TV189"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2005_tv189::1.0"
           },
           {
-               "name": "MARS ADVANCED RADAR FOR SUBSURFACE AND IONOSPHERE SOUNDING",
-               "type": "ALTIMETER",
+               "name": [
+                    "MARS ADVANCED RADAR FOR SUBSURFACE AND IONOSPHERE SOUNDING"
+               ],
+               "type": [
+                    "ALTIMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:marsis.mex::1.0"
           },
           {
-               "name": "(6369) 1983 UC",
-               "type": "ASTEROID",
+               "name": [
+                    "(6369) 1983 UC"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.6369_1983_uc::1.0"
           },
           {
-               "name": "MARINER 10",
-               "type": "Spacecraft",
+               "name": [
+                    "MARINER 10"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.m10::1.0"
           },
           {
-               "name": "APOLLO 12 COLD CATHODE ION GAGE EXPERIMENT",
-               "type": "PARTICLE DETECTOR",
+               "name": [
+                    "APOLLO 12 COLD CATHODE ION GAGE EXPERIMENT"
+               ],
+               "type": [
+                    "PARTICLE DETECTOR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:ccig.a12a::1.0"
           },
           {
-               "name": "GSC 03089-00929",
-               "type": "STAR",
+               "name": [
+                    "GSC 03089-00929"
+               ],
+               "type": [
+                    "STAR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:star.1swasp_j175207.01+373246.3::1.0"
           },
           {
-               "name": "MARS LABORATORY ANALOG",
-               "type": "LABORATORY ANALOG",
+               "name": [
+                    "MARS LABORATORY ANALOG"
+               ],
+               "type": [
+                    "LABORATORY ANALOG"
+               ],
                "lidvid": "urn:nasa:pds:context:target:laboratory_analog.mars::1.0"
           },
           {
-               "name": "(300245) 2007 EC20",
-               "type": "ASTEROID",
+               "name": [
+                    "(300245) 2007 EC20"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300245_2007_ec20::1.0"
           },
           {
-               "name": "TRENT ENVIRONMENTAL WIND TUNNEL",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "TRENT ENVIRONMENTAL WIND TUNNEL"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:tu-tewt.tewt::1.0"
           },
           {
-               "name": "SOLAR ENERGETIC PARTICLE INSTRUMENT",
-               "type": "ENERGETIC PARTICLE DETECTOR",
+               "name": [
+                    "SOLAR ENERGETIC PARTICLE INSTRUMENT"
+               ],
+               "type": [
+                    "ENERGETIC PARTICLE DETECTOR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:sep.maven::1.0"
           },
           {
-               "name": "2002 GP32",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2002 GP32"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2002_gp32::1.0"
           },
           {
-               "name": "NAVIGATION CAMERA RIGHT STRING B",
-               "type": "IMAGER",
+               "name": [
+                    "NAVIGATION CAMERA RIGHT STRING B"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:nav_right_b.msl::1.0"
           },
           {
-               "name": "(300230) 2006 YZ",
-               "type": "ASTEROID",
+               "name": [
+                    "(300230) 2006 YZ"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300230_2006_yz::1.0"
           },
           {
-               "name": "2000 YA2",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2000 YA2"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2000_ya2::1.0"
           },
           {
-               "name": "(182397) 2001 QW297",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(182397) 2001 QW297"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.182397_2001_qw297::1.0"
           },
           {
-               "name": "S/2004 S 12",
-               "type": "SATELLITE",
+               "name": [
+                    "S/2004 S 12"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.s2004s12::1.1"
           },
           {
-               "name": "1996 TS66",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "1996 TS66"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.1996_ts66::1.0"
           },
           {
-               "name": "1998 UR43",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "1998 UR43"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.1998_ur43::1.0"
           },
           {
-               "name": "PRE-MAGELLAN",
-               "type": "Mission",
+               "name": [
+                    "PRE-MAGELLAN"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.pre-magellan::1.1"
           },
           {
-               "name": "2000 PA30",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2000 PA30"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2000_pa30::1.0"
           },
           {
-               "name": "(86047) 1999 OY3",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(86047) 1999 OY3"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.86047_1999_oy3::1.0"
           },
           {
-               "name": "2006 QP180",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2006 QP180"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2006_qp180::1.0"
           },
           {
-               "name": "MICROSCOPIC IMAGER",
-               "type": "IMAGER",
+               "name": [
+                    "MICROSCOPIC IMAGER"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:mi.mer2::1.0"
           },
           {
-               "name": "VISIBLE SPECTROMETER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "VISIBLE SPECTROMETER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:vsp.lcross::1.0"
           },
           {
-               "name": "C/2001 Q4 (NEAT)",
-               "type": "COMET",
+               "name": [
+                    "C/2001 Q4 (NEAT)"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.c2001_q4_neat::1.0"
           },
           {
-               "name": "(24470) 2000 SJ310",
-               "type": "ASTEROID",
+               "name": [
+                    "(24470) 2000 SJ310"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.24470_2000_sj310::1.0"
           },
           {
-               "name": "ACCELEROMETER",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "ACCELEROMETER"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:accel.mgs::1.0"
           },
           {
-               "name": "NAVIGATION CAMERA",
-               "type": "IMAGER",
+               "name": [
+                    "NAVIGATION CAMERA"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:navcam.sdu::1.0"
           },
           {
-               "name": "MARS EXPLORATION ROVER 1",
-               "type": "Spacecraft",
+               "name": [
+                    "MARS EXPLORATION ROVER 1"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.mer1::1.0"
           },
           {
-               "name": "(160256) 2002 PD149",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(160256) 2002 PD149"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.160256_2002_pd149::1.0"
           },
           {
-               "name": "COMPOSITE INFRARED SPECTROMETER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "COMPOSITE INFRARED SPECTROMETER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:cirs.co::1.0"
           },
           {
-               "name": "(469707) 2005 GB187",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(469707) 2005 GB187"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.469707_2005_gb187::1.0"
           },
           {
-               "name": "(181871) 1999 CO153",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(181871) 1999 CO153"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.181871_1999_co153::1.0"
           },
           {
-               "name": "2060 CHIRON",
-               "type": "CENTAUR",
+               "name": [
+                    "2060 CHIRON"
+               ],
+               "type": [
+                    "CENTAUR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:centaur.2060_chiron::1.0"
           },
           {
-               "name": "CONTOUR FORWARD IMAGER",
-               "type": "IMAGER",
+               "name": [
+                    "CONTOUR FORWARD IMAGER"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:cfi.con::1.0"
           },
           {
-               "name": "(37360) 2001 UZ24",
-               "type": "ASTEROID",
+               "name": [
+                    "(37360) 2001 UZ24"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.37360_2001_uz24::1.0"
           },
           {
-               "name": "FLUXGATE MAGNETOMETER",
-               "type": "MAGNETOMETER",
+               "name": [
+                    "FLUXGATE MAGNETOMETER"
+               ],
+               "type": [
+                    "MAGNETOMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:mag.vg1::1.0"
           },
           {
-               "name": "(54869) 2001 OP43",
-               "type": "ASTEROID",
+               "name": [
+                    "(54869) 2001 OP43"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.54869_2001_op43::1.0"
           },
           {
-               "name": "MARINER 6 WIDE ANGLE CAMERA",
-               "type": "IMAGER",
+               "name": [
+                    "MARINER 6 WIDE ANGLE CAMERA"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:wac.mr6::1.0"
           },
           {
-               "name": "COSPIN-HIGH ENERGY TELESCOPE",
-               "type": "PARTICLE DETECTOR",
+               "name": [
+                    "COSPIN-HIGH ENERGY TELESCOPE"
+               ],
+               "type": [
+                    "PARTICLE DETECTOR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:cospin-het.uly::1.0"
           },
           {
-               "name": "(129746) 1999 CE119",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(129746) 1999 CE119"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.129746_1999_ce119::1.0"
           },
           {
-               "name": "(41379) 2000 AS105",
-               "type": "ASTEROID",
+               "name": [
+                    "(41379) 2000 AS105"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.41379_2000_as105::1.0"
           },
           {
-               "name": "2000 CE105",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2000 CE105"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2000_ce105::1.0"
           },
           {
-               "name": "LUNAR RECONNAISSANCE ORBITER CAMERA",
-               "type": "IMAGER",
+               "name": [
+                    "LUNAR RECONNAISSANCE ORBITER CAMERA"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:lroc.lro::1.0"
           },
           {
-               "name": "D/1993 F2-H (SHOEMAKER-LEVY 9-H)",
-               "type": "COMET",
+               "name": [
+                    "D/1993 F2-H (SHOEMAKER-LEVY 9-H)"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.d1993_f2-h_shoemaker-levy_9-h::1.0"
           },
           {
-               "name": "(60454) 2000 CH105",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(60454) 2000 CH105"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.60454_2000_ch105::1.0"
           },
           {
-               "name": "(26375) 1999 DE9",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(26375) 1999 DE9"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.26375_1999_de9::1.0"
           },
           {
-               "name": "DEEP IMPACT HIGH RESOLUTION INSTRUMENT - VISIBLE CCD",
-               "type": "IMAGER",
+               "name": [
+                    "DEEP IMPACT HIGH RESOLUTION INSTRUMENT - VISIBLE CCD"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:hriv.dif::1.0"
           },
           {
-               "name": "COSPIN-HIGH FLUX TELESCOPE",
-               "type": "PARTICLE DETECTOR",
+               "name": [
+                    "COSPIN-HIGH FLUX TELESCOPE"
+               ],
+               "type": [
+                    "PARTICLE DETECTOR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:cospin-hft.uly::1.0"
           },
           {
-               "name": "(300172) 2006 VS168",
-               "type": "ASTEROID",
+               "name": [
+                    "(300172) 2006 VS168"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300172_2006_vs168::1.0"
           },
           {
-               "name": "CANON EOS DIGITAL REBEL XT",
-               "type": "IMAGER",
+               "name": [
+                    "CANON EOS DIGITAL REBEL XT"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:rebelxt.n-a::1.0"
           },
           {
-               "name": "SA 92",
-               "type": "STAR",
+               "name": [
+                    "SA 92"
+               ],
+               "type": [
+                    "STAR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:star.sa_92::1.0"
           },
           {
-               "name": "MARS COLOR IMAGER",
-               "type": "IMAGER",
+               "name": [
+                    "MARS COLOR IMAGER"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:marci.mro::1.0"
           },
           {
-               "name": "(33001) 1997 CU29",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(33001) 1997 CU29"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.33001_1997_cu29::1.0"
           },
           {
-               "name": "LONG-WAVELENGTH REDUNDANT",
-               "type": "SPECTROGRAPH",
+               "name": [
+                    "LONG-WAVELENGTH REDUNDANT"
+               ],
+               "type": [
+                    "SPECTROGRAPH"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:lwr.iue::1.0"
           },
           {
-               "name": "INTERPLANETARY MAGNETIC FIELD EXPERIMENT",
-               "type": "MAGNETOMETER",
+               "name": [
+                    "INTERPLANETARY MAGNETIC FIELD EXPERIMENT"
+               ],
+               "type": [
+                    "MAGNETOMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:imf.sakig::1.0"
           },
           {
-               "name": "NAVIGATION CAMERA RIGHT STRING A",
-               "type": "IMAGER",
+               "name": [
+                    "NAVIGATION CAMERA RIGHT STRING A"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:nav_right_a.msl::1.0"
           },
           {
-               "name": "C/2000 WM1 (LINEAR)",
-               "type": "COMET",
+               "name": [
+                    "C/2000 WM1 (LINEAR)"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.c2000_wm1_linear::1.0"
           },
           {
-               "name": "(21566) 1998 QM103",
-               "type": "ASTEROID",
+               "name": [
+                    "(21566) 1998 QM103"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.21566_1998_qm103::1.0"
           },
           {
-               "name": "MARINER 7",
-               "type": "Spacecraft",
+               "name": [
+                    "MARINER 7"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.mr7::1.1"
           },
           {
-               "name": "ORTHOSIE",
-               "type": "SATELLITE",
+               "name": [
+                    "ORTHOSIE"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.orthosie::1.1"
           },
           {
-               "name": "GRAIN IMPACT ANALYSER AND DUST ACCUMULATOR",
-               "type": "DUST",
+               "name": [
+                    "GRAIN IMPACT ANALYSER AND DUST ACCUMULATOR"
+               ],
+               "type": [
+                    "DUST"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:giada.ro::1.0"
           },
           {
-               "name": "MICROWAVE RADIOMETER",
-               "type": "RADIOMETER",
+               "name": [
+                    "MICROWAVE RADIOMETER"
+               ],
+               "type": [
+                    "RADIOMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:mwr.jno::1.0"
           },
           {
-               "name": "2000 FF8",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2000 FF8"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2000_ff8::1.0"
           },
           {
-               "name": "INFRARED SPECTROMETER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "INFRARED SPECTROMETER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:irs.mr6::1.0"
           },
           {
-               "name": "(15809) 1994 JS",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(15809) 1994 JS"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.15809_1994_js::1.0"
           },
           {
-               "name": "(300227) 2006 XA52",
-               "type": "ASTEROID",
+               "name": [
+                    "(300227) 2006 XA52"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300227_2006_xa52::1.0"
           },
           {
-               "name": "IUE",
-               "type": "Mission",
+               "name": [
+                    "IUE"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.iue::1.0"
           },
           {
-               "name": "LYMAN ALPHA MAPPING PROJECT",
-               "type": "SPECTROGRAPH",
+               "name": [
+                    "LYMAN ALPHA MAPPING PROJECT"
+               ],
+               "type": [
+                    "SPECTROGRAPH"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:lamp.lro::1.0"
           },
           {
-               "name": "S/2006 S 3",
-               "type": "SATELLITE",
+               "name": [
+                    "S/2006 S 3"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.s2006s3::1.1"
           },
           {
-               "name": "2003 YQ179",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2003 YQ179"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2003_yq179::1.0"
           },
           {
-               "name": "PIONEER 11",
-               "type": "Mission",
+               "name": [
+                    "PIONEER 11"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.pioneer_11::1.0"
           },
           {
-               "name": "(447178) 2005 RO43",
-               "type": "CENTAUR",
+               "name": [
+                    "(447178) 2005 RO43"
+               ],
+               "type": [
+                    "CENTAUR"
+               ],
                "lidvid": "urn:nasa:pds:context:target:centaur.447178_2005_ro43::1.0"
           },
           {
-               "name": "C/2003 A2 (GLEASON)",
-               "type": "COMET",
+               "name": [
+                    "C/2003 A2 (GLEASON)"
+               ],
+               "type": [
+                    "COMET"
+               ],
                "lidvid": "urn:nasa:pds:context:target:comet.c2003_a2_gleason::1.1"
           },
           {
-               "name": "182 ELSA",
-               "type": "ASTEROID",
+               "name": [
+                    "182 ELSA"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.182_elsa::1.1"
           },
           {
-               "name": "LIGHT DETECTION AND RANGING INSTRUMENT",
-               "type": "ALTIMETER",
+               "name": [
+                    "LIGHT DETECTION AND RANGING INSTRUMENT"
+               ],
+               "type": [
+                    "ALTIMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:lidar.hay::1.0"
           },
           {
-               "name": "S/2003 J 16",
-               "type": "SATELLITE",
+               "name": [
+                    "S/2003 J 16"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.s2003j16::1.1"
           },
           {
-               "name": "20000 VARUNA",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "20000 VARUNA"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.20000_varuna::1.1"
           },
           {
-               "name": "PIONEER 9",
-               "type": "Mission",
+               "name": [
+                    "PIONEER 9"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.pioneer_9::1.0"
           },
           {
-               "name": "(300253) 2007 GP7",
-               "type": "ASTEROID",
+               "name": [
+                    "(300253) 2007 GP7"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300253_2007_gp7::1.0"
           },
           {
-               "name": "(300174) 2006 WM11",
-               "type": "ASTEROID",
+               "name": [
+                    "(300174) 2006 WM11"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300174_2006_wm11::1.0"
           },
           {
-               "name": "(300205) 2006 WH125",
-               "type": "ASTEROID",
+               "name": [
+                    "(300205) 2006 WH125"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300205_2006_wh125::1.0"
           },
           {
-               "name": "(300224) 2006 XJ43",
-               "type": "ASTEROID",
+               "name": [
+                    "(300224) 2006 XJ43"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300224_2006_xj43::1.0"
           },
           {
-               "name": "TAYGETE",
-               "type": "SATELLITE",
+               "name": [
+                    "TAYGETE"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.taygete::1.1"
           },
           {
-               "name": "BESTLA",
-               "type": "SATELLITE",
+               "name": [
+                    "BESTLA"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.bestla::1.1"
           },
           {
-               "name": "LYSITHEA",
-               "type": "SATELLITE",
+               "name": [
+                    "LYSITHEA"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.lysithea::1.1"
           },
           {
-               "name": "ROSETTA-ORBITER",
-               "type": "Spacecraft",
+               "name": [
+                    "ROSETTA-ORBITER"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.ro::1.1"
           },
           {
-               "name": "2007 WD5",
-               "type": "ASTEROID",
+               "name": [
+                    "2007 WD5"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.2007_wd5::1.0"
           },
           {
-               "name": "INERTIAL MEASUREMENT UNIT",
-               "type": "ATMOSPHERIC SCIENCES",
+               "name": [
+                    "INERTIAL MEASUREMENT UNIT"
+               ],
+               "type": [
+                    "ATMOSPHERIC SCIENCES"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:imu.mer2::1.0"
           },
           {
-               "name": "GIOTTO EXTENDED MISSION",
-               "type": "Mission",
+               "name": [
+                    "GIOTTO EXTENDED MISSION"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.giotto_extended_mission::1.1"
           },
           {
-               "name": "MARS CLIMATE SOUNDER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "MARS CLIMATE SOUNDER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:mcs.mro::1.0"
           },
           {
-               "name": "STARFIELD",
-               "type": "CALIBRATION FIELD",
+               "name": [
+                    "STARFIELD"
+               ],
+               "type": [
+                    "CALIBRATION FIELD"
+               ],
                "lidvid": "urn:nasa:pds:context:target:calibration_field.starfield::1.0"
           },
           {
-               "name": "ARIEL",
-               "type": "SATELLITE",
+               "name": [
+                    "ARIEL"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.uranus.ariel::1.1"
           },
           {
-               "name": "SPONDE",
-               "type": "SATELLITE",
+               "name": [
+                    "SPONDE"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.sponde::1.1"
           },
           {
-               "name": "MID-INFRARED SPECTROMETER AND IMAGER",
-               "type": "SPECTROMETER",
+               "name": [
+                    "MID-INFRARED SPECTROMETER AND IMAGER"
+               ],
+               "type": [
+                    "SPECTROMETER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:irtf.3m0.mirsi::1.0"
           },
           {
-               "name": "DEEP SPACE PROGRAM SCIENCE EXPERIMENT",
-               "type": "Mission",
+               "name": [
+                    "DEEP SPACE PROGRAM SCIENCE EXPERIMENT"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.deep_space_program_science_experiment::1.1"
           },
           {
-               "name": "S/2010 J 1",
-               "type": "SATELLITE",
+               "name": [
+                    "S/2010 J 1"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.s2010j1::1.1"
           },
           {
-               "name": "YMIR",
-               "type": "SATELLITE",
+               "name": [
+                    "YMIR"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.saturn.ymir::1.1"
           },
           {
-               "name": "HIMALIA",
-               "type": "SATELLITE",
+               "name": [
+                    "HIMALIA"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.himalia::1.1"
           },
           {
-               "name": "(307616) 2003 QW90",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(307616) 2003 QW90"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.307616_2003_qw90::1.0"
           },
           {
-               "name": "TRITON",
-               "type": "SATELLITE",
+               "name": [
+                    "TRITON"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.neptune.triton::1.1"
           },
           {
-               "name": "MIRANDA",
-               "type": "SATELLITE",
+               "name": [
+                    "MIRANDA"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.uranus.miranda::1.1"
           },
           {
-               "name": "48424 SOUCHAY",
-               "type": "ASTEROID",
+               "name": [
+                    "48424 SOUCHAY"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.48424_souchay::1.1"
           },
           {
-               "name": "1137 RAISSA",
-               "type": "ASTEROID",
+               "name": [
+                    "1137 RAISSA"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.1137_raissa::1.1"
           },
           {
-               "name": "APOLLO 17",
-               "type": "Mission",
+               "name": [
+                    "APOLLO 17"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.apollo_17::1.1"
           },
           {
-               "name": "2005 CA79",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "2005 CA79"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2005_ca79::1.0"
           },
           {
-               "name": "19 FORTUNA",
-               "type": "ASTEROID",
+               "name": [
+                    "19 FORTUNA"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.19_fortuna::1.1"
           },
           {
-               "name": "(300182) 2006 WJ53",
-               "type": "ASTEROID",
+               "name": [
+                    "(300182) 2006 WJ53"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.300182_2006_wj53::1.0"
           },
           {
-               "name": "APOLLO 16",
-               "type": "Mission",
+               "name": [
+                    "APOLLO 16"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.apollo_16::1.1"
           },
           {
-               "name": "(42301) 2001 UR163",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(42301) 2001 UR163"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.42301_2001_ur163::1.0"
           },
           {
-               "name": "HAZARD AVOIDANCE CAMERA",
-               "type": "IMAGER",
+               "name": [
+                    "HAZARD AVOIDANCE CAMERA"
+               ],
+               "type": [
+                    "IMAGER"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:hazcam.mer2::1.0"
           },
           {
-               "name": "COSMIC RAY TELESCOPE",
-               "type": "PARTICLE DETECTOR",
+               "name": [
+                    "COSMIC RAY TELESCOPE"
+               ],
+               "type": [
+                    "PARTICLE DETECTOR"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:crt.p10::1.0"
           },
           {
-               "name": "38 LEDA",
-               "type": "ASTEROID",
+               "name": [
+                    "38 LEDA"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.38_leda::1.1"
           },
           {
-               "name": "S/2011 J 2",
-               "type": "SATELLITE",
+               "name": [
+                    "S/2011 J 2"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.s2011j2::1.1"
           },
           {
-               "name": "KALLICHORE",
-               "type": "SATELLITE",
+               "name": [
+                    "KALLICHORE"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.kallichore::1.1"
           },
           {
-               "name": "OSIRIS-REX",
-               "type": "Mission",
+               "name": [
+                    "OSIRIS-REX"
+               ],
+               "type": [
+                    "Mission"
+               ],
                "lidvid": "urn:nasa:pds:context:investigation:mission.orex::1.1"
           },
           {
-               "name": "NEREID",
-               "type": "SATELLITE",
+               "name": [
+                    "NEREID"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.neptune.nereid::1.1"
           },
           {
-               "name": "5026 MARTES",
-               "type": "ASTEROID",
+               "name": [
+                    "5026 MARTES"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.5026_martes::1.1"
           },
           {
-               "name": "12379 THULIN",
-               "type": "ASTEROID",
+               "name": [
+                    "12379 THULIN"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
                "lidvid": "urn:nasa:pds:context:target:asteroid.12379_thulin::1.1"
           },
           {
-               "name": "VIKING ORBITER 2",
-               "type": "Spacecraft",
+               "name": [
+                    "VIKING ORBITER 2"
+               ],
+               "type": [
+                    "Spacecraft"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.vo2::1.1"
           },
           {
-               "name": "(29981) 1999 TD10",
-               "type": "TRANS-NEPTUNIAN OBJECT",
+               "name": [
+                    "(29981) 1999 TD10"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
                "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.29981_1999_td10::1.0"
           },
           {
-               "name": "RADIO SCIENCE SUBSYSTEM",
-               "type": "RADIO SCIENCE",
+               "name": [
+                    "RADIO SCIENCE SUBSYSTEM"
+               ],
+               "type": [
+                    "RADIO SCIENCE"
+               ],
                "lidvid": "urn:nasa:pds:context:instrument:rss.mess::1.1"
           },
           {
-               "name": "PSAMATHE",
-               "type": "SATELLITE",
+               "name": [
+                    "PSAMATHE"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.neptune.psamathe::1.1"
           },
           {
-               "name": "KORE",
-               "type": "SATELLITE",
+               "name": [
+                    "KORE"
+               ],
+               "type": [
+                    "SATELLITE"
+               ],
                "lidvid": "urn:nasa:pds:context:target:satellite.jupiter.kore::1.1"
           }
      ]

--- a/src/test/java/gov/nasa/pds/validate/ValidationIntegrationTests.java
+++ b/src/test/java/gov/nasa/pds/validate/ValidationIntegrationTests.java
@@ -190,6 +190,7 @@ class ValidationIntegrationTests {
 
             //System.out.println("Test file: " + testPath + File.separator + "test_check-pass_context_products.xml");
             String[] args = {
+                    "-v1",
                     "-r", report.getAbsolutePath(),
                     "-s", "json",
                     "-R", "pds4.label",
@@ -197,14 +198,13 @@ class ValidationIntegrationTests {
                     };
 
             ValidateLauncher.main(args);
-
             Gson gson = new Gson();
             JsonObject reportJson = gson.fromJson(new FileReader(report), JsonObject.class);
 
             int count = this.getMessageCount(reportJson, ProblemType.CONTEXT_REFERENCE_FOUND.getKey());
             count += this.getMessageCount(reportJson, ProblemType.CONTEXT_REFERENCE_NOT_FOUND.getKey());
 
-            assertEquals(count, 0, "No errors expected for invalid context reference (Lid, name, value) test.");
+            assertEquals(count, 4, "4 valid context references should be found.");
 
             //get warnings/errors test
             report = new File(outFilePath + File.separator + "report_github15_no-pass.json");
@@ -263,7 +263,9 @@ class ValidationIntegrationTests {
 
             // System.out.println("Test file: " + testPath + File.separator +
             // "test_context_products.xml");
-            String[] args2 = { "-r", report.getAbsolutePath(), "-s", "json", "-R", "pds4.label",
+            String[] args2 = {
+                    "-r", report.getAbsolutePath(), 
+                    "-s", "json", "-R", "pds4.label",
                     testPath + File.separator + "test_context_products.xml" };
 
             ValidateLauncher.main(args2);
@@ -441,7 +443,7 @@ class ValidationIntegrationTests {
                     
                     };
             ValidateLauncher.main(args2);
-            
+
             gson = new Gson();
             reportJson = gson.fromJson(new FileReader(report), JsonObject.class);
 

--- a/src/test/resources/github28/new_context.json
+++ b/src/test/resources/github28/new_context.json
@@ -1,8 +1,8 @@
 {
 	"Product_Context": [
 		{
-			"name": "FOO",
-			"type": "Spacecraft",
+			"name": [ "FOO" ],
+			"type": [ "Spacecraft" ],
 			"lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.FOO::1.0"
 		}
 	]


### PR DESCRIPTION
Per the IM, both name and type can be multi-valued, so the context product name/type rule should allow that.

Resolves #107