### PR TITLE
Update all timing metrics to only appear for DEBUG

### DIFF
--- a/src/main/java/gov/nasa/pds/tools/validate/ProblemType.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/ProblemType.java
@@ -216,7 +216,9 @@ public enum ProblemType {
 
     FIELD_VALUE_DATA_TYPE_MATCH("debug.table.field_value_matches_data_type"),
 
-    BIT_FIELD_MATCH("debug.table.bit_field_match");
+    BIT_FIELD_MATCH("debug.table.bit_field_match"),
+    
+    TIMING_METRICS("debug.execution.time");
 
     private final String key;
 

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/AbstractValidationRule.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/AbstractValidationRule.java
@@ -249,4 +249,8 @@ public abstract class AbstractValidationRule implements ValidationRule {
   protected boolean isInfoLogLevel() {
   	return getContext().getLogLevel().isInfoApplicable();
   }
+
+  protected boolean isDebugLogLevel() {
+      return getContext().getLogLevel().isDebugApplicable();
+    }
 }

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/ArrayContentValidationRule.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/ArrayContentValidationRule.java
@@ -225,8 +225,8 @@ public class ArrayContentValidationRule extends AbstractValidationRule {
       fileAreaObserveIndex++;
     }
 
-    if (isInfoLogLevel()) {
-      System.out.println(System.currentTimeMillis() + " :: " + targetFileName + " :: validateArray() in " + (System.currentTimeMillis() - t0) + " ms");
+    if (isDebugLogLevel()) {
+      System.out.println("\nDEBUG  [" + ProblemType.TIMING_METRICS.getKey() + "]  " + System.currentTimeMillis() + " :: " + targetFileName + " :: validateArray() in " + (System.currentTimeMillis() - t0) + " ms\n");
     }
   }
   

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/LabelInFolderRule.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/LabelInFolderRule.java
@@ -85,7 +85,7 @@ public class LabelInFolderRule extends AbstractValidationRule {
           e.printStackTrace();
         }
 
-        System.out.println("COMPLETED " + targetCount + " targets.");
+//        System.out.println("COMPLETED " + targetCount + " targets.");
 
       } catch (IOException io) {
         reportError(GenericProblems.UNCAUGHT_EXCEPTION, getContext().getTarget(), -1, -1, io.getMessage());

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/LabelValidationRule.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/LabelValidationRule.java
@@ -192,8 +192,8 @@ public class LabelValidationRule extends AbstractValidationRule {
       }
       long t1 = System.currentTimeMillis();
 
-      if (isInfoLogLevel()) {
-        System.out.println(System.currentTimeMillis() + " :: " + targetFileName + " :: validateLabel() in " + (t1 - t0) + " ms");
+      if (isDebugLogLevel()) {
+        System.out.println("\nDEBUG  [" + ProblemType.TIMING_METRICS.getKey() + "]  " + System.currentTimeMillis() + " :: " + targetFileName + " :: validateLabel() in " + (t1 - t0) + " ms\n");
       }
 	}
 	

--- a/src/main/java/gov/nasa/pds/validate/ValidateLauncher.java
+++ b/src/main/java/gov/nasa/pds/validate/ValidateLauncher.java
@@ -1257,8 +1257,8 @@ public class ValidateLauncher {
             }
         }
 
-        if (severity.isWarningApplicable()) {
-            System.out.println(System.currentTimeMillis() + " :: Validation complete (" + targets.size() + " targets completed in " + (System.currentTimeMillis() - t0) + " ms)");
+        if (severity.isDebugApplicable()) {
+            System.out.println("\nDEBUG  [" + ProblemType.TIMING_METRICS.getKey() + "]  " + System.currentTimeMillis() + " :: Validation complete (" + targets.size() + " targets completed in " + (System.currentTimeMillis() - t0) + " ms)\n");
         }
     }
 
@@ -1354,7 +1354,7 @@ public class ValidateLauncher {
      * @param args
      *            list of command-line arguments.
      */
-    public void processMain(String[] args) {
+    public void processMain(String[] args) throws Exception {
         long t0 = System.currentTimeMillis();
         try {
             CommandLine cmdLine = parse(args);
@@ -1424,10 +1424,10 @@ public class ValidateLauncher {
             }
             printReportFooter();
             if (severity.isDebugApplicable()) {
-                System.out.println(System.currentTimeMillis() + " :: processMain() in " + (System.currentTimeMillis() - t0) + " ms\n");
+                System.out.println("DEBUG  [" + ProblemType.TIMING_METRICS.getKey() + "]  " + System.currentTimeMillis() + " :: processMain() in " + (System.currentTimeMillis() - t0) + " ms\n");
             }
         } catch (Exception e) {
-            System.out.println(e.getMessage());
+            throw new Exception(e);
         }
     }
     
@@ -1462,8 +1462,12 @@ public class ValidateLauncher {
         ca.setThreshold(Priority.FATAL);
         BasicConfigurator.configure(ca);
 
-        new ValidateLauncher().processMain(args);
-        System.out.println(System.currentTimeMillis() + " :: main in " + (System.currentTimeMillis()-t0) + " ms\n");
+        try {
+            new ValidateLauncher().processMain(args);
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+        }
+        System.out.println("Completed execution in " + (System.currentTimeMillis()-t0) + " ms\n");
     }
 
     /**


### PR DESCRIPTION
The timing metrics may be of interest to some, but most people don't care.
Changed all timing metrics to only appear during DEBUG, except for end of execution
timing.

Resolves #160