### PR TITLE
Revert back to Saxon 9.5.1-3 to avoid schematron bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,8 +160,7 @@ POSSIBILITY OF SUCH DAMAGE.
     <dependency>
       <groupId>net.sf.saxon</groupId>
       <artifactId>Saxon-HE</artifactId>
-      <!--<version>9.6.0-5</version>-->
-      <version>9.9.1-4</version>
+      <version>9.5.1-3</version>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>

--- a/src/main/java/gov/nasa/pds/tools/label/validate/DefaultDocumentValidator.java
+++ b/src/main/java/gov/nasa/pds/tools/label/validate/DefaultDocumentValidator.java
@@ -31,8 +31,6 @@ import gov.nasa.pds.tools.validate.ValidationProblem;
 import net.sf.saxon.om.DocumentInfo;
 import net.sf.saxon.tree.tiny.TinyNodeImpl;
 
-import javax.xml.transform.Source;
-
 /**
  * The intent of this class is to perform some default semantic validation
  * on the parsed PDS4 label.
@@ -46,7 +44,7 @@ public class DefaultDocumentValidator implements DocumentValidator {
       "/processing-instruction('xml-model')";
 
   @Override
-  public boolean validate(ProblemHandler handler, Source xml) {
+  public boolean validate(ProblemHandler handler, DocumentInfo xml) {
     boolean passFlag = true;
     // Check the xml-model processing instructions specification
     List<TinyNodeImpl> xmlModels = new ArrayList<TinyNodeImpl>();

--- a/src/main/java/gov/nasa/pds/tools/label/validate/DocumentValidator.java
+++ b/src/main/java/gov/nasa/pds/tools/label/validate/DocumentValidator.java
@@ -17,8 +17,6 @@ package gov.nasa.pds.tools.label.validate;
 import gov.nasa.pds.tools.validate.ProblemHandler;
 import net.sf.saxon.om.DocumentInfo;
 
-import javax.xml.transform.Source;
-
 public interface DocumentValidator {
 
   /**
@@ -29,5 +27,5 @@ public interface DocumentValidator {
    *
    * @return flag indicating whether or not the step in validation was passed.
    */
-  public boolean validate(ProblemHandler handler, Source xml);
+  public boolean validate(ProblemHandler handler, DocumentInfo xml);
 }

--- a/src/main/java/gov/nasa/pds/tools/label/validate/FileReferenceValidator.java
+++ b/src/main/java/gov/nasa/pds/tools/label/validate/FileReferenceValidator.java
@@ -31,7 +31,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.xml.transform.Source;
 import javax.xml.xpath.XPathExpressionException;
 
 import org.apache.commons.io.FileUtils;
@@ -68,7 +67,7 @@ public class FileReferenceValidator implements DocumentValidator {
   }
 
   @Override
-  public boolean validate(ProblemHandler handler, Source xml) {
+  public boolean validate(ProblemHandler handler, DocumentInfo xml) {
     boolean passFlag = true;
     URL systemIdUrl = null;
     try {

--- a/src/main/java/gov/nasa/pds/tools/util/XMLExtractor.java
+++ b/src/main/java/gov/nasa/pds/tools/util/XMLExtractor.java
@@ -21,7 +21,6 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.transform.Source;
 import javax.xml.transform.sax.SAXSource;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpressionException;
@@ -29,7 +28,6 @@ import javax.xml.xpath.XPathExpressionException;
 import net.sf.saxon.Configuration;
 import net.sf.saxon.lib.ParseOptions;
 import net.sf.saxon.om.DocumentInfo;
-import net.sf.saxon.om.TreeInfo;
 import net.sf.saxon.tree.tiny.TinyNodeImpl;
 import net.sf.saxon.trans.XPathException;
 import net.sf.saxon.xpath.XPathEvaluator;
@@ -43,7 +41,7 @@ import org.xml.sax.InputSource;
 */
 public class XMLExtractor {
     /** The DOM source. */
-    private Source xml = null;
+    private DocumentInfo xml = null;
 
     /** The XPath evaluator object. */
     private XPathEvaluator xpath = null;
@@ -67,12 +65,11 @@ public class XMLExtractor {
      * the default namespace.
      *
      */
-    public XMLExtractor(Source xml) throws XPathExpressionException,
+    public XMLExtractor(DocumentInfo xml) throws XPathExpressionException,
     XPathException {
       this.xml = xml;
-      this.xpath = new XPathEvaluator();
-        Configuration configuration = xpath.getConfiguration();
-
+      this.xpath = new XPathEvaluator(this.xml.getConfiguration());
+      Configuration configuration = xpath.getConfiguration();
       configuration.setLineNumbering(true);
       configuration.setXIncludeAware(Utility.supportXincludes());
       String definedNamespace = getValueFromDoc("namespace-uri(/*)");
@@ -154,8 +151,7 @@ public class XMLExtractor {
      */
     public String getValueFromDoc(String expression)
     throws XPathExpressionException, XPathException {
-        TreeInfo ti = xpath.getConfiguration().buildDocumentTree(xml);
-        return getValueFromItem(expression, ti); //xpath.setSource(xml));
+        return getValueFromItem(expression, xpath.setSource(xml));
     }
 
     /**
@@ -184,8 +180,8 @@ public class XMLExtractor {
      * @throws XPathExpressionException If the given expression was malformed.
      */
     public TinyNodeImpl getNodeFromDoc(String expression)
-            throws XPathExpressionException, XPathException {
-        return getNodeFromItem(expression, xpath.getConfiguration().buildDocumentTree(xml));
+    throws XPathExpressionException, XPathException {
+        return getNodeFromItem(expression, xml);
     }
 
     /**
@@ -215,8 +211,8 @@ public class XMLExtractor {
      * @throws XPathExpressionException If the given expression was malformed.
      */
     public List<String> getValuesFromDoc(String expression)
-            throws XPathExpressionException, XPathException {
-        return getValuesFromItem(expression, xpath.getConfiguration().buildDocumentTree(xml));
+    throws XPathExpressionException, XPathException {
+        return getValuesFromItem(expression, xml);
     }
 
     /**
@@ -250,8 +246,8 @@ public class XMLExtractor {
      * @return The Document Node.
      * @throws XPathException
      */
-    public Source getDocNode() throws XPathException {
-        return xml;
+    public DocumentInfo getDocNode() throws XPathException {
+        return xpath.setSource(xml).getDocumentRoot();
     }
 
     /**
@@ -264,8 +260,8 @@ public class XMLExtractor {
      * @throws XPathExpressionException If the given expression was malformed.
      */
     public List<TinyNodeImpl> getNodesFromDoc(String expression)
-            throws XPathExpressionException, XPathException {
-        return getNodesFromItem(expression, xpath.getConfiguration().buildDocumentTree(xml));
+    throws XPathExpressionException, XPathException {
+        return getNodesFromItem(expression, xml);
     }
 
     /**


### PR DESCRIPTION
Saxon HE 9.5.1-4 introduced a bug when attempting to do comparison operations with count() values.

A temporary workaround has been found for the Schematron rules, but a rollback to previous Saxon is probably the better route for now.

Resolves #175