### PR TITLE
Upgrade Saxon to help prevent memory leak

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
   <groupId>gov.nasa.pds</groupId>
   <artifactId>validate</artifactId>
-  <version>1.19.0-SNAPSHOT</version>
+  <version>1.20.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>${project.groupId}:${project.artifactId}</name>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@ POSSIBILITY OF SUCH DAMAGE.
   </licenses>
   
   <properties>
-    <pds4-jparser.version>1.4.0-SNAPSHOT</pds4-jparser.version>
+    <pds4-jparser.version>1.3.2</pds4-jparser.version>
     <model-version>1D00</model-version>
     <pds3-product-tools.version>4.0.1</pds3-product-tools.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,8 @@ POSSIBILITY OF SUCH DAMAGE.
     <dependency>
       <groupId>net.sf.saxon</groupId>
       <artifactId>Saxon-HE</artifactId>
-      <version>9.5.1-3</version>
+      <!--<version>9.6.0-5</version>-->
+      <version>9.9.1-4</version>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>

--- a/src/main/java/gov/nasa/pds/tools/label/SchematronTransformer.java
+++ b/src/main/java/gov/nasa/pds/tools/label/SchematronTransformer.java
@@ -115,7 +115,7 @@ public class SchematronTransformer {
       isoTransformer.transform(source, new StreamResult(
           schematronStyleSheet));
       transformer = transformerFactory.newTransformer(
-          new StreamSource(new StringReader(schematronStyleSheet.toString())));
+          new StreamSource(new StringReader(cleanSchematronStylesheet(schematronStyleSheet.toString()))));
     }
     return transformer;
   }
@@ -169,7 +169,7 @@ public class SchematronTransformer {
           schematronStyleSheet));
         transformer = transformerFactory.newTransformer(
             new StreamSource(new StringReader(
-                schematronStyleSheet.toString())));
+                    cleanSchematronStylesheet(schematronStyleSheet.toString()))));
       } catch (TransformerException te) {
         // Only throw problem if a handler was not set.
         if (handler == null) {
@@ -197,5 +197,9 @@ public class SchematronTransformer {
       }
     }
     return transformer;
+  }
+  
+  public String cleanSchematronStylesheet(String stylesheet) {
+    return stylesheet.replace("parent::node()", "node()[child::node()]");
   }
 }

--- a/src/main/java/gov/nasa/pds/tools/label/validate/DefaultDocumentValidator.java
+++ b/src/main/java/gov/nasa/pds/tools/label/validate/DefaultDocumentValidator.java
@@ -31,6 +31,8 @@ import gov.nasa.pds.tools.validate.ValidationProblem;
 import net.sf.saxon.om.DocumentInfo;
 import net.sf.saxon.tree.tiny.TinyNodeImpl;
 
+import javax.xml.transform.Source;
+
 /**
  * The intent of this class is to perform some default semantic validation
  * on the parsed PDS4 label.
@@ -44,7 +46,7 @@ public class DefaultDocumentValidator implements DocumentValidator {
       "/processing-instruction('xml-model')";
 
   @Override
-  public boolean validate(ProblemHandler handler, DocumentInfo xml) {
+  public boolean validate(ProblemHandler handler, Source xml) {
     boolean passFlag = true;
     // Check the xml-model processing instructions specification
     List<TinyNodeImpl> xmlModels = new ArrayList<TinyNodeImpl>();

--- a/src/main/java/gov/nasa/pds/tools/label/validate/DocumentValidator.java
+++ b/src/main/java/gov/nasa/pds/tools/label/validate/DocumentValidator.java
@@ -17,6 +17,8 @@ package gov.nasa.pds.tools.label.validate;
 import gov.nasa.pds.tools.validate.ProblemHandler;
 import net.sf.saxon.om.DocumentInfo;
 
+import javax.xml.transform.Source;
+
 public interface DocumentValidator {
 
   /**
@@ -27,5 +29,5 @@ public interface DocumentValidator {
    *
    * @return flag indicating whether or not the step in validation was passed.
    */
-  public boolean validate(ProblemHandler handler, DocumentInfo xml);
+  public boolean validate(ProblemHandler handler, Source xml);
 }

