### PR TITLE
Add logic to skip schematron validation on --skip-product-validation

### DIFF
--- a/src/main/java/gov/nasa/pds/tools/label/LabelValidator.java
+++ b/src/main/java/gov/nasa/pds/tools/label/LabelValidator.java
@@ -26,6 +26,7 @@ import gov.nasa.pds.tools.validate.ProblemContainer;
 import gov.nasa.pds.tools.validate.ProblemDefinition;
 import gov.nasa.pds.tools.validate.ProblemHandler;
 import gov.nasa.pds.tools.validate.ProblemType;
+import gov.nasa.pds.tools.validate.TargetExaminer;
 import gov.nasa.pds.tools.validate.ValidationProblem;
 import gov.nasa.pds.validate.constants.Constants;
 
@@ -337,13 +338,13 @@ public class LabelValidator {
       // Function return true if the validation against the schematron should be done or not.
       // Note: schematron validation can be time consuming.  Only the bundle or collection should be validated against schematron.
       // If the flag skipProductValidation is true, the labels belong to data files should not be done.
-      String nameOnly = Paths.get(url.getPath()).getFileName().toString();
       Boolean validateAgainstSchematronFlag;
       if (!this.skipProductValidation) {
           validateAgainstSchematronFlag = true;
       } else {
           // If skip product validation is true, perform schematron validation bundle/collection labels only.
-          if (nameOnly.contains("bundle") || nameOnly.contains("collection")) {
+          // Since the bundle and collection are not required to have the same token in the name, we must inspect the content of each file.
+          if (TargetExaminer.isTargetBundleType(url) || TargetExaminer.isTargetCollectionType(url)) {
               validateAgainstSchematronFlag = true;
           } else {
               // Do not validate labels belonging to data files.
@@ -490,7 +491,7 @@ public class LabelValidator {
       // Note: schematron validation can be time consuming.  Only the bundle or collection should be validated against schematron.
       // If the flag skipProductValidation is true, the labels belong to data files should not be done.
       Boolean validateAgainstSchematronFlag = this.determineSchematronValidationFlag(url);
-      //LOG.debug("parseAndValidate:url,skipProductValidation,validateAgainstSchematronFlag {},{},{}",url,skipProductValidation,validateAgainstSchematronFlag);
+      LOG.debug("parseAndValidate:url,skipProductValidation,validateAgainstSchematronFlag {},{},{}",url,skipProductValidation,validateAgainstSchematronFlag);
 
       for (Transformer schematron : cachedSchematron) {
         if (!validateAgainstSchematronFlag) continue;  // Skip the validation if validateAgainstSchematronFlag is not true.

--- a/src/main/java/gov/nasa/pds/tools/label/LocationValidator.java
+++ b/src/main/java/gov/nasa/pds/tools/label/LocationValidator.java
@@ -226,10 +226,8 @@ public class LocationValidator {
 			ruleContext.setCrawler(crawler);
 			ruleContext.setRule(rule);
 
-            LOG.info("validate:Submitting task {} to taskManager location {} rule {} ",task,location, rule.getCaption());
             LOG.debug("validate:Submitting task to taskManager location {} rule {} ",location, rule.getCaption());
             taskManager.submit(task);
-            LOG.info("validate:Returning from task {} to taskManager location {} rule {} ",task,location, rule.getCaption());
             LOG.debug("validate:Returning from task to taskManager location {} rule {} ",location, rule.getCaption());
 		}
 	}

--- a/src/main/java/gov/nasa/pds/tools/label/LocationValidator.java
+++ b/src/main/java/gov/nasa/pds/tools/label/LocationValidator.java
@@ -226,8 +226,10 @@ public class LocationValidator {
 			ruleContext.setCrawler(crawler);
 			ruleContext.setRule(rule);
 
+            LOG.info("validate:Submitting task {} to taskManager location {} rule {} ",task,location, rule.getCaption());
             LOG.debug("validate:Submitting task to taskManager location {} rule {} ",location, rule.getCaption());
             taskManager.submit(task);
+            LOG.info("validate:Returning from task {} to taskManager location {} rule {} ",task,location, rule.getCaption());
             LOG.debug("validate:Returning from task to taskManager location {} rule {} ",location, rule.getCaption());
 		}
 	}

--- a/src/main/java/gov/nasa/pds/tools/validate/crawler/FileCrawler.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/crawler/FileCrawler.java
@@ -52,8 +52,8 @@ public class FileCrawler extends Crawler {
    */
   public List<Target> crawl(URL fileUrl, boolean getDirectories, IOFileFilter fileFilter) throws IOException {
     File directory = FileUtils.toFile(fileUrl);
-    LOG.debug("crawl:directory,fileUrl,fileFilter,this.fileFilter {},{},{}",directory,fileUrl,fileFilter,this.fileFilter);
-    LOG.debug("crawl:this.fileFilter {}",this.fileFilter);
+    //LOG.debug("crawl:directory,fileUrl,fileFilter,this.fileFilter {},{},{}",directory,fileUrl,fileFilter,this.fileFilter);
+    //LOG.debug("crawl:this.fileFilter {}",this.fileFilter);
     if ( !directory.isDirectory() ) {
       LOG.error("Input file is not a directory: " + directory);
       throw new IllegalArgumentException("Input file is not a directory: "
@@ -70,23 +70,23 @@ public class FileCrawler extends Crawler {
         results.add(new Target(dir.toURI().toURL(), true));
       }
     }
-    LOG.debug("crawl:directory,fileUrl,results.size() {},{},{}",directory,fileUrl,results.size());
+    //LOG.debug("crawl:directory,fileUrl,results.size() {},{},{}",directory,fileUrl,results.size());
     for (Target target : results) {
-        LOG.debug("crawl:target: {}",target);
+        //LOG.debug("crawl:target: {}",target);
     }
-    LOG.debug("crawl:this.ignoreList.size(),fileUrl {},{}",this.ignoreList.size(),fileUrl);
+    //LOG.debug("crawl:this.ignoreList.size(),fileUrl {},{}",this.ignoreList.size(),fileUrl);
     for (Target ignoreItem : this.ignoreList) {
-        LOG.debug("crawl:ignoreItem: {}",ignoreItem);
+        //LOG.debug("crawl:ignoreItem: {}",ignoreItem);
     }
 
     // Remove all items from results list if they occur in ignoreList.
     results.removeAll(this.ignoreList);
 
     for (Target target : results) {
-        LOG.debug("crawl:final:target: {}",target.getUrl());
+        //LOG.debug("crawl:final:target: {}",target.getUrl());
     }
 
-    LOG.debug("crawl:fileUrl,this.ignoreList.size(),results.size() {},{},{}",fileUrl,this.ignoreList.size(),results.size());
+    //LOG.debug("crawl:fileUrl,this.ignoreList.size(),results.size() {},{},{}",fileUrl,this.ignoreList.size(),results.size());
 
     return results;
   }

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/CollectionReferentialIntegrityRule.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/CollectionReferentialIntegrityRule.java
@@ -60,9 +60,6 @@ public class CollectionReferentialIntegrityRule extends AbstractValidationRule {
   private static final String LOGICAL_IDENTIFIER =
       "//*[starts-with(name(),'Identification_Area')]/logical_identifier";
 
-  private static final String VERSION_ID =
-      "//*[starts-with(name(),'Identification_Area')]/version_id";
-  
   private String lid = null;
   private double totalTimeElapsed = 0.0;
   

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/FileReferenceValidationRule.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/FileReferenceValidationRule.java
@@ -31,6 +31,8 @@ import javax.xml.xpath.XPathExpressionException;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 
 import gov.nasa.pds.tools.label.ExceptionType;
@@ -55,6 +57,7 @@ import net.sf.saxon.tree.tiny.TinyNodeImpl;
  */
 public class FileReferenceValidationRule extends AbstractValidationRule {
 
+  private static final Logger LOG = LoggerFactory.getLogger(FileReferenceValidationRule.class);
   private static final Pattern LABEL_PATTERN = Pattern.compile(".*\\.xml", Pattern.CASE_INSENSITIVE);
   
   /**
@@ -112,6 +115,7 @@ public class FileReferenceValidationRule extends AbstractValidationRule {
             new ValidationTarget(getTarget())));        
       }
     }
+    LOG.debug("validateFileReferences:leaving:uri {}",uri);
   }
     
   private boolean validate(DocumentInfo xml) {

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/FindUnreferencedFiles.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/FindUnreferencedFiles.java
@@ -20,12 +20,15 @@ import gov.nasa.pds.tools.validate.rule.ValidationTest;
 import java.net.MalformedURLException;
 import java.net.URL;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Implements a validation rule that checks that all files are
  * referenced by some label.
  */
 public class FindUnreferencedFiles extends AbstractValidationRule {
-
+  private static final Logger LOG = LoggerFactory.getLogger(FindUnreferencedIdentifiers.class);
   @Override
   public boolean isApplicable(String location) {
     // This rule is applicable at the top level only.
@@ -37,6 +40,7 @@ public class FindUnreferencedFiles extends AbstractValidationRule {
    */
   @ValidationTest
   public void findUnreferencedTargets() {
+    LOG.debug("findUnreferencedTargets:getContext().getTarget(): {}",getContext().getTarget());
     // Only run the test if we are the root target, to avoid duplicate errors.
     if (getContext().isRootTarget() && !getContext().getAllowUnlabeledFiles()) {
       for (String location : getRegistrar().getUnreferencedTargets()) {

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/LabelInFolderRule.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/LabelInFolderRule.java
@@ -32,14 +32,20 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
 /**
  * Implements the rule that all files that look like labels in a folder
  * must be valid labels.
  */
 public class LabelInFolderRule extends AbstractValidationRule {
 
+  private static final Logger LOG = LoggerFactory.getLogger(LabelInFolderRule.class);
   private static final String XML_SUFFIX = ".xml";
   private static final long THREAD_TIMEOUT = 100; // HOURS
+  private double totalTimeElapsed = 0.0;
 
   private ExecutorService validateThreadExecutor;
   List<Future<?>> futures = new ArrayList<Future<?>>();
@@ -54,6 +60,8 @@ public class LabelInFolderRule extends AbstractValidationRule {
    */
   @ValidationTest
   public void validateLabelsInFolder() {
+      //LOG.info("validateLabelsInFolder:BEGIN_PROCESSING_FOLDER");
+
       validateThreadExecutor = Executors.newFixedThreadPool(1);
 
       ValidationRule labelRuleTmp = null;
@@ -69,6 +77,8 @@ public class LabelInFolderRule extends AbstractValidationRule {
 
       Crawler crawler = getContext().getCrawler();
       URL target = getTarget();
+      long startTime = System.currentTimeMillis();
+      LOG.info("validateLabelsInFolder:BEGIN_PROCESSING_FOLDER:target,labelRuleTmp {},{}",target,labelRuleTmp);
       try {
         int targetCount = 0;
         List<Target> targetList = crawler.crawl(getTarget(), false, getContext().getFileFilters());
@@ -112,6 +122,10 @@ public class LabelInFolderRule extends AbstractValidationRule {
       } catch (IOException io) {
         reportError(GenericProblems.UNCAUGHT_EXCEPTION, getContext().getTarget(), -1, -1, io.getMessage());
       }
+      long finishTime = System.currentTimeMillis();
+      long timeElapsed = finishTime - startTime;
+      this.totalTimeElapsed += timeElapsed;
+      LOG.info("validateLabelsInFolder:END_PROCESSING_FOLDER:target,timeElapsed,this.totalTimeElapsed {},{} ms",target,timeElapsed,this.totalTimeElapsed);
   }
 
 }

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/LabelValidationRule.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/LabelValidationRule.java
@@ -54,6 +54,8 @@ import javax.xml.transform.stream.StreamSource;
 import javax.xml.xpath.XPathExpressionException;
 
 import org.apache.commons.io.FilenameUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.ls.LSInput;
 import org.xml.sax.SAXException;
@@ -65,6 +67,7 @@ import org.xml.sax.SAXParseException;
  */
 public class LabelValidationRule extends AbstractValidationRule {
 
+    private static final Logger LOG = LoggerFactory.getLogger(LabelValidationRule.class);
 	private static final Pattern LABEL_PATTERN = Pattern.compile(".*\\.xml", 
 	    Pattern.CASE_INSENSITIVE);
 
@@ -169,6 +172,7 @@ public class LabelValidationRule extends AbstractValidationRule {
         }
         if (pass) {
           getListener().addLocation(target.toString());
+          LOG.debug("validateLabel:afor:target {}",target);
           document = validator.parseAndValidate(processor, target);
         }
         if (document != null) {

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/RegisterTargetReferences.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/RegisterTargetReferences.java
@@ -29,6 +29,8 @@ import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 
 import org.apache.commons.io.FilenameUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -38,6 +40,7 @@ import org.w3c.dom.NodeList;
  * reference to the label itself.
  */
 public class RegisterTargetReferences extends AbstractValidationRule {
+  private static final Logger LOG = LoggerFactory.getLogger(RegisterTargetReferences.class);
 
   private static final String PDS4_NS = "http://pds.nasa.gov/pds4/pds/v1";
 
@@ -71,6 +74,9 @@ public class RegisterTargetReferences extends AbstractValidationRule {
   public void registerFileReferences() throws XPathExpressionException {
     // We have a reference to the current target, since it is a label.
     URL target = getTarget();
+    // Debugging and info can be time consuming, should only be uncommented by developer only.
+    //LOG.debug("registerFileReferences:target {}",target);
+
     getRegistrar().setTargetIsLabel(target.toString(), true);
     
     if (!getContext().containsKey(PDS4Context.LABEL_DOCUMENT)) {


### PR DESCRIPTION
resolves #254: validate does not perform expediently when doing bundle-level validation against large bundles

The reduction in time is due to not performing the time consuming process of validating each label file (associated with a data file) against the 9 schematrons if the --skip-product-validation is used.

Running with the --skip-product-validation should take about 20 minutes for the bundle uploaded by the user.

validate -R pds4.bundle -r /data/home/pds4/qchau/test_artifacts/large_bundle_with_skip_product_validation.json     --skip-product-validation -s json -t /data/home/pds4/insight_cameras/ > & /data/home/pds4/qchau/test_artifacts/log_with_skip_product_validation.txt

The test below without the --skip-product-validation flag can be ran as well but it may take a long time.   At the time as of this pull request, the test is still running:

validate -R pds4.bundle -r /data/home/pds4/qchau/test_artifacts/large_bundle_without_skip_product_validation.json                            -s json -t /data/home/pds4/insight_cameras/ > & /data/home/pds4/qchau/test_artifacts/log_without_skip_product_validation.txt

