### PR TITLE
Use enum type defined in FieldType instead of hard-coded string

### DIFF
--- a/src/main/java/gov/nasa/pds/tools/validate/content/table/FieldValueValidator.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/content/table/FieldValueValidator.java
@@ -177,11 +177,12 @@ public class FieldValueValidator {
 
     int actualFieldNumber = 1;
     for (int i = 0; i < fields.length; i++) {
-      boolean fieldIsBitStringFlag = false; // Flag to store whether field is a UNSIGNEDBITSTRING or not.
+      boolean fieldIsBitStringFlag = false; // Flag to store whether field is a UNSIGNEDBITSTRING or SIGNEDBITSTRING
       String value = "dummy_value";   // Set to a dummy value to allow inspection when the value changed to a legitimate value.
       //LOG.info("validate:i,fields.length {},{}",i,fields.length);
       try {
-        if (fields[i].getType().toString().toUpperCase().contains("BIT")) {
+        // Use the enum types defined in FieldType class.
+        if (fields[i].getType() == FieldType.SIGNEDBITSTRING || fields[i].getType() == FieldType.UNSIGNEDBITSTRING) {
             fieldIsBitStringFlag = true;
         }
         //String value = record.getString(i+1);


### PR DESCRIPTION
1. Use enum type defined in FieldType instead of hard-coded string : src/main/java/gov/nasa/pds/tools/validate/content/table/FieldValueValidator.java

Refs:

https://github.com/nasa-pds/validate/issues/392 Validate throws incorrect overlap error when first Field_Bit has length 1

Closes https://github.com/nasa-pds/validate/issues/392 Validate throws incorrect overlap error when first Field_Bit has length 1

This pull request is a follow up on the previous pull request for the same issue.  The only change was to use an enum type instead of a hard-code string.  

All regression tests passed.