### PR TITLE
issue_156:  Performance Log Metrics and more

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,6 +164,7 @@ POSSIBILITY OF SUCH DAMAGE.
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>buildnumber-maven-plugin</artifactId>
+        <version>1.4</version>
         <executions>
           <execution>
             <phase>validate</phase>
@@ -183,8 +184,8 @@ POSSIBILITY OF SUCH DAMAGE.
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
+        <version>3.1.1</version>
         <executions>
           <execution>
             <id>bin-release</id>
@@ -197,6 +198,7 @@ POSSIBILITY OF SUCH DAMAGE.
                 <descriptor>src/main/assembly/tar-assembly.xml</descriptor>
                 <descriptor>src/main/assembly/zip-assembly.xml</descriptor>
               </descriptors>
+              <tarLongFileMode>posix</tarLongFileMode>
             </configuration>
           </execution>
         </executions>
@@ -211,11 +213,11 @@ POSSIBILITY OF SUCH DAMAGE.
       </plugin>
       <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.22.2</version>
+          <version>3.0.0-M3</version>
       </plugin>
       <plugin>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>2.22.2</version>
+          <version>3.0.0-M3</version>
       </plugin>
     </plugins>
   </build>
@@ -242,10 +244,10 @@ POSSIBILITY OF SUCH DAMAGE.
       <id>snapshots-repo</id>
       <url>https://oss.sonatype.org/content/repositories/snapshots</url>
       <releases>
-  <enabled>false</enabled>
+        <enabled>false</enabled>
       </releases>
       <snapshots>
-  <enabled>true</enabled>
+        <enabled>true</enabled>
       </snapshots>
     </repository>
   </repositories>
@@ -258,6 +260,7 @@ POSSIBILITY OF SUCH DAMAGE.
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-source-plugin</artifactId>
+            <version>3.1.0</version>
             <executions>
               <execution>
                 <id>attach-sources</id>
@@ -272,6 +275,7 @@ POSSIBILITY OF SUCH DAMAGE.
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
+            <version>3.1.1</version>
             <configuration>
               <source>1.8</source>
               <failOnError>false</failOnError>
@@ -288,7 +292,7 @@ POSSIBILITY OF SUCH DAMAGE.
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.5</version>
+            <version>1.6</version>
             <executions>
                 <execution>
                     <id>sign-artifacts</id>
@@ -326,7 +330,7 @@ POSSIBILITY OF SUCH DAMAGE.
     <dependency>
       <groupId>commons-configuration</groupId>
       <artifactId>commons-configuration</artifactId>
-      <version>1.6</version>
+      <version>1.7</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -347,7 +351,7 @@ POSSIBILITY OF SUCH DAMAGE.
    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-nop</artifactId>
-      <version>1.7.25</version>
+      <version>1.7.28</version>
     </dependency>         
     <dependency>
       <groupId>com.jamesmurty.utils</groupId>
@@ -367,12 +371,12 @@ POSSIBILITY OF SUCH DAMAGE.
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
-      <version>1.16</version>
+      <version>1.19</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>18.0</version>
+      <version>23.0</version>
     </dependency>
     <dependency>
       <groupId>xerces</groupId>
@@ -439,6 +443,7 @@ POSSIBILITY OF SUCH DAMAGE.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-project-info-reports-plugin</artifactId>
+        <version>3.0.0</version>
         <reportSets>
           <reportSet>
             <reports>
@@ -455,6 +460,7 @@ POSSIBILITY OF SUCH DAMAGE.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-changes-plugin</artifactId>
+        <version>2.12.1</version>
         <reportSets>
           <reportSet>
             <reports>

--- a/src/main/java/gov/nasa/pds/tools/label/ExceptionType.java
+++ b/src/main/java/gov/nasa/pds/tools/label/ExceptionType.java
@@ -38,6 +38,22 @@ public enum ExceptionType {
     return this.value;
   }
 
+  public boolean isDebugApplicable() {
+    return getValue() >= DEBUG.getValue();
+  }
+
+  public boolean isInfoApplicable() {
+    return getValue() >= INFO.getValue();
+  }
+
+  public boolean isWarningApplicable() {
+    return getValue() >= WARNING.getValue();
+  }
+
+  public boolean isErrorApplicable() {
+    return getValue() >= ERROR.getValue();
+  }
+
   public String getName() {
     return this.name;
   }

