### PR TITLE
Updated parent LID check to include ':'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
   <groupId>gov.nasa.pds</groupId>
   <artifactId>validate</artifactId>
-  <version>1.18.0-SNAPSHOT-SNAPSHOT</version>
+  <version>1.18.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/AbstractValidationRule.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/AbstractValidationRule.java
@@ -13,8 +13,10 @@
 // $Id$
 package gov.nasa.pds.tools.validate.rule;
 
+import gov.nasa.pds.tools.label.ExceptionType;
 import gov.nasa.pds.tools.validate.ProblemDefinition;
 import gov.nasa.pds.tools.validate.ProblemListener;
+import gov.nasa.pds.tools.validate.ProblemType;
 import gov.nasa.pds.tools.validate.TargetRegistrar;
 import gov.nasa.pds.tools.validate.ValidationTarget;
 import gov.nasa.pds.tools.validate.ValidationProblem;
@@ -206,6 +208,42 @@ public abstract class AbstractValidationRule implements ValidationRule {
    */
   public final void setCaption(String caption) {
     this.caption = caption;
+  }
+  
+  /**
+   * Verifies that the lid contains the parent bundle/collection lid. Applies to
+   * Bundle and Collection referential integrity (L5.PRP.VA.36)
+   * 
+   * @see gov.nasa.pds.tools.validate.rule.pds4.BundleReferentialIntegrityRule
+   * @see gov.nasa.pds.tools.validate.rule.pds4.CollectionReferentialIntegrityRule
+   * 
+   * @param lid
+   * @param parentLid
+   * @param status
+   * @param url
+   */
+  protected void verifyLidPrefix (String lid, String parentLid, String status,
+          URL url) {
+    if (!status.equalsIgnoreCase("Primary")) {
+        return;
+    }
+    if (!lid.startsWith(parentLid + ":")) {
+      getListener().addProblem(new ValidationProblem(
+          new ProblemDefinition(
+              ExceptionType.ERROR,
+              ProblemType.MISSING_PARENT_PREFIX,
+              "Member LID " + lid + " does not begin with required parent LID " +
+              parentLid),
+          url));
+    } else {
+        getListener().addProblem(new ValidationProblem(
+            new ProblemDefinition(
+                ExceptionType.INFO,
+                ProblemType.PARENT_PREFIX_FOUND,
+                "Member LID " + lid + " begins with required parent LID " +
+                parentLid),
+            url));
+    }
   }
 
 }

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/BundleReferentialIntegrityRule.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/BundleReferentialIntegrityRule.java
@@ -234,28 +234,4 @@ public class BundleReferentialIntegrityRule extends AbstractValidationRule {
     return results;
   }
   
-  private void verifyLidPrefix (String lid, String parentLid, String status,
-      URL bundle) {
-	if (!status.equalsIgnoreCase("Primary")) {
-		return;
-	}
-	if (!lid.startsWith(parentLid)) {
-      getListener().addProblem(new ValidationProblem(
-	      new ProblemDefinition(
-	          ExceptionType.ERROR,
-	          ProblemType.MISSING_PARENT_PREFIX,
-	          "Member LID " + lid + " does not begin with parent LID " +
-	          parentLid),
-	      bundle));
-	} else {
-		getListener().addProblem(new ValidationProblem(
-			new ProblemDefinition(
-			    ExceptionType.INFO,
-			    ProblemType.PARENT_PREFIX_FOUND,
-			    "Member LID " + lid + " begins with parent LID " +
-			    parentLid),
-			bundle));
-	}
-  }
-  
 }

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/CollectionReferentialIntegrityRule.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/CollectionReferentialIntegrityRule.java
@@ -217,29 +217,4 @@ public class CollectionReferentialIntegrityRule extends AbstractValidationRule {
     return results;
   }
   
-  private void verifyLidPrefix (String lid, String parentLid, String status,
-      URL collection) {
-    if (!status.equalsIgnoreCase("P")) {
-    	  //System.out.println("Non-primary member: " + lid + ", " + status);
-	  return;
-    }
-	if (!lid.startsWith(parentLid)) {
-	  getListener().addProblem(new ValidationProblem(
-		  new ProblemDefinition(
-		       ExceptionType.ERROR,
-		       ProblemType.MISSING_PARENT_PREFIX,
-		       "Member LID " + lid + " does not begin with parent LID " +
-		       parentLid),
-		   collection));
-	} else {
-	  getListener().addProblem(new ValidationProblem(
-		  new ProblemDefinition(
-			   ExceptionType.INFO,
-			   ProblemType.PARENT_PREFIX_FOUND,
-			   "Member LID " + lid + " begins with parent LID " +
-			   parentLid),
-		    collection));
-	}
-  }
-  
 }


### PR DESCRIPTION
Previous implementation did not ensure exact validity of parent bundle/collection lid.

Updates also include a refactoring to move method to parent abstract class

Resolves #139