### PR TITLE
Fixed #203, Assembly plugin non-fatal errors on Windows

### DIFF
--- a/src/main/assembly/tar-assembly.xml
+++ b/src/main/assembly/tar-assembly.xml
@@ -95,7 +95,7 @@ POSSIBILITY OF SUCH DAMAGE.
   <files>
     <file>
       <source>LICENSE.txt</source>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory/>
       <fileMode>644</fileMode>
       <lineEnding>unix</lineEnding>
     </file>

--- a/src/main/assembly/zip-assembly.xml
+++ b/src/main/assembly/zip-assembly.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <!--
 Copyright © 2019, California Institute of Technology ("Caltech").
@@ -95,7 +95,7 @@ POSSIBILITY OF SUCH DAMAGE.
   <files>
     <file>
       <source>LICENSE.txt</source>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory/>
       <fileMode>644</fileMode>
       <lineEnding>unix</lineEnding>
     </file>


### PR DESCRIPTION
In tar-assembly.xml and zip-assembly.xml, replaced `<outputDirectory>/</outputDirectory>` with `<outputDirectory/>`
