### PR TITLE
Fix for issue #233, #234, and #243.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@ POSSIBILITY OF SUCH DAMAGE.
   </licenses>
   
   <properties>
-    <pds4-jparser.version>1.8.0</pds4-jparser.version>
+    <pds4-jparser.version>1.9.0-SNAPSHOT</pds4-jparser.version>
     <model-version>1D00</model-version>
     <pds3-product-tools.version>4.0.1</pds3-product-tools.version>
   </properties>


### PR DESCRIPTION
Resolved #233, #234, and #243.

issue_233: Fix for product validation does not detect the number of table records correctly for Table + Array object 
issue_234: Fix for validate gives incorrect records mismatch WARNING for interleaved data objects
issue_243: Fix for validate 1.24.0-SNAPSHOT chokes on a probably good file 