--- a/src/main/java/gov/nasa/pds/tools/util/XMLExtractor.java
+++ b/src/main/java/gov/nasa/pds/tools/util/XMLExtractor.java
@@ -21,6 +21,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.xml.transform.Source;
 import javax.xml.transform.sax.SAXSource;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpressionException;
@@ -28,6 +29,7 @@ import javax.xml.xpath.XPathExpressionException;
 import net.sf.saxon.Configuration;
 import net.sf.saxon.lib.ParseOptions;
 import net.sf.saxon.om.DocumentInfo;
+import net.sf.saxon.om.TreeInfo;
 import net.sf.saxon.tree.tiny.TinyNodeImpl;
 import net.sf.saxon.trans.XPathException;
 import net.sf.saxon.xpath.XPathEvaluator;
@@ -41,7 +43,7 @@ import org.xml.sax.InputSource;
 */
 public class XMLExtractor {
     /** The DOM source. */
-    private DocumentInfo xml = null;
+    private Source xml = null;
 
     /** The XPath evaluator object. */
     private XPathEvaluator xpath = null;
@@ -65,11 +67,12 @@ public class XMLExtractor {
      * the default namespace.
      *
      */
-    public XMLExtractor(DocumentInfo xml) throws XPathExpressionException,
+    public XMLExtractor(Source xml) throws XPathExpressionException,
     XPathException {
       this.xml = xml;
-      this.xpath = new XPathEvaluator(this.xml.getConfiguration());
-      Configuration configuration = xpath.getConfiguration();
+      this.xpath = new XPathEvaluator();
+        Configuration configuration = xpath.getConfiguration();
+
       configuration.setLineNumbering(true);
       configuration.setXIncludeAware(Utility.supportXincludes());
       String definedNamespace = getValueFromDoc("namespace-uri(/*)");
@@ -151,7 +154,8 @@ public class XMLExtractor {
      */
     public String getValueFromDoc(String expression)
     throws XPathExpressionException, XPathException {
-        return getValueFromItem(expression, xpath.setSource(xml));
+        TreeInfo ti = xpath.getConfiguration().buildDocumentTree(xml);
+        return getValueFromItem(expression, ti); //xpath.setSource(xml));
     }
 
     /**
@@ -180,8 +184,8 @@ public class XMLExtractor {
      * @throws XPathExpressionException If the given expression was malformed.
      */
     public TinyNodeImpl getNodeFromDoc(String expression)
-    throws XPathExpressionException, XPathException {
-        return getNodeFromItem(expression, xml);
+            throws XPathExpressionException, XPathException {
+        return getNodeFromItem(expression, xpath.getConfiguration().buildDocumentTree(xml));
     }
 
     /**
@@ -211,8 +215,8 @@ public class XMLExtractor {
      * @throws XPathExpressionException If the given expression was malformed.
      */
     public List<String> getValuesFromDoc(String expression)
-    throws XPathExpressionException, XPathException {
-        return getValuesFromItem(expression, xml);
+            throws XPathExpressionException, XPathException {
+        return getValuesFromItem(expression, xpath.getConfiguration().buildDocumentTree(xml));
     }
 
     /**
@@ -246,8 +250,8 @@ public class XMLExtractor {
      * @return The Document Node.
      * @throws XPathException
      */
-    public DocumentInfo getDocNode() throws XPathException {
-        return xpath.setSource(xml).getDocumentRoot();
+    public Source getDocNode() throws XPathException {
+        return xml;
     }
 
     /**
@@ -260,8 +264,8 @@ public class XMLExtractor {
      * @throws XPathExpressionException If the given expression was malformed.
      */
     public List<TinyNodeImpl> getNodesFromDoc(String expression)
-    throws XPathExpressionException, XPathException {
-        return getNodesFromItem(expression, xml);
+            throws XPathExpressionException, XPathException {
+        return getNodesFromItem(expression, xpath.getConfiguration().buildDocumentTree(xml));
     }
 
     /**


### PR DESCRIPTION
Saxon downgrade brought memory leak back. Update includes a hacked workaround to also hopefully prevent `parent::node()` issue that caused the initial downgrade.

Resolves #183 