### PR TITLE
Add validated product counter to pass/fail reporting and end summary

### DIFF
--- a/src/main/java/gov/nasa/pds/tools/validate/rule/RuleContext.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/RuleContext.java
@@ -1,16 +1,32 @@
-// Copyright 2006-2018, by the California Institute of Technology.
-// ALL RIGHTS RESERVED. United States Government Sponsorship acknowledged.
-// Any commercial use must be negotiated with the Office of Technology Transfer
-// at the California Institute of Technology.
+// Copyright © 2019, California Institute of Technology ("Caltech").
+// U.S. Government sponsorship acknowledged.
 //
-// This software is subject to U. S. export control laws and regulations
-// (22 C.F.R. 120-130 and 15 C.F.R. 730-774). To the extent that the software
-// is subject to U.S. export control laws and regulations, the recipient has
-// the responsibility to obtain export licenses or other export authority as
-// may be required before exporting such information to foreign countries or
-// providing access to foreign nationals.
+// All rights reserved.
 //
-// $Id$
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// • Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+// • Redistributions must reproduce the above copyright notice, this list of
+//   conditions and the following disclaimer in the documentation and/or other
+//   materials provided with the distribution.
+// • Neither the name of Caltech nor its operating division, the Jet Propulsion
+//   Laboratory, nor the names of its contributors may be used to endorse or
+//   promote products derived from this software without specific prior written
+//   permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 package gov.nasa.pds.tools.validate.rule;
 
 import gov.nasa.pds.tools.label.ExceptionType;

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/SetReportHeader.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/SetReportHeader.java
@@ -1,16 +1,32 @@
-// Copyright 2006-2017, by the California Institute of Technology.
-// ALL RIGHTS RESERVED. United States Government Sponsorship acknowledged.
-// Any commercial use must be negotiated with the Office of Technology Transfer
-// at the California Institute of Technology.
+// Copyright © 2019, California Institute of Technology ("Caltech").
+// U.S. Government sponsorship acknowledged.
 //
-// This software is subject to U. S. export control laws and regulations
-// (22 C.F.R. 120-130 and 15 C.F.R. 730-774). To the extent that the software
-// is subject to U.S. export control laws and regulations, the recipient has
-// the responsibility to obtain export licenses or other export authority as
-// may be required before exporting such information to foreign countries or
-// providing access to foreign nationals.
+// All rights reserved.
 //
-// $Id$
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// • Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+// • Redistributions must reproduce the above copyright notice, this list of
+//   conditions and the following disclaimer in the documentation and/or other
+//   materials provided with the distribution.
+// • Neither the name of Caltech nor its operating division, the Jet Propulsion
+//   Laboratory, nor the names of its contributors may be used to endorse or
+//   promote products derived from this software without specific prior written
+//   permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 package gov.nasa.pds.tools.validate.rule;
 
 import gov.nasa.pds.tools.validate.ListenerExceptionPropagator;

--- a/src/main/java/gov/nasa/pds/validate/report/FullReport.java
+++ b/src/main/java/gov/nasa/pds/validate/report/FullReport.java
@@ -36,6 +36,7 @@ import gov.nasa.pds.tools.validate.ValidationProblem;
 import gov.nasa.pds.tools.validate.content.array.ArrayContentProblem;
 import gov.nasa.pds.tools.validate.content.table.TableContentProblem;
 import gov.nasa.pds.validate.status.Status;
+import gov.nasa.pds.tools.util.Utility;
 
 import java.io.PrintWriter;
 import java.net.URI;
@@ -125,7 +126,9 @@ public class FullReport extends Report {
       writer.print("    End Content Validation: ");
       writer.println(dataFile);
     }  
