### PR TITLE
Remove dead code that was causing issue on Windows machine

### DIFF
--- a/src/main/java/gov/nasa/pds/tools/label/LabelValidator.java
+++ b/src/main/java/gov/nasa/pds/tools/label/LabelValidator.java
@@ -348,12 +348,8 @@ public class LabelValidator {
       // Function return true if the validation against the schematron should be done or not.
       // Note: schematron validation can be time consuming.  Only the bundle or collection should be validated against schematron.
       // If the flag skipProductValidation is true, the labels belong to data files should not be done.
-      String nameOnly = Paths.get(url.getPath()).getFileName().toString();
 
-      //LOG.debug("url.getPath() {}",url.getPath()); 
-      //LOG.debug("nameOnly {}",nameOnly); 
-      //LOG.debug("nameOnly.contains('bundle') {}",nameOnly.contains("bundle")); 
-      //LOG.debug("nameOnly.contains('collection') {}",nameOnly.contains("collection")); 
+      // Removed String nameOnly = Paths.get(url.getPath()).getFileName().toString() due to issue for Windows machine.
 
       Boolean validateAgainstSchematronFlag;
       if (!this.skipProductValidation) {
@@ -362,14 +358,11 @@ public class LabelValidator {
           // If skip product validation is true, perform schematron validation bundle/collection labels only.
           // Note: To inspect the file is time consuming
           // If the name of the file contains 'bundle' or 'collection' do the schematron validation.
-          //if (TargetExaminer.isTargetBundleType(url) || TargetExaminer.isTargetCollectionType(url))
-          // Comment out the file inspection in favor of checking the name only as it can be time consuming.
           // 6C.1.3 Reserved File Names
           //     The following file names are reserved for specific purposes within PDS archives and may not be used otherwise:
           //         bundle*.xml
           //         collection*.[xml,csv]
 
-          //if ((nameOnly.startsWith("bundle") || nameOnly.startsWith("collection")) && nameOnly.endsWith(".xml")) {
           if (TargetExaminer.isTargetBundleType(url) || TargetExaminer.isTargetCollectionType(url)) {
               validateAgainstSchematronFlag = true;
           } else {
@@ -377,7 +370,8 @@ public class LabelValidator {
               validateAgainstSchematronFlag = false;
           }
       }
-      LOG.debug("url,validateAgainstSchematronFlag {},{}",url,validateAgainstSchematronFlag);
+      LOG.debug("determineSchematronValidationFlag:url,validateAgainstSchematronFlag {},{}",url,validateAgainstSchematronFlag);
+
       return(validateAgainstSchematronFlag);
   }
 


### PR DESCRIPTION
…Windows machine.

1. Remove nameOnly variable from LabelValidator.java

Refs:

https://github.com/nasa-pds/validate/issues/360 validate does not parse colon in Windows path

Jodan had ran the test on a Windows machine and verified that it was the issue with the function call;
Paths.get(url.getPath()).getFileName().toString()

Closes:

https://github.com/nasa-pds/validate/issues/360 validate does not parse colon in Windows path
