### PR TITLE
Changes to support issue #246: Add -d parameter to validate-bundle tool.

### DIFF
--- a/src/main/resources/bin/validate-bundle
+++ b/src/main/resources/bin/validate-bundle
@@ -9,7 +9,7 @@
 usage()
 {
     echo
-    echo "usage: validate-bundle -t </path/to/bundle.xml> [-n <num-groups>] [-r <report-file-path>]"
+    echo "usage: validate-bundle -t </path/to/bundle.xml> [-n <num-groups>] [-r <report-file-path>] [-d <dir-path>] [--dry-run]"
     echo
     echo "  Script to run Validate Tool on a bundle parallelizing across "
     echo "  multiple cores. This script will split up the PDS4 products in "
@@ -46,14 +46,29 @@ usage()
     echo "                                              NOTE: Reports from all parallel executed validation"
     echo "                                                    runs will be output to the parent directory of"
     echo "                                                    this file path."
+    echo "  -d, --dir-path       <dir-path>             Optional argument to specify the directory to output"
+    echo "                                              the final summary report."
+    echo "  --dry-run                                   Optional argument to make a dry run to confirm the created output directory"
+    echo "                                              specified in the --dir-path parameter."
     echo
 }
 
 ##### Main
 
+dry_run_flag='false'
+now_as_text=$(date +%Y%m%d_%H%M%S)
 PRODUCT_DIR=
 NUM_GROUPS=
-REPORT_FILE=$(pwd)/validate_$(date +%Y%m%d_%H%M%S)/validate_summary.log
+REPORT_FILE=''
+REPORT_DIR=''
+
+# Build the unique directory where to write report files to.
+
+DEFAULT_UNIQUE_REPORT_DIR_STEM=validate_$now_as_text
+DEFAULT_UNIQUE_REPORT_DIR_DIR='./$DEFAULT_UNIQUE_REPORT_DIR_STEM'
+
+# Save where the code is ran from so the default directory can be returned.
+my_default_dir=$(pwd)
 
 while [ "$1" != "" ]; do
     case $1 in
@@ -65,6 +80,12 @@ while [ "$1" != "" ]; do
                                 ;;
         -r | --report-file )     shift
                                 REPORT_FILE=$1
+                                ;;
+        -d | --report-dir )     shift
+                                REPORT_DIR=$1
+                                ;;
+        --dry-run)
+                                dry_run_flag='true'
                                 ;;
         -h | --help )           usage
                                 exit
@@ -80,9 +101,18 @@ if [ "$PRODUCT_DIR" == "" ]; then
     exit 1
 fi
 
+# If the user has provided the REPORT_DIR (not a blank space), append the unique directory.
+if [ $REPORT_DIR != "" ]; then
+    REPORT_DIR=$REPORT_DIR/$DEFAULT_UNIQUE_REPORT_DIR_STEM
+fi
+# If the user has not provided the REPORT_FILE (not a blank space), set to unique file beneath the default dir.
+if [ "$REPORT_FILE" = "" ]; then
+    REPORT_FILE=$REPORT_DIR/validate_summary.log
+fi
 
 # Setup the directory to run the the parallel processes
 RUN_DIR=$(dirname $REPORT_FILE)
+
 mkdir -p $RUN_DIR
 cd $RUN_DIR
 
@@ -117,6 +147,7 @@ else
   echo
   exit 1
 fi
+
 
 NUM_CORES=`getconf _NPROCESSORS_ONLN`
 HALF_CORES=$((($NUM_CORES/2)))
@@ -158,6 +189,17 @@ done
 echo "  +--------------------+-----------------"
 
 # rm validate_all_files.txt
+
+# If this is a dry run, print the directory create and exit.
+if [ "$dry_run_flag" == "true" ]; then
+    echo "* dry_run_flag is true"
+    echo "* The following directory has been created: $RUN_DIR"
+    echo "* Variables inspection:"
+    echo "*   REPORT_FILE = $REPORT_FILE"
+    echo "*   RUN_DIR     = $RUN_DIR"
+    echo "* Program exiting"
+    exit
+fi
 
 echo
 echo "Running all $NUM_GROUPS groups in parallel now..."
@@ -205,7 +247,8 @@ echo | tee -a $REPORT_FILE
 echo "<<<<<<<<<<<<<<<" | tee -a $REPORT_FILE
 echo | tee -a $REPORT_FILE
 
-cd ..
+# Go back to where ran the code from.
+cd $my_default_dir
 
 echo "Validation complete."
 echo "* See $RUN_DIR/$REPORT_FILE for a summary of results."


### PR DESCRIPTION
Some notes on the installation of parallel and validate.

The developer's own installation of parallel is in /home/qchau/bin and /home/qchau/tools/parallel-20201022/src/parallel.qchau on pds-dev3 (formerly known as pds-dev-el7)

The bash script will perform a 'which' to see where parallel and validate commands are defined.  Make sure both
your executables are found.


The current code for validate-bundle creates a series of text files that starts with 'validate' in the user's default directory:

 ls -1 | grep validate_

validate_all_files.txt
validate_set_aa
validate_set_ab
validate_set_ac
validate_set_ad

This makes it hard to distinguish between one run and another.  The next iteration of run overwrites previous files.