--- a/src/main/java/gov/nasa/pds/tools/label/LocationValidator.java
+++ b/src/main/java/gov/nasa/pds/tools/label/LocationValidator.java
@@ -74,13 +74,14 @@ public class LocationValidator {
 	 * @throws TransformerConfigurationException if a label validator cannot 
 	 * configure its transformer
 	 */
-	public LocationValidator() throws TransformerConfigurationException, 
+	public LocationValidator(ExceptionType logLevel) throws TransformerConfigurationException,
 	ParserConfigurationException {
 		settingsManager = SettingsManager.INSTANCE;
 		taskManager = new BlockingTaskManager();
 		labelValidator = ValidationResourceManager.INSTANCE.getResource(
 		    LabelValidator.class);
 		ruleContext = new RuleContext();
+		ruleContext.setLogLevel(logLevel);
 		
 		ConfigParser parser = new ConfigParser();
 		URL commandsURL = ClassLoader.getSystemResource("validation-commands.xml");

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/AbstractValidationRule.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/AbstractValidationRule.java
@@ -90,6 +90,7 @@ public abstract class AbstractValidationRule implements ValidationRule {
 	    throws MalformedURLException, URISyntaxException {
     RuleContext newContext = new RuleContext();
 
+    newContext.setLogLevel(context.getLogLevel());
     newContext.setProblemListener(context.getProblemListener());
     newContext.setRuleManager(context.getRuleManager());
     newContext.setTargetRegistrar(context.getTargetRegistrar());
@@ -243,5 +244,9 @@ public abstract class AbstractValidationRule implements ValidationRule {
                 url));
         }
     }
+  }
+
+  protected boolean isInfoLogLevel() {
+  	return getContext().getLogLevel().isInfoApplicable();
   }
 }

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/RuleContext.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/RuleContext.java
@@ -13,6 +13,7 @@
 // $Id$
 package gov.nasa.pds.tools.validate.rule;
 
+import gov.nasa.pds.tools.label.ExceptionType;
 import gov.nasa.pds.tools.label.LocationValidator;
 import gov.nasa.pds.tools.label.XMLCatalogResolver;
 import gov.nasa.pds.tools.util.ContextProductReference;
