### PR TITLE
Check Header of File_Area_Ancillary and provide meaningful error mess…

### DIFF
--- a/src/main/java/gov/nasa/pds/tools/validate/content/table/FieldValueValidator.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/content/table/FieldValueValidator.java
@@ -251,10 +251,12 @@ public class FieldValueValidator {
             // if (((i+1)<fields.length) && (fields[i].getOffset()+fields[i].getLength() > fields[i+1].getOffset()))
             // The next line is hard to read.  Perhaps the parenthesis should surround the 2nd > comparison.
         	if (((i+1)<fields.length) && (fields[i].getOffset()+fields[i].getLength()) > fields[i+1].getOffset()) {
+                int currentFieldEndsAt = fields[i].getOffset()+fields[i].getLength();
+                int nextOffsetShouldBe = fields[i].getOffset()+fields[i].getLength() + 1;
         		String message = "This field overlaps the next field. Current field ends at " 
-        				+ (fields[i].getOffset()+fields[i].getLength()) 
-        				+ ". Next field starts at " + fields[i+1].getOffset();
-                LOG.error(message);
+        				+ currentFieldEndsAt  
+        				+ ". Next field starts at " + fields[i+1].getOffset() + " but should be at least at " + nextOffsetShouldBe;
+                LOG.error("{}","MESSAGE_1:" + message);
         		addTableProblem(ExceptionType.ERROR,
         				ProblemType.FIELD_VALUE_OVERLAP,
         				message,
@@ -295,10 +297,13 @@ public class FieldValueValidator {
                 // issue_257: Product with incorrect table binary definition pass validation
                 // Corrected logic: using the OR logic || and put parenthesis surround the 2nd check for readability.
         		if ((fields[i].getOffset()>fields[i+1].getOffset()) || (fields[i].getOffset()+fields[i].getLength()) > fields[i+1].getOffset()) {       
+                    int currentFieldEndsAt = fields[i].getOffset()+fields[i].getLength();
+                    int nextOffsetShouldBe = fields[i].getOffset()+fields[i].getLength() + 1;
         			String message = "This field overlaps the next field. Current field ends at " 
-        					+ (fields[i].getOffset()+fields[i].getLength()+1) 
-        					+ ". Next field starts at " + (fields[i+1].getOffset()+1);
-                    LOG.error("{}",message);
+        					//+ (fields[i].getOffset()+fields[i].getLength()+1) 
+        					+ currentFieldEndsAt
+        					+ ". Next field starts at " + (fields[i+1].getOffset()+1) + " but should be at least at " + nextOffsetShouldBe;
+                    LOG.error("{}","MESSAGE_2:" + message);
         			addTableProblem(ExceptionType.ERROR,
         					ProblemType.FIELD_VALUE_OVERLAP,
         					message,

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/TableDataContentValidationRule.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/TableDataContentValidationRule.java
@@ -585,6 +585,48 @@ public class TableDataContentValidationRule extends AbstractValidationRule {
       return(tableIsLineOrientedFlag);
   }
 
+  private void performOffsetCheck(long readerOffset, int headerOffset, int headerSize, URL dataFile, int tableIndex, String tableName) {
+          // Add new checks for the header and the table data area to see if they overlap.
+          //
+          // Case 1:
+          // This case is OK because the table starts after the header ends.
+          // Validate only know that the table offset starts after the header ends.
+          // It cannot know if the offset will NOT cause any problem with the parsing of each record.
+          // That is the responsibility of the user to make any correction if it turns out that
+          // many fields are invalid due to a "bad" offset.
+          //
+          //     [this is the header]
+          //                          [this is the table]
+          //
+          // Case 2:
+          // This is NOT OK because the table starts before the header ends.
+          // The header and the table overlaps.
+          //
+          //     [this is the header]
+          //           [this is the table]
+          //
+          // reader.getOffset()        = from beginning of file to table data area
+          // headerOffset + headerSize = total header length
+
+          if (readerOffset < (headerOffset + headerSize)) {
+              // Case 2:
+              String message = "The table offset " + readerOffset + " for object " + "'" + tableName + "'" + " is invalid.  The previously defined object ends at byte " + (headerOffset + headerSize);
+              LOG.error("validateTableDataContents: " + message);
+              addTableProblem(ExceptionType.ERROR,
+                              ProblemType.FIELDS_MISMATCH,
+                              message,
+                              dataFile,
+                              tableIndex,
+                              -1);
+          } else {
+              // Case 1:
+              String message = "The table offset " + readerOffset + " for object " + "'" + tableName + "'" + " is OK, with entire header length which is headerOffset " + headerOffset + " plus header size " + headerSize;
+              LOG.debug("validateTableDataContents:" + message);
+          }
+
+  }
+
+
   @ValidationTest
   public void validateTableDataContents() throws MalformedURLException, 
   URISyntaxException {
@@ -798,6 +840,9 @@ public class TableDataContentValidationRule extends AbstractValidationRule {
         	    inventoryTable = true;
           }
           actualRecordNumber = actualTotalRecords;
+
+          this.performOffsetCheck(reader.getOffset(), headerOffset, headerSize, dataFile, tableIndex,  td.getName());
+
         } else if (table instanceof TableBinary) {
           LOG.debug("validateTableDataContents:table instanceof TableBinary");
           TableBinary tb = (TableBinary) table;
@@ -821,6 +866,9 @@ public class TableDataContentValidationRule extends AbstractValidationRule {
         	  long actualRecordSize = actualTotalRecords - reader.getOffset();
         	  actualRecordNumber = actualRecordSize/recordLength;
           }
+
+          this.performOffsetCheck(reader.getOffset(), headerOffset, headerSize, dataFile, tableIndex,  tb.getName());
+
         } else {
           LOG.debug("table instanceof TableCharacter: else");
 
@@ -856,43 +904,7 @@ public class TableDataContentValidationRule extends AbstractValidationRule {
           LOG.debug("recordLength,definedNumRecords,recordsToRemove,actualRecordNumber {},{},{},{}",recordLength,definedNumRecords,recordsToRemove,actualRecordNumber);
           // Print the stack trace to an external file for inspection.
 
-          // Add new checks for the header and the table data area to see if they overlap.
-          //
-          // Case 1:
-          // This case is OK because the table starts after the header ends.
-          // Validate only know that the table offset starts after the header ends.
-          // It cannot know if the offset will NOT cause any problem with the parsing of each record.
-          // That is the responsibility of the user to make any correction if it turns out that
-          // many fields are invalid due to a "bad" offset.
-          //
-          //     [this is the header]
-          //                          [this is the table]
-          //
-          // Case 2:
-          // This is NOT OK because the table starts before the header ends.
-          // The header and the table overlaps.
-          //
-          //     [this is the header]
-          //           [this is the table]
-          //
-          // reader.getOffset()        = from beginning of file to table data area
-          // headerOffset + headerSize = total header length
-
-          if (reader.getOffset() < (headerOffset + headerSize)) {
-              // Case 2:
-              String message = "The table offset " + reader.getOffset() + " for object " + "'" + tc.getName() + "'" + " is invalid.  The previously defined object ends at byte " + (headerOffset + headerSize);
-              LOG.error("validateTableDataContents: " + message);
-              addTableProblem(ExceptionType.ERROR,
-                              ProblemType.FIELDS_MISMATCH,
-                              message,
-                              dataFile,
-                              tableIndex,
-                              -1);
-          } else {
-              // Case 1:
-              String message = "The table offset " + reader.getOffset() + " for object " + "'" + tc.getName() + "'" + " is OK, with entire header length which is headerOffset " + headerOffset + " plus header size " + headerSize;
-              LOG.debug("validateTableDataContents:" + message);
-          }
+          this.performOffsetCheck(reader.getOffset(), headerOffset, headerSize, dataFile, tableIndex,  tc.getName());
 
         } 
         

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/TableFieldDefinitionRule.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/TableFieldDefinitionRule.java
@@ -93,9 +93,10 @@ public class TableFieldDefinitionRule extends AbstractValidationRule {
         ASCII_NUMBER_TYPE_LIST.add("ASCII_Integer".toUpperCase());
     }
 
-    private static String PRODUCT_OBSERVATIONAL   = "Product_Observational";
-    private static String FILE_AREA_OBSERVATIONAL = PRODUCT_OBSERVATIONAL + "/File_Area_Observational";
-    private static String TABLE_CHARACTER         = FILE_AREA_OBSERVATIONAL + "/Table_Character";
+    // Use wild card since not all labels has Product_Observational/File_Area_Observational/Table_Character
+    // Some labels have the following structure Product_Ancillary/File_Area_Ancillary/Table_Character
+
+    private static String TABLE_CHARACTER         = "*/*/Table_Character";  // Use wild card since not all labels has Product_Observational/File_Area_Observational/Table_Character
     private static String RECORD_CHARACTER        = TABLE_CHARACTER + "/Record_Character";
     private static String RECORD_CHARACTER_FIELDS      = RECORD_CHARACTER + "/fields";
     private static String FIELD_CHARACTER              = RECORD_CHARACTER + "/Field_Character";
@@ -185,13 +186,11 @@ public class TableFieldDefinitionRule extends AbstractValidationRule {
 
      try {
         XMLExtractor extractor = new XMLExtractor(getTarget());
-        TinyNodeImpl productObservationalNode = extractor.getNodeFromDoc(PRODUCT_OBSERVATIONAL);
         TinyNodeImpl tableCharacterNode       = extractor.getNodeFromDoc(TABLE_CHARACTER);
         TinyNodeImpl recordCharacterNode      = extractor.getNodeFromDoc(RECORD_CHARACTER); 
 
         // If any of the nodes are null, cannot continue.  Not all labels are expected to contain the PRODUCT_OBSERVATIONAL nodes.
-        if (productObservationalNode == null ||
-            tableCharacterNode       == null ||
+        if (tableCharacterNode       == null ||
             recordCharacterNode      == null) { 
             LOG.info("Label " + getTarget() + " does not contain any fields pertaining to " + TABLE_CHARACTER + " or " + RECORD_CHARACTER + " to valid ASCII field formats on");
             return;

--- a/src/test/resources/github361/maven_orb_rec_210101_210401_v1.invalid.minimal.header.xml
+++ b/src/test/resources/github361/maven_orb_rec_210101_210401_v1.invalid.minimal.header.xml
@@ -91,7 +91,7 @@
         <Field_Character>
           <name>Event UTC PERI</name>
           <field_number>2</field_number>
-          <field_location unit="byte">8</field_location>
+          <field_location unit="byte">2</field_location>
           <data_type>ASCII_String</data_type>
           <field_length unit="byte">20</field_length>
           <field_format>A20</field_format>

--- a/src/test/resources/github361/maven_orb_rec_210101_210401_v1.minimal.offset.good.xml
+++ b/src/test/resources/github361/maven_orb_rec_210101_210401_v1.minimal.offset.good.xml
@@ -72,6 +72,7 @@
     </Header>
     <Table_Character>
       <name>Orbit number table</name>
+      <!-- The offset can be any values including 267 and after since it does not overlap with header. -->
       <offset unit="byte">267</offset>
       <records>5</records>
       <record_delimiter>Carriage-Return Line-Feed</record_delimiter>

--- a/src/test/resources/github361/maven_orb_rec_210101_210401_v1.minimal.offset.late.is.ok.but.throws.off.table.validation.xml
+++ b/src/test/resources/github361/maven_orb_rec_210101_210401_v1.minimal.offset.late.is.ok.but.throws.off.table.validation.xml
@@ -72,7 +72,8 @@
     </Header>
     <Table_Character>
       <name>Orbit number table</name>
-      <offset unit="byte">267</offset>
+      <!-- The offset can be any values including 267 and after since it does not overlap with header but can cause table to not behave. -->
+      <offset unit="byte">333</offset>
       <records>5</records>
       <record_delimiter>Carriage-Return Line-Feed</record_delimiter>
       <Record_Character>

--- a/src/test/resources/github361/maven_orb_rec_210101_210401_v1.minimal.offset.too.early.xml
+++ b/src/test/resources/github361/maven_orb_rec_210101_210401_v1.minimal.offset.too.early.xml
@@ -72,7 +72,8 @@
     </Header>
     <Table_Character>
       <name>Orbit number table</name>
-      <offset unit="byte">267</offset>
+      <!-- Setting to 222 (table starts before header ends) to cause havoc in validate</offset>-->
+      <offset unit="byte">222</offset>
       <records>5</records>
       <record_delimiter>Carriage-Return Line-Feed</record_delimiter>
       <Record_Character>


### PR DESCRIPTION
…ages when the offset overlap between Header and table data or table fields overlap between each others.

1. Add test resources :src/test/resources/github361
2. Add meaningful error message when fields overlap :src/main/java/gov/nasa/pds/tools/validate/content/table/FieldValueValidator.java
3. Add logic to check for overlap of header total length with table offset, and add meaningful error message when offset is incorrect :src/main/java/gov/nasa/pds/tools/validate/rule/pds4/TableDataContentValidationRule.java
4. Modify logic to read Table_Character tags from all possible main tags not just Product_Observational :src/main/java/gov/nasa/pds/tools/validate/rule/pds4/TableFieldDefinitionRule.java

Refs:

https://github.com/nasa-pds/validate/issues/361 validate does not check Header of a File_Area_Ancillary nor does not provide a meaningful error message for an incorrect Table_Character offset

Closes https://github.com/nasa-pds/validate/issues/361 validate does not check Header of a File_Area_Ancillary nor does not provide a meaningful error message for an incorrect Table_Character offset

The error messages weren't as meaningful to the user so extra verbiage were added so the user can make the correction in the label.
Also, previously, the code was not reading the Table_Character tag but it does now.
The reason was the Table_Character can also be File_Area_Ancillary product.

Since issue #361 is a follow on issue #257, a new test set was added to allow the tester to validate the meaningful-ness of the error messages.
No new regression tests were added.

Tested in DEV:

Case 1:  The offsets and headers are good.

```
% validate -R pds4.label --skip-context-reference-check -r report_github361_label_valid_mini_good_offset.json  -s json -t src/test/resources/github361/maven_orb_rec_210101_210401_v1.minimal.offset.good.xml
```
Case 2: The table offset is too early before the header total length ends.
```
% validate -R pds4.label --skip-context-reference-check -r report_github361_label_invalid_mini_offset_too_early.json  -s json -t src/test/resources/github361/maven_orb_rec_210101_210401_v1.minimal.offset.too.early.xml >& t11
```
Case 3: The table offset is past the header total length (which is OK) but throws off table validation since the fields are all wrong because
the first field is starting in the middle of the 1st record and not the first byte.
```
% validate -R pds4.label --skip-context-reference-check -r report_github361_label_invalid_mini_offset_late_is_ok_but_throws_of_table_validation.json  -s json -t src/test/resources/github361/maven_orb_rec_210101_210401_v1.minimal.offset.late.is.ok.but.throws.off.table.validation.xml
```
Case 4 :  The start position of field 2 is too early and overlaps with field 1
```
% validate -R pds4.label --skip-context-reference-check -r report_github361_label_invalid_mini_header.json  -s json -t src/test/resources/github361/maven_orb_rec_210101_210401_v1.invalid.minimal.header.xml
```