With the changes, the user now can specify -d or --dir-path for a top level output directory (where a unique directory based on today's date and time e.g validate_20201111_150002 if run ran the code at 3:02 pm) will be created).

The --dry-run parameter can be used to see where the files will go without actually doing any validation:

{pds-dev3.jpl.nasa.gov}/home/qchau/sandbox/validate 117 % src/main/resources/bin/validate-bundle --dry-run -t /home/qchau/sandbox/validate/src/test/resources/github246/valid/bundle_kaguya_derived.xml -d /data/home/pds4/qchau/validate-parallel/run_artifacts
  validate binary is available (/home/qchau/sandbox/validate/target/validate-1.25.0-SNAPSHOT/bin/validate) [OK]
  GNU parallel binary is available (/home/qchau/bin/parallel) [OK]
  Directory to process is : /home/qchau/sandbox/validate/src/test/resources/github246/valid
  Number of effective cores on this system: 8
  Half of effective cores on this system  : 4 (usually better than running all cores)
  Splitting up into groups, based on number of cores this machine has...
  Total number of products found to validate: 7
  Cleaning up files from previous runs...
  Splitting up inputs into 4 groups...
    (2 files per group)
  +--------------------+----------------+
  |       Group        |   # in Group   |
  +--------------------+----------------+
  | ./validate_set_aa  |   2
  | ./validate_set_ab  |   2
  | ./validate_set_ac  |   2
  | ./validate_set_ad  |   1
  +--------------------+-----------------
* dry_run_flag is true
* The following directory has been created: /data/home/pds4/qchau/validate-parallel/run_artifacts/validate_20201111_140611
* Variables inspection:
*   REPORT_FILE = validate_summary.log
*   RUN_DIR     = /data/home/pds4/qchau/validate-parallel/run_artifacts/validate_20201111_140611
* Program exiting


{pds-dev3.jpl.nasa.gov}/home/qchau/sandbox/validate 118 % ls -l /data/home/pds4/qchau/validate-parallel/run_artifacts
total 0
drwxr-xr-x 2 qchau pds 128 Nov 11 14:06 validate_20201111_140611/
{pds-dev3.jpl.nasa.gov}/home/qchau/sandbox/validate 119 % ls -l /data/home/pds4/qchau/validate-parallel/run_artifacts/validate_20201111_140611
total 20
-rw-r--r-- 1 qchau pds 755 Nov 11 14:06 validate_all_files.txt
-rw-r--r-- 1 qchau pds 200 Nov 11 14:06 validate_set_aa
-rw-r--r-- 1 qchau pds 220 Nov 11 14:06 validate_set_ab
-rw-r--r-- 1 qchau pds 220 Nov 11 14:06 validate_set_ac
-rw-r--r-- 1 qchau pds 115 Nov 11 14:06 validate_set_ad


The actual run can now be made on a bundle from github246 test (or any bundle you have that you know works):
{pds-dev3.jpl.nasa.gov}/home/qchau/sandbox/validate 121 % src/main/resources/bin/validate-bundle -t /home/qchau/sandbox/validate/src/test/resources/github246/valid/bundle_kaguya_derived.xml --dir-path /data/home/pds4/qchau/validate-parallel/run_artifacts

<<<<<<<<<<<<<<<

Validation complete.
* See /data/home/pds4/qchau/validate-parallel/run_artifacts/validate_20201111_140743/validate_summary.log for a summary of results.
* See /data/home/pds4/qchau/validate-parallel/run_artifacts/validate_20201111_140743 for individual Validate Tool execution reports.


{pds-dev3.jpl.nasa.gov}/home/qchau/sandbox/validate 121 % ls -l /data/home/pds4/qchau/validate-parallel/run_artifacts
total 0
drwxr-xr-x 2 qchau pds 128 Nov 11 14:06 validate_20201111_140611/
drwxr-xr-x 2 qchau pds 310 Nov 11 14:07 validate_20201111_140743/
{pds-dev3.jpl.nasa.gov}/home/qchau/sandbox/validate 122 % ls -l /data/home/pds4/qchau/validate-parallel/run_artifacts/validate_20201111_140743
total 48
-rw-r--r-- 1 qchau pds 236 Nov 11 14:07 {}.log
-rw-r--r-- 1 qchau pds 755 Nov 11 14:07 validate_all_files.txt
-rw-r--r-- 1 qchau pds 385 Nov 11 14:07 validate_referential.log
-rw-r--r-- 1 qchau pds 200 Nov 11 14:07 validate_set_aa
-rw-r--r-- 1 qchau pds 385 Nov 11 14:07 validate_set_aa.log
-rw-r--r-- 1 qchau pds 220 Nov 11 14:07 validate_set_ab
-rw-r--r-- 1 qchau pds 385 Nov 11 14:07 validate_set_ab.log
-rw-r--r-- 1 qchau pds 220 Nov 11 14:07 validate_set_ac
-rw-r--r-- 1 qchau pds 385 Nov 11 14:07 validate_set_ac.log
-rw-r--r-- 1 qchau pds 115 Nov 11 14:07 validate_set_ad
-rw-r--r-- 1 qchau pds 385 Nov 11 14:07 validate_set_ad.log
-rw-r--r-- 1 qchau pds 398 Nov 11 14:07 validate_summary.log
{pds-dev3.jpl.nasa.gov}/home/qchau/sandbox/validate 123 %


Resolves #246 