@@ -114,6 +115,8 @@ public class RuleContext extends ContextBase {
   
   private boolean rootTarget = false;
 
+  private ExceptionType logLevel;
+
   /**
    * Gets a value from the context in a type-safe manner.
    *
@@ -138,6 +141,12 @@ public class RuleContext extends ContextBase {
    */
   public <T> void putContextValue(String key, T value) {
     put(key, value);
+  }
+
+  public ExceptionType getLogLevel() { return logLevel; }
+
+  public void setLogLevel(ExceptionType logLevel) {
+      this.logLevel = logLevel;
   }
 
   public URL getTarget() {  

--- a/src/main/java/gov/nasa/pds/validate/ValidatorFactory.java
+++ b/src/main/java/gov/nasa/pds/validate/ValidatorFactory.java
@@ -30,6 +30,7 @@
 
 package gov.nasa.pds.validate;
 
+import gov.nasa.pds.tools.label.ExceptionType;
 import gov.nasa.pds.tools.label.LocationValidator;
 import gov.nasa.pds.tools.label.ValidatorException;
 import gov.nasa.pds.tools.label.validate.DocumentValidator;
@@ -86,11 +87,10 @@ public class ValidatorFactory {
    * @throws ValidatorException Validator error occurred.
    * @throws TransformerConfigurationException Transformer configuration error occurred.
    */
-  public LocationValidator newInstance(URL target) throws ValidatorException,
+  public LocationValidator newInstance(ExceptionType logLevel) throws ValidatorException,
   TransformerConfigurationException, ParserConfigurationException {
-    Validator validator = null;
     if (cachedValidator == null) {
-    	cachedValidator = new LocationValidator();
+    	cachedValidator = new LocationValidator(logLevel);
     	cachedValidator.setModelVersion(modelVersion);
     	for(DocumentValidator dv : documentValidators) {
     		cachedValidator.addValidator(dv);

--- a/src/main/java/gov/nasa/pds/validate/util/Utility.java
+++ b/src/main/java/gov/nasa/pds/validate/util/Utility.java
@@ -35,6 +35,7 @@ import gov.nasa.pds.validate.target.Target;
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.io.FileUtils;
@@ -57,11 +58,12 @@ public class Utility {
    * @param list A list of strings.
    * @return A list with the quotes removed.
    */
-  public static List<String> removeQuotes(List<String> list) {
-    for (int i = 0; i < list.size(); i++) {
-      list.set(i, list.get(i).toString().replace('"', ' ').trim());
+  public static List<String> removeQuotes(List<Object> list) {
+    List<String> strList = new ArrayList<>();
+    for (Object obj : list) {
+      strList.add(obj.toString().replace('"', ' ').trim());
     }
-    return list;
+    return strList;
   }
 
   public static String toStringNoBraces(JsonObject json) {

--- a/src/test/parallel.sh
+++ b/src/test/parallel.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+NUM=$1
+SRC_DIR=$2
+VALIDATE_BIN=$3
+
+ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $ROOT
+
+time find ${SRC_DIR} -name "*.xml" | head -$NUM | parallel --jobs 200% ${VALIDATE_BIN}/validate
+

--- a/src/test/parallel2.sh
+++ b/src/test/parallel2.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+NUM=$1
+SRC_DIR=$2
+VALIDATE_BIN=$3
+
+ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $ROOT
+
+time find ${SRC_DIR} -name "*.xml" | head -$NUM | parallel ${VALIDATE_BIN}/validate
+

--- a/src/test/timing_metrics.sh
+++ b/src/test/timing_metrics.sh
@@ -4,14 +4,19 @@ ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $ROOT
 
 rm -rf temp
-mkdir temp
+mkdir -p temp/insight_cameras/data/0001
 cd temp
 
 curl -O https://starbase.jpl.nasa.gov/pds4/1900/dph_examples_v1900.zip
-
 unzip dph_examples_v1900.zip
 
+scp -r ghollins@pds-dev-el7:/data/home/pds4/insight_cameras/data/0001/ ./insight_cameras/data/0001
+
 cd ../../..
+
+echo "----------------------------------"
+pwd
+echo "----------------------------------"
 
 mvn clean
 mvn package -DskipTests
@@ -21,15 +26,22 @@ tar zxf validate-*-bin.tar.gz
 
 cd ${ROOT}
 
+echo "RUNNING AGAINST A DIRECTORY WITH 80 FILES..."
+time ../../target/validate-*/bin/validate  temp//insight_cameras/data/0001/0001/mipl/rdr/idc
+
+#echo "RUNNING SINGLE XML FILE"
+#time ../../target/validate-*/bin/validate ${ROOT}/C000M0010_597420115CNF_C0000_0461M3.xml
+
 echo "RUNNING FULL CONTENT VALIDATION ON A ~4.8GB FILE."
-echo "  (As of 2019-09-20:  should take 9-10 minutes to complete)"
+echo "  (As of 2019-11-20:  should take 9:21 to complete)"
 time ../../target/validate-*/bin/validate ./temp/V1900/dph_example_archive/data_imagecube/virs/H01/virs_cube_64ppd_h01np.xml
-exit 0
+
 #
 # SMALL
 #
 time ../../target/validate-*/bin/validate ./temp/V1900/dph_example_archive/data_tnmap/thermal_neutron_map.xml
 exit 0
+
 #
 # LARGE --no-data-check
 #


### PR DESCRIPTION
This change adds performance timing logging of array content
and label validation.  The logging will be enabled at verbosity
level 1 (INFO) or below (e.g. DEBUG).

Also, the hooks for experimentation of multi-threading has
been setup at the LabelInFolderRule level.  In other words a
thread pool exists, that can run targets within a folder
concurrently.  However, due to thread safety issues with the
current code and libraries, the thread level is currently set
to one (no multi-threading).  In the future, this can be
experimented with.  A few synchronized locks have been placed
throughout the code, where multi-threading proved problematic
during experimentation.  More may be needed in the future.
When the thread level is set to greater than one, the
performance does improve, but there are failures sometimes,
due to thread saftety issues.  If this can be solved, real
performance gains can be realized.

Some basic GNU parallel scripts have been added in the
src/test directory, as well, for future experimentation into
running validate concurrently at the JVM level.

Also, some library versions have been upgraded in the pom.xml.

Resolves #156 