### PR TITLE
Improve logic to validate File.file_size tag in label

### DIFF
--- a/src/main/java/gov/nasa/pds/tools/util/FileSizesUtil.java
+++ b/src/main/java/gov/nasa/pds/tools/util/FileSizesUtil.java
@@ -1,0 +1,38 @@
+package gov.nasa.pds.tools.util;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLConnection;
+import java.io.IOException;
+
+/**
+ * A class that calculates the filesize of a file in bytes.
+ */
+public class FileSizesUtil {
+
+  /**
+   * Gets the filesize value.
+   *
+   * @param url The url to the file or resource.
+   * @return The filesize of the given filename.
+   *
+   * @throws Exception If an error occurred while calculating the checksum.
+   */
+  public static int getExternalFilesize(URL url) throws Exception {
+        URLConnection conn = null;
+        try {
+            conn = url.openConnection();
+            if(conn instanceof HttpURLConnection) {
+                ((HttpURLConnection)conn).setRequestMethod("HEAD");
+            }
+            conn.getInputStream();
+            return conn.getContentLength();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        } finally {
+            if(conn instanceof HttpURLConnection) {
+                ((HttpURLConnection)conn).disconnect();
+            }
+        }
+  }
+}

--- a/src/main/java/gov/nasa/pds/tools/validate/ProblemType.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/ProblemType.java
@@ -50,6 +50,10 @@ public enum ProblemType {
 
     MISSING_CHECKSUM("error.label.missing_checksum"),
 
+    FILESIZE_MISMATCH("error.label.filesize_mismatch"),
+
+    MISSING_FILESIZE("error.label.missing_filesize"),
+
     SCHEMA_ERROR("error.label.schema"),
 
     SCHEMATRON_ERROR("error.label.schematron"),
@@ -183,7 +187,11 @@ public enum ProblemType {
 
     CHECKSUM_MATCHES("info.label.checksum_matches"),
 
+    FILESIZE_MATCHES("info.label.filesize_matches"),
+
     MISSING_CHECKSUM_INFO("info.label.missing_checksum"),
+
+    MISSING_FILESIZE_INFO("info.label.missing_filesize"),
 
     SCHEMATRON_INFO("info.label.schematron"),
 

--- a/src/test/java/gov/nasa/pds/validate/ValidationIntegrationTests.java
+++ b/src/test/java/gov/nasa/pds/validate/ValidationIntegrationTests.java
@@ -1322,6 +1322,122 @@ class ValidationIntegrationTests {
         }
     }
 
+
+
+
+    @Test
+    void testGithub281() {
+        try {
+            // Setup paths
+            String testPath = Utility.getAbsolutePath(TestConstants.TEST_DATA_DIR + File.separator + "github281");
+            String outFilePath = TestConstants.TEST_OUT_DIR;
+            File report = new File(outFilePath + File.separator + "report_github281_label_invalid_1.json.json");
+
+            // Run the invalid label test with bad file size.
+
+            String[] args = {
+                    "-r", report.getAbsolutePath(),
+                    "-R", "pds4.label",
+                    "-s", "json",
+                    "-t" , testPath + File.separator + "invalid/collection_gwe_spk_invalid_1_bad_filesize.xml",
+                    };
+            this.launcher.processMain(args);
+
+            Gson gson = new Gson();
+            JsonObject reportJson = null;
+
+            reportJson = gson.fromJson(new FileReader(report), JsonObject.class);
+
+            int count = 0;
+
+            count = this.getMessageCount(reportJson, ProblemType.FILESIZE_MISMATCH.getKey());
+            assertEquals(1, count,  "1 " + ProblemType.FILESIZE_MISMATCH.getKey() + "  messages expected, received " + Integer.toString(count) + ".\n" + reportJson.toString());
+
+
+            File report2 = new File(outFilePath + File.separator + "report_github281_label_invalid_2.json");
+
+            // Run the invalid label test with bad checksum.
+
+            String[] args2 = {
+                    "-r", report2.getAbsolutePath(),
+                    "-R", "pds4.label",
+                    "-s", "json",
+                    "-t" , testPath + File.separator + "invalid/collection_gwe_spk_invalid_2_bad_checksum.xml",
+                    };   
+            this.launcher.processMain(args2);
+
+            reportJson = gson.fromJson(new FileReader(report2), JsonObject.class);
+
+            count = this.getMessageCount(reportJson, ProblemType.CHECKSUM_MISMATCH.getKey());
+            assertEquals(1, count,  "1 " + ProblemType.CHECKSUM_MISMATCH.getKey() + "  messages expected, received " + Integer.toString(count) + ".\n" + reportJson.toString());
+
+
+            File report3 = new File(outFilePath + File.separator + "report_github281_label_invalid_3.json");
+
+            // Run the invalid label test with bad checksum, no file size.
+
+            String[] args3 = {
+                    "-r", report3.getAbsolutePath(),
+                    "-R", "pds4.label",
+                    "-s", "json",
+                    "-t" , testPath + File.separator + "invalid/collection_gwe_spk_invalid_3_bad_checksum_no_filesize.xml",
+                    };   
+            this.launcher.processMain(args3);
+            reportJson = gson.fromJson(new FileReader(report3), JsonObject.class);
+
+            count = this.getMessageCount(reportJson, ProblemType.CHECKSUM_MISMATCH.getKey());
+            assertEquals(1, count,  "1 " + ProblemType.CHECKSUM_MISMATCH.getKey() + "  messages expected, received " + Integer.toString(count) + ".\n" + reportJson.toString());
+
+            // Run the valid label test 1.
+            File report4 = new File(outFilePath + File.separator + "report_github281_label_valid_1.json");
+
+            String[] args4 = {
+                    "-r", report4.getAbsolutePath(),
+                    "-R", "pds4.label",
+                    "-s", "json",
+                    "-t" , testPath + File.separator + "valid/collection_gwe_spk_valid_1.xml",
+                    };
+            this.launcher.processMain(args4);
+            reportJson = gson.fromJson(new FileReader(report4), JsonObject.class);
+
+            count = this.getMessageCount(reportJson, ProblemType.FILESIZE_MISMATCH.getKey());
+            assertEquals(0, count,  "0 " + ProblemType.FILESIZE_MISMATCH.getKey() + "  messages expected, received " + Integer.toString(count) + ".\n" + reportJson.toString());
+
+            File report5 = new File(outFilePath + File.separator + "report_github281_label_valid_2.json");
+
+            String[] args5 = {
+                    "-r", report5.getAbsolutePath(),
+                    "-R", "pds4.label",
+                    "-s", "json",
+                    "-t" , testPath + File.separator + "valid/collection_gwe_spk_valid_2_no_filesize.xml",
+                    };
+            this.launcher.processMain(args5);
+            reportJson = gson.fromJson(new FileReader(report5), JsonObject.class);
+
+            count = this.getMessageCount(reportJson, ProblemType.FILESIZE_MISMATCH.getKey());
+            assertEquals(0, count,  "0 " + ProblemType.FILESIZE_MISMATCH.getKey() + "  messages expected, received " + Integer.toString(count) + ".\n" + reportJson.toString());
+
+            File report6 = new File(outFilePath + File.separator + "report_github281_label_valid_3.json");
+
+            String[] args6 = {
+                    "-r", report6.getAbsolutePath(),
+                    "-R", "pds4.label",
+                    "-s", "json",
+                    "-t" , testPath + File.separator + "valid/collection_gwe_spk_valid_3_no_filesize_no_checksum.xml",
+                    };
+            this.launcher.processMain(args6);
+            reportJson = gson.fromJson(new FileReader(report6), JsonObject.class);
+
+            count = this.getMessageCount(reportJson, ProblemType.FILESIZE_MISMATCH.getKey());
+            assertEquals(0, count,  "0 " + ProblemType.FILESIZE_MISMATCH.getKey() + "  messages expected, received " + Integer.toString(count) + ".\n" + reportJson.toString());
+        } catch (ExitException e) {
+            assertEquals(0, e.status, "Exit status");
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail("Test Failed Due To Exception: " + e.getMessage());
+        }
+    }
+
     @Test
     void testGithub209() {
         try {

--- a/src/test/resources/github11/test_data/science_index_good.xml
+++ b/src/test/resources/github11/test_data/science_index_good.xml
@@ -74,7 +74,7 @@
     <File>
       <file_name>science_index.tab</file_name>
       <local_identifier>SCIENCE_INDEX_TAB</local_identifier>
-      <file_size unit="byte">3591</file_size>
+      <file_size unit="byte">399</file_size>
       <records>3</records>
     </File>
     <Table_Character>

--- a/src/test/resources/github17/delimited_table_good.xml
+++ b/src/test/resources/github17/delimited_table_good.xml
@@ -77,7 +77,7 @@
   <File_Area_Observational>
     <File>
       <file_name>delimited_table_good.tab</file_name>
-      <file_size unit="byte">101</file_size>
+      <file_size unit="byte">32</file_size>
     </File>
 
 <!--    <Table_Character>

--- a/src/test/resources/github281/invalid/collection_gwe_spk.csv
+++ b/src/test/resources/github281/invalid/collection_gwe_spk.csv
@@ -1,0 +1,3 @@
+P,urn:nasa:pds:cassini.rss.raw.gwe:calib.spk:c40eagw2003_314_2003_333::1.0
+P,urn:nasa:pds:cassini.rss.raw.gwe:calib.spk:c35eagw2002_340_2003_014::1.0
+P,urn:nasa:pds:cassini.rss.raw.gwe:calib.spk:c29eagw2001_330_2002_006::1.0

--- a/src/test/resources/github281/invalid/collection_gwe_spk_invalid_1_bad_filesize.xml
+++ b/src/test/resources/github281/invalid/collection_gwe_spk_invalid_1_bad_filesize.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1D00.sch" 
+   schematypens="http://purl.oclc.org/dsdl/schematron"?>
+
+<Product_Collection
+   xmlns="http://pds.nasa.gov/pds4/pds/v1"
+   xmlns:pds="http://pds.nasa.gov/pds4/pds/v1" 
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="
+      http://pds.nasa.gov/pds4/pds/v1
+      https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1D00.xsd">
+  <Identification_Area>
+    <logical_identifier>urn:nasa:pds:cassini.rss.raw.gwe:calib.spk</logical_identifier>
+    <version_id>1.0</version_id>
+    <title>Cassini Radio Science GWE SPICE SPK Calibration Products Collection</title>
+    <information_model_version>1.13.0.0</information_model_version>
+    <product_class>Product_Collection</product_class>
+    <Citation_Information>
+      <author_list>Simpson, R. A.</author_list>
+      <publication_year>2021</publication_year>
+      <description>
+          Cassini Orbiter ephemeris kernel (SPK) files for radio science GWE 
+          observations, migrated from the original PDS3 archive.</description>
+    </Citation_Information>
+    <Modification_History>
+      <Modification_Detail>
+<!--        <modification_date>2020-12-21</modification_date>   -->
+        <modification_date>2020-12-30</modification_date>
+        <version_id>1.0</version_id>
+<!-- Two additional lines added to the description value   -->
+        <description>
+          Collection of Cassini GWE SPK data migrated from PDS3 to PDS4.
+          Duplicate files (same content, but different file names) have been omitted.
+          Because of the LID construction algorithm, the duplicates would have been assigned identical LIDs.</description>
+      </Modification_Detail>
+    </Modification_History>
+  </Identification_Area>
+
+  <Context_Area>
+    <Time_Coordinates>
+      <start_date_time>2001-11-26T03:59:55.817Z</start_date_time>
+      <stop_date_time>2003-11-28T23:58:55.817Z</stop_date_time>
+    </Time_Coordinates>
+
+    <Primary_Result_Summary>
+      <purpose>Calibration</purpose>
+      <processing_level>Derived</processing_level>
+    </Primary_Result_Summary>
+
+    <Investigation_Area>
+      <name>Cassini-Huygens</name>
+      <type>Mission</type>
+      <Internal_Reference>
+        <lid_reference>urn:nasa:pds:context:investigation:mission.cassini-huygens</lid_reference>
+        <reference_type>collection_to_investigation</reference_type>
+      </Internal_Reference>
+    </Investigation_Area>
+
+    <Observing_System>
+          <Observing_System_Component>
+                <name>Cassini Orbiter</name>
+                <type>Spacecraft</type>
+                <Internal_Reference>
+                      <lid_reference>urn:nasa:pds:context:instrument_host:spacecraft.co</lid_reference>
+                      <reference_type>is_instrument_host</reference_type>
+                </Internal_Reference>
+          </Observing_System_Component>
+<!--          <Observing_System_Component> 
+                <name>Radio Science Subsystem</name>
+                <type>Instrument</type>
+                <Internal_Reference>
+                      <lid_reference>urn:nasa:pds:context:instrument:co.rss</lid_reference>
+                      <reference_type>is_instrument</reference_type>
+                </Internal_Reference>
+          </Observing_System_Component>   -->
+          <Observing_System_Component>
+            <name>NASA Deep Space Network</name>
+                <type>Facility</type>
+                <Internal_Reference>
+                      <lid_reference>urn:nasa:pds:context:facility:observatory.dsn</lid_reference>
+                      <reference_type>is_facility</reference_type>
+                </Internal_Reference>
+          </Observing_System_Component>
+          <Observing_System_Component>
+                <name>Deep Space Network Instrumentation</name>
+                <type>Instrument</type>
+                <Internal_Reference>
+                      <lid_reference>urn:nasa:pds:context:instrument:dsn.rss</lid_reference>
+                      <reference_type>is_instrument</reference_type>
+                </Internal_Reference>
+          </Observing_System_Component>
+    </Observing_System>
+
+    <Target_Identification>
+          <name>Gravitational Waves</name>
+          <type>Astrophysical</type>
+          <Internal_Reference>
+                <lid_reference>urn:nasa:pds:context:target:astrophysical.gravitational_waves</lid_reference>
+                <reference_type>collection_to_target</reference_type>
+          </Internal_Reference>
+    </Target_Identification>
+
+  </Context_Area>
+
+  <Reference_List>
+       <Internal_Reference>
+             <lid_reference>urn:nasa:pds:cassini.rss.raw.gwe:document:sis.spk</lid_reference>
+             <reference_type>collection_to_document</reference_type>
+       </Internal_Reference>
+  </Reference_List>
+
+  <Collection>
+    <collection_type>Calibration</collection_type>
+    <description>
+       Cassini Orbiter ephemeris kernel (SPK) files for radio science 
+       observations, migrated from the original PDS3 archive.
+    </description>
+  </Collection>
+
+  <File_Area_Inventory>
+    <File>
+      <file_name>collection_gwe_spk.csv</file_name>
+      <creation_date_time>2020-12-16T23:05:39.866Z</creation_date_time>
+      <file_size unit="byte">288</file_size>
+      <md5_checksum>231af86c81c5e24563cbf4f8a42822a1</md5_checksum>
+    </File>
+    <Inventory>
+      <offset unit="byte">0</offset>
+      <parsing_standard_id>PDS DSV 1</parsing_standard_id>
+      <records>3</records>
+      <record_delimiter>Carriage-Return Line-Feed</record_delimiter>
+      <field_delimiter>Comma</field_delimiter>
+      <Record_Delimited>
+        <fields>2</fields>
+        <groups>0</groups>
+        <maximum_record_length unit="byte">257</maximum_record_length>
+        <Field_Delimited>
+          <name>Member Status</name>
+          <field_number>1</field_number>
+          <data_type>ASCII_String</data_type>
+          <maximum_field_length unit="byte">1</maximum_field_length>
+        </Field_Delimited>
+        <Field_Delimited>
+          <name>LIDVID_LID</name>
+          <field_number>2</field_number>
+          <data_type>ASCII_LIDVID_LID</data_type>
+          <maximum_field_length unit="byte">255</maximum_field_length>
+        </Field_Delimited>
+      </Record_Delimited>
+      <reference_type>inventory_has_member_product</reference_type>
+    </Inventory>
+  </File_Area_Inventory>
+</Product_Collection>

--- a/src/test/resources/github281/invalid/collection_gwe_spk_invalid_2_bad_checksum.xml
+++ b/src/test/resources/github281/invalid/collection_gwe_spk_invalid_2_bad_checksum.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1D00.sch" 
+   schematypens="http://purl.oclc.org/dsdl/schematron"?>
+
+<Product_Collection
+   xmlns="http://pds.nasa.gov/pds4/pds/v1"
+   xmlns:pds="http://pds.nasa.gov/pds4/pds/v1" 
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="
+      http://pds.nasa.gov/pds4/pds/v1
+      https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1D00.xsd">
+  <Identification_Area>
+    <logical_identifier>urn:nasa:pds:cassini.rss.raw.gwe:calib.spk</logical_identifier>
+    <version_id>1.0</version_id>
+    <title>Cassini Radio Science GWE SPICE SPK Calibration Products Collection</title>
+    <information_model_version>1.13.0.0</information_model_version>
+    <product_class>Product_Collection</product_class>
+    <Citation_Information>
+      <author_list>Simpson, R. A.</author_list>
+      <publication_year>2021</publication_year>
+      <description>
+          Cassini Orbiter ephemeris kernel (SPK) files for radio science GWE 
+          observations, migrated from the original PDS3 archive.</description>
+    </Citation_Information>
+    <Modification_History>
+      <Modification_Detail>
+<!--        <modification_date>2020-12-21</modification_date>   -->
+        <modification_date>2020-12-30</modification_date>
+        <version_id>1.0</version_id>
+<!-- Two additional lines added to the description value   -->
+        <description>
+          Collection of Cassini GWE SPK data migrated from PDS3 to PDS4.
+          Duplicate files (same content, but different file names) have been omitted.
+          Because of the LID construction algorithm, the duplicates would have been assigned identical LIDs.</description>
+      </Modification_Detail>
+    </Modification_History>
+  </Identification_Area>
+
+  <Context_Area>
+    <Time_Coordinates>
+      <start_date_time>2001-11-26T03:59:55.817Z</start_date_time>
+      <stop_date_time>2003-11-28T23:58:55.817Z</stop_date_time>
+    </Time_Coordinates>
+
+    <Primary_Result_Summary>
+      <purpose>Calibration</purpose>
+      <processing_level>Derived</processing_level>
+    </Primary_Result_Summary>
+
+    <Investigation_Area>
+      <name>Cassini-Huygens</name>
+      <type>Mission</type>
+      <Internal_Reference>
+        <lid_reference>urn:nasa:pds:context:investigation:mission.cassini-huygens</lid_reference>
+        <reference_type>collection_to_investigation</reference_type>
+      </Internal_Reference>
+    </Investigation_Area>
+
+    <Observing_System>
+          <Observing_System_Component>
+                <name>Cassini Orbiter</name>
+                <type>Spacecraft</type>
+                <Internal_Reference>
+                      <lid_reference>urn:nasa:pds:context:instrument_host:spacecraft.co</lid_reference>
+                      <reference_type>is_instrument_host</reference_type>
+                </Internal_Reference>
+          </Observing_System_Component>
+<!--          <Observing_System_Component> 
+                <name>Radio Science Subsystem</name>
+                <type>Instrument</type>
+                <Internal_Reference>
+                      <lid_reference>urn:nasa:pds:context:instrument:co.rss</lid_reference>
+                      <reference_type>is_instrument</reference_type>
+                </Internal_Reference>
+          </Observing_System_Component>   -->
+          <Observing_System_Component>
+            <name>NASA Deep Space Network</name>
+                <type>Facility</type>
+                <Internal_Reference>
+                      <lid_reference>urn:nasa:pds:context:facility:observatory.dsn</lid_reference>
+                      <reference_type>is_facility</reference_type>
+                </Internal_Reference>
+          </Observing_System_Component>
+          <Observing_System_Component>
+                <name>Deep Space Network Instrumentation</name>
+                <type>Instrument</type>
+                <Internal_Reference>
+                      <lid_reference>urn:nasa:pds:context:instrument:dsn.rss</lid_reference>
+                      <reference_type>is_instrument</reference_type>
+                </Internal_Reference>
+          </Observing_System_Component>
+    </Observing_System>
+
+    <Target_Identification>
+          <name>Gravitational Waves</name>
+          <type>Astrophysical</type>
+          <Internal_Reference>
+                <lid_reference>urn:nasa:pds:context:target:astrophysical.gravitational_waves</lid_reference>
+                <reference_type>collection_to_target</reference_type>
+          </Internal_Reference>
+    </Target_Identification>
+
+  </Context_Area>
+
+  <Reference_List>
+       <Internal_Reference>
+             <lid_reference>urn:nasa:pds:cassini.rss.raw.gwe:document:sis.spk</lid_reference>
+             <reference_type>collection_to_document</reference_type>
+       </Internal_Reference>
+  </Reference_List>
+
+  <Collection>
+    <collection_type>Calibration</collection_type>
+    <description>
+       Cassini Orbiter ephemeris kernel (SPK) files for radio science 
+       observations, migrated from the original PDS3 archive.
+    </description>
+  </Collection>
+
+  <File_Area_Inventory>
+    <File>
+      <file_name>collection_gwe_spk.csv</file_name>
+      <creation_date_time>2020-12-16T23:05:39.866Z</creation_date_time>
+      <file_size unit="byte">228</file_size>
+      <md5_checksum>231af86c81c5e24563cbf4f8a42822af</md5_checksum>
+    </File>
+    <Inventory>
+      <offset unit="byte">0</offset>
+      <parsing_standard_id>PDS DSV 1</parsing_standard_id>
+      <records>3</records>
+      <record_delimiter>Carriage-Return Line-Feed</record_delimiter>
+      <field_delimiter>Comma</field_delimiter>
+      <Record_Delimited>
+        <fields>2</fields>
+        <groups>0</groups>
+        <maximum_record_length unit="byte">257</maximum_record_length>
+        <Field_Delimited>
+          <name>Member Status</name>
+          <field_number>1</field_number>
+          <data_type>ASCII_String</data_type>
+          <maximum_field_length unit="byte">1</maximum_field_length>
+        </Field_Delimited>
+        <Field_Delimited>
+          <name>LIDVID_LID</name>
+          <field_number>2</field_number>
+          <data_type>ASCII_LIDVID_LID</data_type>
+          <maximum_field_length unit="byte">255</maximum_field_length>
+        </Field_Delimited>
+      </Record_Delimited>
+      <reference_type>inventory_has_member_product</reference_type>
+    </Inventory>
+  </File_Area_Inventory>
+</Product_Collection>

--- a/src/test/resources/github281/invalid/collection_gwe_spk_invalid_3_bad_checksum_no_filesize.xml
+++ b/src/test/resources/github281/invalid/collection_gwe_spk_invalid_3_bad_checksum_no_filesize.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1D00.sch" 
+   schematypens="http://purl.oclc.org/dsdl/schematron"?>
+
+<Product_Collection
+   xmlns="http://pds.nasa.gov/pds4/pds/v1"
+   xmlns:pds="http://pds.nasa.gov/pds4/pds/v1" 
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="
+      http://pds.nasa.gov/pds4/pds/v1
+      https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1D00.xsd">
+  <Identification_Area>
+    <logical_identifier>urn:nasa:pds:cassini.rss.raw.gwe:calib.spk</logical_identifier>
+    <version_id>1.0</version_id>
+    <title>Cassini Radio Science GWE SPICE SPK Calibration Products Collection</title>
+    <information_model_version>1.13.0.0</information_model_version>
+    <product_class>Product_Collection</product_class>
+    <Citation_Information>
+      <author_list>Simpson, R. A.</author_list>
+      <publication_year>2021</publication_year>
+      <description>
+          Cassini Orbiter ephemeris kernel (SPK) files for radio science GWE 
+          observations, migrated from the original PDS3 archive.</description>
+    </Citation_Information>
+    <Modification_History>
+      <Modification_Detail>
+<!--        <modification_date>2020-12-21</modification_date>   -->
+        <modification_date>2020-12-30</modification_date>
+        <version_id>1.0</version_id>
+<!-- Two additional lines added to the description value   -->
+        <description>
+          Collection of Cassini GWE SPK data migrated from PDS3 to PDS4.
+          Duplicate files (same content, but different file names) have been omitted.
+          Because of the LID construction algorithm, the duplicates would have been assigned identical LIDs.</description>
+      </Modification_Detail>
+    </Modification_History>
+  </Identification_Area>
+
+  <Context_Area>
+    <Time_Coordinates>
+      <start_date_time>2001-11-26T03:59:55.817Z</start_date_time>
+      <stop_date_time>2003-11-28T23:58:55.817Z</stop_date_time>
+    </Time_Coordinates>
+
+    <Primary_Result_Summary>
+      <purpose>Calibration</purpose>
+      <processing_level>Derived</processing_level>
+    </Primary_Result_Summary>
+
+    <Investigation_Area>
+      <name>Cassini-Huygens</name>
+      <type>Mission</type>
+      <Internal_Reference>
+        <lid_reference>urn:nasa:pds:context:investigation:mission.cassini-huygens</lid_reference>
+        <reference_type>collection_to_investigation</reference_type>
+      </Internal_Reference>
+    </Investigation_Area>
+
+    <Observing_System>
+          <Observing_System_Component>
+                <name>Cassini Orbiter</name>
+                <type>Spacecraft</type>
+                <Internal_Reference>
+                      <lid_reference>urn:nasa:pds:context:instrument_host:spacecraft.co</lid_reference>
+                      <reference_type>is_instrument_host</reference_type>
+                </Internal_Reference>
+          </Observing_System_Component>
+<!--          <Observing_System_Component> 
+                <name>Radio Science Subsystem</name>
+                <type>Instrument</type>
+                <Internal_Reference>
+                      <lid_reference>urn:nasa:pds:context:instrument:co.rss</lid_reference>
+                      <reference_type>is_instrument</reference_type>
+                </Internal_Reference>
+          </Observing_System_Component>   -->
+          <Observing_System_Component>
+            <name>NASA Deep Space Network</name>
+                <type>Facility</type>
+                <Internal_Reference>
+                      <lid_reference>urn:nasa:pds:context:facility:observatory.dsn</lid_reference>
+                      <reference_type>is_facility</reference_type>
+                </Internal_Reference>
+          </Observing_System_Component>
+          <Observing_System_Component>
+                <name>Deep Space Network Instrumentation</name>
+                <type>Instrument</type>
+                <Internal_Reference>
+                      <lid_reference>urn:nasa:pds:context:instrument:dsn.rss</lid_reference>
+                      <reference_type>is_instrument</reference_type>
+                </Internal_Reference>
+          </Observing_System_Component>
+    </Observing_System>
+
+    <Target_Identification>
+          <name>Gravitational Waves</name>
+          <type>Astrophysical</type>
+          <Internal_Reference>
+                <lid_reference>urn:nasa:pds:context:target:astrophysical.gravitational_waves</lid_reference>
+                <reference_type>collection_to_target</reference_type>
+          </Internal_Reference>
+    </Target_Identification>
+
+  </Context_Area>
+
+  <Reference_List>
+       <Internal_Reference>
+             <lid_reference>urn:nasa:pds:cassini.rss.raw.gwe:document:sis.spk</lid_reference>
+             <reference_type>collection_to_document</reference_type>
+       </Internal_Reference>
+  </Reference_List>
+
+  <Collection>
+    <collection_type>Calibration</collection_type>
+    <description>
+       Cassini Orbiter ephemeris kernel (SPK) files for radio science 
+       observations, migrated from the original PDS3 archive.
+    </description>
+  </Collection>
+
+  <File_Area_Inventory>
+    <File>
+      <file_name>collection_gwe_spk.csv</file_name>
+      <creation_date_time>2020-12-16T23:05:39.866Z</creation_date_time>
+      <md5_checksum>231af86c81c5e24563cbf4f8a42822af</md5_checksum>
+    </File>
+    <Inventory>
+      <offset unit="byte">0</offset>
+      <parsing_standard_id>PDS DSV 1</parsing_standard_id>
+      <records>3</records>
+      <record_delimiter>Carriage-Return Line-Feed</record_delimiter>
+      <field_delimiter>Comma</field_delimiter>
+      <Record_Delimited>
+        <fields>2</fields>
+        <groups>0</groups>
+        <maximum_record_length unit="byte">257</maximum_record_length>
+        <Field_Delimited>
+          <name>Member Status</name>
+          <field_number>1</field_number>
+          <data_type>ASCII_String</data_type>
+          <maximum_field_length unit="byte">1</maximum_field_length>
+        </Field_Delimited>
+        <Field_Delimited>
+          <name>LIDVID_LID</name>
+          <field_number>2</field_number>
+          <data_type>ASCII_LIDVID_LID</data_type>
+          <maximum_field_length unit="byte">255</maximum_field_length>
+        </Field_Delimited>
+      </Record_Delimited>
+      <reference_type>inventory_has_member_product</reference_type>
+    </Inventory>
+  </File_Area_Inventory>
+</Product_Collection>

--- a/src/test/resources/github281/valid/collection_gwe_spk.csv
+++ b/src/test/resources/github281/valid/collection_gwe_spk.csv
@@ -1,0 +1,3 @@
+P,urn:nasa:pds:cassini.rss.raw.gwe:calib.spk:c40eagw2003_314_2003_333::1.0
+P,urn:nasa:pds:cassini.rss.raw.gwe:calib.spk:c35eagw2002_340_2003_014::1.0
+P,urn:nasa:pds:cassini.rss.raw.gwe:calib.spk:c29eagw2001_330_2002_006::1.0

--- a/src/test/resources/github281/valid/collection_gwe_spk_valid_1.xml
+++ b/src/test/resources/github281/valid/collection_gwe_spk_valid_1.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1D00.sch" 
+   schematypens="http://purl.oclc.org/dsdl/schematron"?>
+
+<Product_Collection
+   xmlns="http://pds.nasa.gov/pds4/pds/v1"
+   xmlns:pds="http://pds.nasa.gov/pds4/pds/v1" 
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="
+      http://pds.nasa.gov/pds4/pds/v1
+      https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1D00.xsd">
+  <Identification_Area>
+    <logical_identifier>urn:nasa:pds:cassini.rss.raw.gwe:calib.spk</logical_identifier>
+    <version_id>1.0</version_id>
+    <title>Cassini Radio Science GWE SPICE SPK Calibration Products Collection</title>
+    <information_model_version>1.13.0.0</information_model_version>
+    <product_class>Product_Collection</product_class>
+    <Citation_Information>
+      <author_list>Simpson, R. A.</author_list>
+      <publication_year>2021</publication_year>
+      <description>
+          Cassini Orbiter ephemeris kernel (SPK) files for radio science GWE 
+          observations, migrated from the original PDS3 archive.</description>
+    </Citation_Information>
+    <Modification_History>
+      <Modification_Detail>
+<!--        <modification_date>2020-12-21</modification_date>   -->
+        <modification_date>2020-12-30</modification_date>
+        <version_id>1.0</version_id>
+<!-- Two additional lines added to the description value   -->
+        <description>
+          Collection of Cassini GWE SPK data migrated from PDS3 to PDS4.
+          Duplicate files (same content, but different file names) have been omitted.
+          Because of the LID construction algorithm, the duplicates would have been assigned identical LIDs.</description>
+      </Modification_Detail>
+    </Modification_History>
+  </Identification_Area>
+
+  <Context_Area>
+    <Time_Coordinates>
+      <start_date_time>2001-11-26T03:59:55.817Z</start_date_time>
+      <stop_date_time>2003-11-28T23:58:55.817Z</stop_date_time>
+    </Time_Coordinates>
+
+    <Primary_Result_Summary>
+      <purpose>Calibration</purpose>
+      <processing_level>Derived</processing_level>
+    </Primary_Result_Summary>
+
+    <Investigation_Area>
+      <name>Cassini-Huygens</name>
+      <type>Mission</type>
+      <Internal_Reference>
+        <lid_reference>urn:nasa:pds:context:investigation:mission.cassini-huygens</lid_reference>
+        <reference_type>collection_to_investigation</reference_type>
+      </Internal_Reference>
+    </Investigation_Area>
+
+    <Observing_System>
+          <Observing_System_Component>
+                <name>Cassini Orbiter</name>
+                <type>Spacecraft</type>
+                <Internal_Reference>
+                      <lid_reference>urn:nasa:pds:context:instrument_host:spacecraft.co</lid_reference>
+                      <reference_type>is_instrument_host</reference_type>
+                </Internal_Reference>
+          </Observing_System_Component>
+<!--          <Observing_System_Component> 
+                <name>Radio Science Subsystem</name>
+                <type>Instrument</type>
+                <Internal_Reference>
+                      <lid_reference>urn:nasa:pds:context:instrument:co.rss</lid_reference>
+                      <reference_type>is_instrument</reference_type>
+                </Internal_Reference>
+          </Observing_System_Component>   -->
+          <Observing_System_Component>
+            <name>NASA Deep Space Network</name>
+                <type>Facility</type>
+                <Internal_Reference>
+                      <lid_reference>urn:nasa:pds:context:facility:observatory.dsn</lid_reference>
+                      <reference_type>is_facility</reference_type>
+                </Internal_Reference>
+          </Observing_System_Component>
+          <Observing_System_Component>
+                <name>Deep Space Network Instrumentation</name>
+                <type>Instrument</type>
+                <Internal_Reference>
+                      <lid_reference>urn:nasa:pds:context:instrument:dsn.rss</lid_reference>
+                      <reference_type>is_instrument</reference_type>
+                </Internal_Reference>
+          </Observing_System_Component>
+    </Observing_System>
+
+    <Target_Identification>
+          <name>Gravitational Waves</name>
+          <type>Astrophysical</type>
+          <Internal_Reference>
+                <lid_reference>urn:nasa:pds:context:target:astrophysical.gravitational_waves</lid_reference>
+                <reference_type>collection_to_target</reference_type>
+          </Internal_Reference>
+    </Target_Identification>
+
+  </Context_Area>
+
+  <Reference_List>
+       <Internal_Reference>
+             <lid_reference>urn:nasa:pds:cassini.rss.raw.gwe:document:sis.spk</lid_reference>
+             <reference_type>collection_to_document</reference_type>
+       </Internal_Reference>
+  </Reference_List>
+
+  <Collection>
+    <collection_type>Calibration</collection_type>
+    <description>
+       Cassini Orbiter ephemeris kernel (SPK) files for radio science 
+       observations, migrated from the original PDS3 archive.
+    </description>
+  </Collection>
+
+  <File_Area_Inventory>
+    <File>
+      <file_name>collection_gwe_spk.csv</file_name>
+      <creation_date_time>2020-12-16T23:05:39.866Z</creation_date_time>
+      <file_size unit="byte">228</file_size>
+      <md5_checksum>231af86c81c5e24563cbf4f8a42822a1</md5_checksum>
+    </File>
+    <Inventory>
+      <offset unit="byte">0</offset>
+      <parsing_standard_id>PDS DSV 1</parsing_standard_id>
+      <records>3</records>
+      <record_delimiter>Carriage-Return Line-Feed</record_delimiter>
+      <field_delimiter>Comma</field_delimiter>
+      <Record_Delimited>
+        <fields>2</fields>
+        <groups>0</groups>
+        <maximum_record_length unit="byte">257</maximum_record_length>
+        <Field_Delimited>
+          <name>Member Status</name>
+          <field_number>1</field_number>
+          <data_type>ASCII_String</data_type>
+          <maximum_field_length unit="byte">1</maximum_field_length>
+        </Field_Delimited>
+        <Field_Delimited>
+          <name>LIDVID_LID</name>
+          <field_number>2</field_number>
+          <data_type>ASCII_LIDVID_LID</data_type>
+          <maximum_field_length unit="byte">255</maximum_field_length>
+        </Field_Delimited>
+      </Record_Delimited>
+      <reference_type>inventory_has_member_product</reference_type>
+    </Inventory>
+  </File_Area_Inventory>
+</Product_Collection>

--- a/src/test/resources/github281/valid/collection_gwe_spk_valid_2_no_filesize.xml
+++ b/src/test/resources/github281/valid/collection_gwe_spk_valid_2_no_filesize.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1D00.sch" 
+   schematypens="http://purl.oclc.org/dsdl/schematron"?>
+
+<Product_Collection
+   xmlns="http://pds.nasa.gov/pds4/pds/v1"
+   xmlns:pds="http://pds.nasa.gov/pds4/pds/v1" 
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="
+      http://pds.nasa.gov/pds4/pds/v1
+      https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1D00.xsd">
+  <Identification_Area>
+    <logical_identifier>urn:nasa:pds:cassini.rss.raw.gwe:calib.spk</logical_identifier>
+    <version_id>1.0</version_id>
+    <title>Cassini Radio Science GWE SPICE SPK Calibration Products Collection</title>
+    <information_model_version>1.13.0.0</information_model_version>
+    <product_class>Product_Collection</product_class>
+    <Citation_Information>
+      <author_list>Simpson, R. A.</author_list>
+      <publication_year>2021</publication_year>
+      <description>
+          Cassini Orbiter ephemeris kernel (SPK) files for radio science GWE 
+          observations, migrated from the original PDS3 archive.</description>
+    </Citation_Information>
+    <Modification_History>
+      <Modification_Detail>
+<!--        <modification_date>2020-12-21</modification_date>   -->
+        <modification_date>2020-12-30</modification_date>
+        <version_id>1.0</version_id>
+<!-- Two additional lines added to the description value   -->
+        <description>
+          Collection of Cassini GWE SPK data migrated from PDS3 to PDS4.
+          Duplicate files (same content, but different file names) have been omitted.
+          Because of the LID construction algorithm, the duplicates would have been assigned identical LIDs.</description>
+      </Modification_Detail>
+    </Modification_History>
+  </Identification_Area>
+
+  <Context_Area>
+    <Time_Coordinates>
+      <start_date_time>2001-11-26T03:59:55.817Z</start_date_time>
+      <stop_date_time>2003-11-28T23:58:55.817Z</stop_date_time>
+    </Time_Coordinates>
+
+    <Primary_Result_Summary>
+      <purpose>Calibration</purpose>
+      <processing_level>Derived</processing_level>
+    </Primary_Result_Summary>
+
+    <Investigation_Area>
+      <name>Cassini-Huygens</name>
+      <type>Mission</type>
+      <Internal_Reference>
+        <lid_reference>urn:nasa:pds:context:investigation:mission.cassini-huygens</lid_reference>
+        <reference_type>collection_to_investigation</reference_type>
+      </Internal_Reference>
+    </Investigation_Area>
+
+    <Observing_System>
+          <Observing_System_Component>
+                <name>Cassini Orbiter</name>
+                <type>Spacecraft</type>
+                <Internal_Reference>
+                      <lid_reference>urn:nasa:pds:context:instrument_host:spacecraft.co</lid_reference>
+                      <reference_type>is_instrument_host</reference_type>
+                </Internal_Reference>
+          </Observing_System_Component>
+<!--          <Observing_System_Component> 
+                <name>Radio Science Subsystem</name>
+                <type>Instrument</type>
+                <Internal_Reference>
+                      <lid_reference>urn:nasa:pds:context:instrument:co.rss</lid_reference>
+                      <reference_type>is_instrument</reference_type>
+                </Internal_Reference>
+          </Observing_System_Component>   -->
+          <Observing_System_Component>
+            <name>NASA Deep Space Network</name>
+                <type>Facility</type>
+                <Internal_Reference>
+                      <lid_reference>urn:nasa:pds:context:facility:observatory.dsn</lid_reference>
+                      <reference_type>is_facility</reference_type>
+                </Internal_Reference>
+          </Observing_System_Component>
+          <Observing_System_Component>
+                <name>Deep Space Network Instrumentation</name>
+                <type>Instrument</type>
+                <Internal_Reference>
+                      <lid_reference>urn:nasa:pds:context:instrument:dsn.rss</lid_reference>
+                      <reference_type>is_instrument</reference_type>
+                </Internal_Reference>
+          </Observing_System_Component>
+    </Observing_System>
+
+    <Target_Identification>
+          <name>Gravitational Waves</name>
+          <type>Astrophysical</type>
+          <Internal_Reference>
+                <lid_reference>urn:nasa:pds:context:target:astrophysical.gravitational_waves</lid_reference>
+                <reference_type>collection_to_target</reference_type>
+          </Internal_Reference>
+    </Target_Identification>
+
+  </Context_Area>
+
+  <Reference_List>
+       <Internal_Reference>
+             <lid_reference>urn:nasa:pds:cassini.rss.raw.gwe:document:sis.spk</lid_reference>
+             <reference_type>collection_to_document</reference_type>
+       </Internal_Reference>
+  </Reference_List>
+
+  <Collection>
+    <collection_type>Calibration</collection_type>
+    <description>
+       Cassini Orbiter ephemeris kernel (SPK) files for radio science 
+       observations, migrated from the original PDS3 archive.
+    </description>
+  </Collection>
+
+  <File_Area_Inventory>
+    <File>
+      <file_name>collection_gwe_spk.csv</file_name>
+      <creation_date_time>2020-12-16T23:05:39.866Z</creation_date_time>
+      <md5_checksum>231af86c81c5e24563cbf4f8a42822a1</md5_checksum>
+    </File>
+    <Inventory>
+      <offset unit="byte">0</offset>
+      <parsing_standard_id>PDS DSV 1</parsing_standard_id>
+      <records>3</records>
+      <record_delimiter>Carriage-Return Line-Feed</record_delimiter>
+      <field_delimiter>Comma</field_delimiter>
+      <Record_Delimited>
+        <fields>2</fields>
+        <groups>0</groups>
+        <maximum_record_length unit="byte">257</maximum_record_length>
+        <Field_Delimited>
+          <name>Member Status</name>
+          <field_number>1</field_number>
+          <data_type>ASCII_String</data_type>
+          <maximum_field_length unit="byte">1</maximum_field_length>
+        </Field_Delimited>
+        <Field_Delimited>
+          <name>LIDVID_LID</name>
+          <field_number>2</field_number>
+          <data_type>ASCII_LIDVID_LID</data_type>
+          <maximum_field_length unit="byte">255</maximum_field_length>
+        </Field_Delimited>
+      </Record_Delimited>
+      <reference_type>inventory_has_member_product</reference_type>
+    </Inventory>
+  </File_Area_Inventory>
+</Product_Collection>

--- a/src/test/resources/github281/valid/collection_gwe_spk_valid_3_no_filesize_no_checksum.xml
+++ b/src/test/resources/github281/valid/collection_gwe_spk_valid_3_no_filesize_no_checksum.xml
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1D00.sch" 
+   schematypens="http://purl.oclc.org/dsdl/schematron"?>
+
+<Product_Collection
+   xmlns="http://pds.nasa.gov/pds4/pds/v1"
+   xmlns:pds="http://pds.nasa.gov/pds4/pds/v1" 
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="
+      http://pds.nasa.gov/pds4/pds/v1
+      https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1D00.xsd">
+  <Identification_Area>
+    <logical_identifier>urn:nasa:pds:cassini.rss.raw.gwe:calib.spk</logical_identifier>
+    <version_id>1.0</version_id>
+    <title>Cassini Radio Science GWE SPICE SPK Calibration Products Collection</title>
+    <information_model_version>1.13.0.0</information_model_version>
+    <product_class>Product_Collection</product_class>
+    <Citation_Information>
+      <author_list>Simpson, R. A.</author_list>
+      <publication_year>2021</publication_year>
+      <description>
+          Cassini Orbiter ephemeris kernel (SPK) files for radio science GWE 
+          observations, migrated from the original PDS3 archive.</description>
+    </Citation_Information>
+    <Modification_History>
+      <Modification_Detail>
+<!--        <modification_date>2020-12-21</modification_date>   -->
+        <modification_date>2020-12-30</modification_date>
+        <version_id>1.0</version_id>
+<!-- Two additional lines added to the description value   -->
+        <description>
+          Collection of Cassini GWE SPK data migrated from PDS3 to PDS4.
+          Duplicate files (same content, but different file names) have been omitted.
+          Because of the LID construction algorithm, the duplicates would have been assigned identical LIDs.</description>
+      </Modification_Detail>
+    </Modification_History>
+  </Identification_Area>
+
+  <Context_Area>
+    <Time_Coordinates>
+      <start_date_time>2001-11-26T03:59:55.817Z</start_date_time>
+      <stop_date_time>2003-11-28T23:58:55.817Z</stop_date_time>
+    </Time_Coordinates>
+
+    <Primary_Result_Summary>
+      <purpose>Calibration</purpose>
+      <processing_level>Derived</processing_level>
+    </Primary_Result_Summary>
+
+    <Investigation_Area>
+      <name>Cassini-Huygens</name>
+      <type>Mission</type>
+      <Internal_Reference>
+        <lid_reference>urn:nasa:pds:context:investigation:mission.cassini-huygens</lid_reference>
+        <reference_type>collection_to_investigation</reference_type>
+      </Internal_Reference>
+    </Investigation_Area>
+
+    <Observing_System>
+          <Observing_System_Component>
+                <name>Cassini Orbiter</name>
+                <type>Spacecraft</type>
+                <Internal_Reference>
+                      <lid_reference>urn:nasa:pds:context:instrument_host:spacecraft.co</lid_reference>
+                      <reference_type>is_instrument_host</reference_type>
+                </Internal_Reference>
+          </Observing_System_Component>
+<!--          <Observing_System_Component> 
+                <name>Radio Science Subsystem</name>
+                <type>Instrument</type>
+                <Internal_Reference>
+                      <lid_reference>urn:nasa:pds:context:instrument:co.rss</lid_reference>
+                      <reference_type>is_instrument</reference_type>
+                </Internal_Reference>
+          </Observing_System_Component>   -->
+          <Observing_System_Component>
+            <name>NASA Deep Space Network</name>
+                <type>Facility</type>
+                <Internal_Reference>
+                      <lid_reference>urn:nasa:pds:context:facility:observatory.dsn</lid_reference>
+                      <reference_type>is_facility</reference_type>
+                </Internal_Reference>
+          </Observing_System_Component>
+          <Observing_System_Component>
+                <name>Deep Space Network Instrumentation</name>
+                <type>Instrument</type>
+                <Internal_Reference>
+                      <lid_reference>urn:nasa:pds:context:instrument:dsn.rss</lid_reference>
+                      <reference_type>is_instrument</reference_type>
+                </Internal_Reference>
+          </Observing_System_Component>
+    </Observing_System>
+
+    <Target_Identification>
+          <name>Gravitational Waves</name>
+          <type>Astrophysical</type>
+          <Internal_Reference>
+                <lid_reference>urn:nasa:pds:context:target:astrophysical.gravitational_waves</lid_reference>
+                <reference_type>collection_to_target</reference_type>
+          </Internal_Reference>
+    </Target_Identification>
+
+  </Context_Area>
+
+  <Reference_List>
+       <Internal_Reference>
+             <lid_reference>urn:nasa:pds:cassini.rss.raw.gwe:document:sis.spk</lid_reference>
+             <reference_type>collection_to_document</reference_type>
+       </Internal_Reference>
+  </Reference_List>
+
+  <Collection>
+    <collection_type>Calibration</collection_type>
+    <description>
+       Cassini Orbiter ephemeris kernel (SPK) files for radio science 
+       observations, migrated from the original PDS3 archive.
+    </description>
+  </Collection>
+
+  <File_Area_Inventory>
+    <File>
+      <file_name>collection_gwe_spk.csv</file_name>
+      <creation_date_time>2020-12-16T23:05:39.866Z</creation_date_time>
+    </File>
+    <Inventory>
+      <offset unit="byte">0</offset>
+      <parsing_standard_id>PDS DSV 1</parsing_standard_id>
+      <records>3</records>
+      <record_delimiter>Carriage-Return Line-Feed</record_delimiter>
+      <field_delimiter>Comma</field_delimiter>
+      <Record_Delimited>
+        <fields>2</fields>
+        <groups>0</groups>
+        <maximum_record_length unit="byte">257</maximum_record_length>
+        <Field_Delimited>
+          <name>Member Status</name>
+          <field_number>1</field_number>
+          <data_type>ASCII_String</data_type>
+          <maximum_field_length unit="byte">1</maximum_field_length>
+        </Field_Delimited>
+        <Field_Delimited>
+          <name>LIDVID_LID</name>
+          <field_number>2</field_number>
+          <data_type>ASCII_LIDVID_LID</data_type>
+          <maximum_field_length unit="byte">255</maximum_field_length>
+        </Field_Delimited>
+      </Record_Delimited>
+      <reference_type>inventory_has_member_product</reference_type>
+    </Inventory>
+  </File_Area_Inventory>
+</Product_Collection>


### PR DESCRIPTION
Improve logic to validate File.file_size in label

Closes NASA-PDS/validate#281


The issue is validate never did check for the File.file_size attribute for correctness.  The fix is now in.
With the new code, it does now flag it as ERROr if the provided size does not match the actual file size.

Tested in DEV:


% validate -R pds4.label -r report_github281_label_invalid_1.json -s json -t src/test/resources/github281/invalid/collection_gwe_spk_invalid_1_bad_filesize.xml
% validate -R pds4.label -r report_github281_label_invalid_2.json -s json -t src/test/resources/github281/invalid/collection_gwe_spk_invalid_2_bad_checksum.xml
% validate -R pds4.label -r report_github281_label_invalid_3.json -s json -t src/test/resources/github281/invalid/collection_gwe_spk_invalid_3_bad_checksum_no_filesize.xml

% validate -R pds4.label -r report_github281_label_valid_1.json   -s json -t src/test/resources/github281/valid/collection_gwe_spk_valid_1.xml
% validate -R pds4.label -r report_github281_label_valid_2.json   -s json -t src/test/resources/github281/valid/collection_gwe_spk_valid_2_no_filesize.xml
% validate -R pds4.label -r report_github281_label_valid_3.json   -s json -t src/test/resources/github281/valid/collection_gwe_spk_valid_3_no_filesize_no_checksum.xml