-    writer.println("   ** Targets completed: " + numProducts + " product(s)/folder(s).");
+    // issue_132: for the progress monitoring
+    if (!Utility.isDir(sourceUri.toString())) 
+      writer.println("   ** Targets completed: " + totalProducts + " product(s)."); 
   }
 
   private void printProblem(PrintWriter writer,

--- a/src/main/java/gov/nasa/pds/validate/report/FullReport.java
+++ b/src/main/java/gov/nasa/pds/validate/report/FullReport.java
@@ -60,6 +60,14 @@ public class FullReport extends Report {
   @Override
   protected void printHeader(PrintWriter writer, String title) {
     //writer.println("Validation Details:");
+
+    // A hacky way to properly track when we are completing product validation versus integrity 
+    // checks. Once we try to print a header other than the initial product level validation,
+    // we are now into integrity checks.
+    if (title.toLowerCase().contains("pds4 bundle") || title.toLowerCase().contains("pds4 collection")) {
+        this.integrityCheckFlag = true;
+    }
+
     writer.println();
     writer.println();
     writer.println(title);
@@ -127,8 +135,18 @@ public class FullReport extends Report {
       writer.println(dataFile);
     }  
     // issue_132: for the progress monitoring
-    if (!Utility.isDir(sourceUri.toString())) 
-      writer.println("   ** Targets completed: " + totalProducts + " product(s)."); 
+    if (!Utility.isDir(sourceUri.toString())) {
+      String msg = "";
+      if (totalProducts > 0) {
+        msg = "        " + totalProducts + " product validation(s) completed";
+      }
+      
+      if (totalIntegrityChecks > 0) {
+        msg = "        " + totalIntegrityChecks + " integrity check(s) completed";
+      }
+
+      writer.println(msg);
+    }
   }
 
   private void printProblem(PrintWriter writer,

--- a/src/main/java/gov/nasa/pds/validate/report/FullReport.java
+++ b/src/main/java/gov/nasa/pds/validate/report/FullReport.java
@@ -124,7 +124,8 @@ public class FullReport extends Report {
       }
       writer.print("    End Content Validation: ");
       writer.println(dataFile);
-    }    
+    }  
+    writer.println("   ** Targets completed: " + numProducts + " product(s)/folder(s).");
   }
 
   private void printProblem(PrintWriter writer,

--- a/src/main/java/gov/nasa/pds/validate/report/Report.java
+++ b/src/main/java/gov/nasa/pds/validate/report/Report.java
@@ -258,7 +258,6 @@ public abstract class Report {
     this.numProducts++;
     this.totalProducts = this.numFailed + this.numPassed + this.numSkipped;
     printRecordMessages(this.writer, status, sourceUri, problems);
-    //this.writer.println(" *Targets completed: " + numProducts + " product(s) of " + totalProducts + ".");
     this.writer.flush();
     return status;
   }

--- a/src/main/java/gov/nasa/pds/validate/report/Report.java
+++ b/src/main/java/gov/nasa/pds/validate/report/Report.java
@@ -78,6 +78,8 @@ public abstract class Report {
   private int numSkipped;
   private int numFailed;
   private int numPassed;
+  protected int totalProducts; 
+  protected int numProducts;
   protected final List<String> parameters;
   protected final List<String> configurations;
   protected PrintWriter writer;
@@ -253,7 +255,10 @@ public abstract class Report {
     } else {
       this.numPassed++;
     }
+    this.numProducts++;
+    this.totalProducts = this.numFailed + this.numPassed + this.numSkipped;
     printRecordMessages(this.writer, status, sourceUri, problems);
+    //this.writer.println(" *Targets completed: " + numProducts + " product(s) of " + totalProducts + ".");
     this.writer.flush();
     return status;
   }
@@ -317,6 +322,7 @@ public abstract class Report {
     if (problem.getProblem().getSeverity().getValue() <= this.level.getValue()) {
       printRecordSkip(this.writer, sourceUri, problem);
     }
+    this.numProducts++;
     return Status.SKIP;
   }
 
@@ -353,6 +359,12 @@ public abstract class Report {
     writer.println("  " + totalErrors + " error(s)");
     writer.println("  " + totalWarnings + " warning(s)");
     writer.println();
+    writer.println("  Number of Passed product(s)/folder(s):  " + getNumPassed());
+    writer.println("  Number of Failed product(s)/folder(s):  " + getNumFailed());
+    writer.println("  Number of Skipped product(s)/folder(s): " + getNumSkipped());
+    writer.println("  Total Number of product(s)/folder(s):   " + getTotalProducts());
+    writer.println();
+    
     if (!this.messageSummary.isEmpty()) {
       writer.println("  Message Types:");
       Map<String, Long> sortedMessageSummary = sortMessageSummary(this.messageSummary);
@@ -365,6 +377,8 @@ public abstract class Report {
     }
     writer.println();
     writer.println("End of Report");
+    
+    
 
 	if (this.deprecatedFlagWarning) {
       writer.println();
@@ -404,6 +418,10 @@ public abstract class Report {
    */
   public int getNumSkipped() {
     return this.numSkipped;
+  }
+  
+  public int getTotalProducts() {
+	return this.totalProducts;
   }
 
   /**

--- a/src/main/java/gov/nasa/pds/validate/report/Report.java
+++ b/src/main/java/gov/nasa/pds/validate/report/Report.java
@@ -73,6 +73,7 @@ public abstract class Report {
                                                     "      of other flags. Please change software execution to use the new flag to avoid any issues.");
 
   private boolean deprecatedFlagWarning;
+  protected boolean integrityCheckFlag;
   private int totalWarnings;
   private int totalErrors;
   private int totalInfos;
@@ -82,8 +83,12 @@ public abstract class Report {
   private int numPassedProds;
   private int numFailedProds;
   private int numSkippedProds;
-  protected int totalProducts; 
+  protected int totalProducts;
   protected int numProducts;
+  private int numPassedIntegrityChecks;
+  private int numFailedIntegrityChecks;
+  private int numSkippedIntegrityChecks;
+  protected int totalIntegrityChecks;
   protected final List<String> parameters;
   protected final List<String> configurations;
   protected PrintWriter writer;
@@ -105,6 +110,10 @@ public abstract class Report {
     this.numPassedProds = 0;
     this.numSkipped = 0;
     this.numSkippedProds = 0;
+    this.numFailedIntegrityChecks = 0;
+    this.numPassedIntegrityChecks = 0;
+    this.numSkippedIntegrityChecks = 0;
+    this.integrityCheckFlag = false;
     this.deprecatedFlagWarning = false;
     this.parameters = new ArrayList<String>();
     this.configurations = new ArrayList<String>();
@@ -259,18 +268,29 @@ public abstract class Report {
     if (numErrors > 0) {
       this.numFailed++;
       status = Status.FAIL;
-      if (!Utility.isDir(sourceUri.toString())) 
-    	  this.numFailedProds++;
+      if (!Utility.isDir(sourceUri.toString())) {
+    	  if (!this.integrityCheckFlag) {
+    	      this.numFailedProds++;
+    	  } else {
+    	      this.numFailedIntegrityChecks++;
+    	  }
+      }
     } else {
       this.numPassed++;
-      if (!Utility.isDir(sourceUri.toString())) 
-    	  this.numPassedProds++;
+      if (!Utility.isDir(sourceUri.toString())) {
+          if (!this.integrityCheckFlag) { 
+              this.numPassedProds++;
+          } else {
+              this.numPassedIntegrityChecks++;
+          }
+      }
     }
     
     //System.out.println("SourceUri: " + sourceUri.toString() + "    isDir = " + Utility.isDir(sourceUri.toString()));
     this.numProducts++;
 
     this.totalProducts = this.numFailedProds + this.numPassedProds + this.numSkippedProds;
+    this.totalIntegrityChecks = this.numFailedIntegrityChecks + this.numPassedIntegrityChecks + this.numSkippedIntegrityChecks;
     printRecordMessages(this.writer, status, sourceUri, problems);
     this.writer.flush();
     return status;
@@ -332,8 +352,13 @@ public abstract class Report {
   
   public Status recordSkip(final URI sourceUri, final ValidationProblem problem) {
     this.numSkipped++;
-    if (!Utility.isDir(sourceUri.toString())) 
-    	this.numSkippedProds++;
+    if (!Utility.isDir(sourceUri.toString())) { 
+        if (!this.integrityCheckFlag) { 
+            this.numSkippedProds++;
+        } else {
+            this.numSkippedIntegrityChecks++;
+        }
+    }
     if (problem.getProblem().getSeverity().getValue() <= this.level.getValue()) {
       printRecordSkip(this.writer, sourceUri, problem);
     }
@@ -375,10 +400,18 @@ public abstract class Report {
     writer.println("  " + totalWarnings + " warning(s)");
     writer.println();
     // issue_132: summary of passed/failed products
-    writer.println("  Number of Passed product(s):  " + this.numPassedProds);
-    writer.println("  Number of Failed product(s):  " + this.numFailedProds);
-    writer.println("  Number of Skipped product(s): " + this.numSkippedProds);
-    writer.println("  Number of Total product(s):   " + getTotalProducts());
+    writer.println("  Product Validation Summary:");
+    writer.printf("    %-10d product(s) passed\n", this.numPassedProds);
+    writer.printf("    %-10d product(s) failed\n", this.numFailedProds);
+    writer.printf("    %-10d product(s) skipped\n", this.numSkippedProds);
+//    writer.println("  Total # of Product(s) processed:   " + getTotalProducts());
+    writer.println();
+    writer.println("  Referential Integrity Check Summary:");
+    writer.printf("    %-10d check(s) passed\n", this.numPassedIntegrityChecks);
+    writer.printf("    %-10d check(s) failed\n", this.numFailedIntegrityChecks);
+    writer.printf("    %-10d check(s) skipped\n", this.numSkippedIntegrityChecks);
+//    writer.println("  Total # of Integrity Check(s) processed:   " + getTotalIntegrityChecks());
+    
     writer.println();
     
     if (!this.messageSummary.isEmpty()) {
@@ -438,6 +471,10 @@ public abstract class Report {
   
   public int getTotalProducts() {
 	return this.totalProducts;
+  }
+  
+  public int getTotalIntegrityChecks() {
+      return this.totalIntegrityChecks;
   }
 
   /**


### PR DESCRIPTION
Added a section in the end summary as

  Number of Passed product(s)/folder(s):  1
  Number of Failed product(s)/folder(s):  4
  Number of Skipped product(s)/folder(s): 0
  Total Number of product(s)/folder(s):   5

A counter for monitoring was added, however, total number of products to go was not included since it takes too much times to implement. 

Resolves #132 