### PR TITLE
Issue #124: The tool shall average less than 1 second execution time when content validation is disabled

### DIFF
--- a/src/main/java/gov/nasa/pds/tools/label/LocationValidator.java
+++ b/src/main/java/gov/nasa/pds/tools/label/LocationValidator.java
@@ -136,6 +136,14 @@ public class LocationValidator {
 		} else {
 			LOG.info("Using validation style '{}' for location {}", 
 			    rule.getCaption(), location);
+
+			if (rule.getCaption().startsWith("PDS4 Label")) {
+			  if (ruleContext.getCheckData())
+				 rule = ruleManager.findRuleByName("pds4.label");
+			  else
+			    rule = ruleManager.findRuleByName("pds4.label.skip.content");	
+			}
+			
 			if (!rule.isApplicable(location)) {
 			  LOG.error("'{}' validation style is not applicable for location {}", 
 			      rule.getCaption(), location);
@@ -180,7 +188,7 @@ public class LocationValidator {
 			validationType = validationRule;
 		}
 		ValidationRule rule;
-
+		//System.out.println("validationType = " + validationType);		
 		if (validationType == null) {
 		  URI uri = null;
 		  try {
@@ -307,6 +315,9 @@ public class LocationValidator {
 	public void setSkipProductValidation(boolean flag) {
 	  ruleContext.setSkipProductValidation(flag);
 	  labelValidator.setSkipProductValidation(flag);
+	  
+	  //if (flag)
+		//  ruleContext.setCheckData()
 	}
 	
 	/**

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/LabelInFolderRule.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/LabelInFolderRule.java
@@ -47,6 +47,11 @@ public class LabelInFolderRule extends AbstractValidationRule {
   public void validateLabelsInFolder() {
     ValidationRule labelRule = getContext().getRuleManager().findRuleByName("pds4.label");
     
+    // issue_124: 
+    if (!getContext().getCheckData()) {
+      labelRule = getContext().getRuleManager().findRuleByName("pds4.label.skip.content");
+    }
+    
     Crawler crawler = getContext().getCrawler();
     try {
       for (Target t : crawler.crawl(getTarget(), false, getContext().getFileFilters())) {

--- a/src/main/resources/validation-commands.xml
+++ b/src/main/resources/validation-commands.xml
@@ -7,7 +7,7 @@
     <command caption="XML files are labels" className="gov.nasa.pds.tools.validate.rule.pds4.LabelInFolderRule" />
     <command caption="Subdirectories of folder" className="gov.nasa.pds.tools.validate.rule.pds4.SubDirectoryRule" />
   </chain>
-
+  
   <command name="pds4.label" caption="PDS4 Label" className="gov.nasa.pds.tools.validate.rule.pds4.LabelValidationChain">
     <command caption="Register targets" className="gov.nasa.pds.tools.validate.rule.RegisterTargets" />
     <command caption="PDS4 label validity" className="gov.nasa.pds.tools.validate.rule.pds4.LabelValidationRule" />
@@ -19,7 +19,18 @@
     <command caption="Data Content matches table descriptions in label" className="gov.nasa.pds.tools.validate.rule.pds4.TableDataContentValidationRule" />
     <command caption="Data Content matches array descriptions in label" className="gov.nasa.pds.tools.validate.rule.pds4.ArrayContentValidationRule" />
     <command caption="Record validation results" className="gov.nasa.pds.tools.validate.rule.RecordValidationResults" />
-  </command>   
+  </command>
+  
+  <command name="pds4.label.skip.content" caption="PDS4 Label Skip Content" className="gov.nasa.pds.tools.validate.rule.pds4.LabelValidationChain">
+    <command caption="Register targets" className="gov.nasa.pds.tools.validate.rule.RegisterTargets" />
+    <command caption="PDS4 label validity" className="gov.nasa.pds.tools.validate.rule.pds4.LabelValidationRule" />
+    <command caption="Validate file references in label" className="gov.nasa.pds.tools.validate.rule.pds4.FileReferenceValidationRule" />
+    <command caption="Validate context product references in label" className="gov.nasa.pds.tools.validate.rule.pds4.ContextProductReferenceValidationRule"/>
+    <command caption="Validate Referenced Local Identifiers in label" className="gov.nasa.pds.tools.validate.rule.pds4.LocalIdentifierReferencesRule"/>
+    <command caption="Register file references" className="gov.nasa.pds.tools.validate.rule.pds4.RegisterTargetReferences" />
+    <command caption="Register label identifiers" className="gov.nasa.pds.tools.validate.rule.pds4.RegisterLabelIdentifiers" />
+    <command caption="Record validation results" className="gov.nasa.pds.tools.validate.rule.RecordValidationResults" />
+  </command>    
 
   <chain name="pds4.bundle" caption="PDS4 Bundle" className="gov.nasa.pds.tools.validate.rule.pds4.BundleValidationRule">
     <command caption="Register targets" className="gov.nasa.pds.tools.validate.rule.RegisterTargets" />


### PR DESCRIPTION
Added new command chain 'pds4.label.skip.content' to use when --skip-content-validation flag is on.

Resolves #124 