### PR TITLE
Fix bug to skip only collection files that are not the latest

### DIFF
--- a/src/main/java/gov/nasa/pds/tools/util/ReferentialIntegrityUtil.java
+++ b/src/main/java/gov/nasa/pds/tools/util/ReferentialIntegrityUtil.java
@@ -900,6 +900,7 @@ public class ReferentialIntegrityUtil {
 
             if ((lidOrLidVidReferences != null) && !lidOrLidVidReferences.isEmpty()) {
                 for (int ii=0; ii < lidOrLidVidReferences.size(); ii++) {
+                    LOG.debug("additionalReferentialIntegrityChecks:ii,url,lidOrLidVidReferences.get(ii) {},{},[{}]",ii,url,lidOrLidVidReferences.get(ii));
                     // Do not add duplicate references by checking for existence of the combination reference id in ReferentialIntegrityUtil.lidOrLidVidReferencesCumulative
                     // and the file name has not already been added already in ReferentialIntegrityUtil.lidOrLidVidReferencesCumulativeFileNames list.
                     // Note that because the reference id can be the same, the combination of the id plus the file name will make it unique. 

--- a/src/main/java/gov/nasa/pds/validate/ValidateLauncher.java
+++ b/src/main/java/gov/nasa/pds/validate/ValidateLauncher.java
@@ -1361,6 +1361,9 @@ public class ValidateLauncher {
                                 new ProblemDefinition(ExceptionType.FATAL, ProblemType.SCHEMA_ERROR, se.getMessage()),
                                 target, se.getLineNumber(), se.getColumnNumber());
                     } else {
+                        // Print stack trace for developer to inspect.
+                        e.printStackTrace();
+                        LOG.error("ValidateLauncher:doValidation:Stack trace content is above");
                         p = new ValidationProblem(
                                 new ProblemDefinition(ExceptionType.FATAL, ProblemType.INTERNAL_ERROR, e.getMessage()),
                                 target);

--- a/src/test/resources/features/validate.feature
+++ b/src/test/resources/features/validate.feature
@@ -272,6 +272,10 @@ Scenario Outline: Execute validate command for tests below.
 
  |"NASA-PDS/validate#390 INVALID" | "github390" | 1 | "1 error messages expected: 1 RECORD_LENGTH_MISMATCH" | "RECORD_LENGTH_MISMATCH" | "src/test/resources" | "target/test" | "-R pds4.label -r {reportDir}/report_github390_label_invalid.json -s json -t {resourceDir}/github390/VALIDATE-TAB/collection_calib_freq.xml" | "report_github390_label_invalid.json" |
 
+# https://github.com/nasa-pds/validate/issues/408 Validate 2.1.0-SNAPSHOT skips a collection XML label
+
+ |"NASA-PDS/validate#408 VALID" | "github408" | 0 | "0 error messages expected" | "totalErrors" | "src/test/resources" | "target/test" | "-R pds4.bundle --skip-content-validation -r {reportDir}/report_github408_bundle_valid.json -s json -t {resourceDir}/github408/valid/bundle_insight_seis.xml" | "report_github408_bundle_valid.json" |
+
 # BIG_NOTE: Add new tests that doesn't involve a catalog above this line.
 # https://github.com/NASA-PDS/validate/issues/297 Content validation of ASCII_Integer field does not accept value with leading zeroes
  |"NASA-PDS/validate#297 VALID" | "github297" | 0 | "0 errors message expected" | "totalErrors" | "src/test/resources" | "target/test" | "--skip-context-validation -R pds4.label -r {reportDir}/report_github297_label_valid.json  -s json -t {resourceDir}/github297/valid/rimfax_rdr_0081_example.xml" | "report_github297_label_valid.json" |

--- a/src/test/resources/github408/valid/bundle_insight_seis.xml
+++ b/src/test/resources/github408/valid/bundle_insight_seis.xml
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1B00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+
+<Product_Bundle xmlns="http://pds.nasa.gov/pds4/pds/v1"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1 http://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1B00.xsd">
+    <Identification_Area>
+        <logical_identifier>urn:nasa:pds:insight_seis</logical_identifier>
+        <version_id>3.0</version_id>
+        <title>InSight SEIS Data Bundle</title>
+        <information_model_version>1.11.0.0</information_model_version>
+        <product_class>Product_Bundle</product_class>
+        <Citation_Information>
+            <author_list>InSight SEIS Science Team</author_list>
+            <publication_year>2019</publication_year>
+            <doi>10.17189/1517570</doi>
+            <description>
+               The InSight SEIS data bundle consists of SEIS instrument observations in two collections,
+               the SEED (Standard for the Exchange of Earthquake Data) collection and the ASCII table collection. 
+               The SEED collection contains data in Mini-SEED files and their metadata in Dataless-SEED files.
+               The ASCII Table collection contains the same data in PDS-compliant ASCII files, with
+               the data in GeoCSV (comma-separated value) tables and the metadata in 
+               StationXML files. The bundle also includes the SEIS document collection and the Lander Activity 
+               Files, Derived Data Mars Quake Service (MQS) Catalog, and MQS XML Schema collections.
+               </description>
+        </Citation_Information>
+        <Modification_History>
+            <Modification_Detail>
+                <modification_date>2018-07-02</modification_date>
+                <version_id>1.0</version_id>
+                <description>First release</description>
+            </Modification_Detail>
+            <Modification_Detail>
+                <modification_date>2020-01-02</modification_date>
+                <version_id>1.1</version_id>
+                <description>Changed instrument name in this label to match name in context product</description>
+            </Modification_Detail>
+            <Modification_Detail>
+                <modification_date>2020-09-24</modification_date>
+                <version_id>2.0</version_id>
+                <description>Added collection data_laf (Lander Activity Files) to this bundle</description>
+            </Modification_Detail>
+            <Modification_Detail>
+                <modification_date>2021-03-23</modification_date>
+                <version_id>3.0</version_id>
+                <description>Added data_derived and schema_mqs collections to this bundle</description>
+            </Modification_Detail>
+        </Modification_History>
+    </Identification_Area>
+    <Context_Area>
+        <Time_Coordinates>
+            <start_date_time>2018-11-26Z</start_date_time>
+            <stop_date_time xsi:nil="true" nilReason="unknown"/>
+        </Time_Coordinates>
+        <Primary_Result_Summary>
+            <purpose>Science</purpose>
+            <processing_level>Raw</processing_level>
+            <processing_level>Calibrated</processing_level>
+        </Primary_Result_Summary>
+        <Investigation_Area>
+            <name>Insight</name>
+            <type>Mission</type>
+            <Internal_Reference>
+                <lid_reference>urn:nasa:pds:context:investigation:mission.insight</lid_reference>
+                <reference_type>bundle_to_investigation</reference_type>
+            </Internal_Reference>
+        </Investigation_Area>
+        <Observing_System>
+            <name>Insight</name>
+            <Observing_System_Component>
+                <name>Insight</name>
+                <type>Spacecraft</type>
+                <Internal_Reference>
+                    <lid_reference>urn:nasa:pds:context:instrument_host:spacecraft.insight</lid_reference>
+                    <reference_type>is_instrument_host</reference_type>
+                </Internal_Reference>
+            </Observing_System_Component>
+            <Observing_System_Component>
+                <name>SEISMIC EXPERIMENT FOR INTERIOR STRUCTURE</name>
+                <type>Instrument</type>
+                <Internal_Reference>
+                    <lid_reference>urn:nasa:pds:context:instrument:seis.insight</lid_reference>
+                    <reference_type>is_instrument</reference_type>
+                </Internal_Reference>
+            </Observing_System_Component>
+        </Observing_System>
+        <Target_Identification>
+            <name>Mars</name>
+            <type>Planet</type>
+            <Internal_Reference>
+                <lid_reference>urn:nasa:pds:context:target:planet.mars</lid_reference>
+                <reference_type>bundle_to_target</reference_type>
+            </Internal_Reference>
+        </Target_Identification>
+    </Context_Area>
+    <Reference_List>
+        <External_Reference>
+            <doi>10.1007/s11214-018-0574-6</doi>
+            <reference_text>
+                Lognonne, P., Banerdt, W. B., Giardini, D., et al., SEIS: InSight's 
+                Seismic Experiment for Internal Structure of Mars, Space Sci. Rev. (2019)
+                215:12.
+            </reference_text>
+        </External_Reference>
+    </Reference_List>
+    <Bundle>
+        <bundle_type>Archive</bundle_type>
+    </Bundle>
+    <File_Area_Text>
+        <File>
+            <file_name>readme.txt</file_name>
+        </File>
+        <Stream_Text>
+            <offset unit="byte">0</offset>
+            <parsing_standard_id>7-Bit ASCII Text</parsing_standard_id>
+            <record_delimiter>Carriage-Return Line-Feed</record_delimiter>
+        </Stream_Text>
+    </File_Area_Text>
+    <Bundle_Member_Entry>
+        <lid_reference>urn:nasa:pds:insight_seis:data_seed</lid_reference>
+        <member_status>Primary</member_status>
+        <reference_type>bundle_has_data_collection</reference_type>
+    </Bundle_Member_Entry>
+    <Bundle_Member_Entry>
+        <lid_reference>urn:nasa:pds:insight_seis:data_table</lid_reference>
+        <member_status>Primary</member_status>
+        <reference_type>bundle_has_data_collection</reference_type>
+    </Bundle_Member_Entry>
+    <Bundle_Member_Entry>
+        <lid_reference>urn:nasa:pds:insight_documents:document_seis</lid_reference>
+        <member_status>Secondary</member_status>
+        <reference_type>bundle_has_document_collection</reference_type>
+    </Bundle_Member_Entry>
+    <Bundle_Member_Entry>
+        <lid_reference>urn:nasa:pds:insight_seis:data_laf</lid_reference>
+        <member_status>Primary</member_status>
+        <reference_type>bundle_has_data_collection</reference_type>
+    </Bundle_Member_Entry>
+    <Bundle_Member_Entry>
+        <lid_reference>urn:nasa:pds:insight_seis:data_derived</lid_reference>
+        <member_status>Primary</member_status>
+        <reference_type>bundle_has_data_collection</reference_type>
+    </Bundle_Member_Entry>
+    <Bundle_Member_Entry>
+        <lid_reference>urn:nasa:pds:insight_seis:schema_mqs</lid_reference>
+        <member_status>Primary</member_status>
+        <reference_type>bundle_has_schema_collection</reference_type>
+    </Bundle_Member_Entry>
+</Product_Bundle>

--- a/src/test/resources/github408/valid/data/collection_data_lander.xml
+++ b/src/test/resources/github408/valid/data/collection_data_lander.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1B00.sch" 
+    schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<Product_Collection xmlns="http://pds.nasa.gov/pds4/pds/v1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1 https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1B00.xsd">
+    <Identification_Area>
+        <logical_identifier>urn:nasa:pds:insight_seis:data_laf</logical_identifier>
+        <version_id>4.0</version_id>
+        <title>InSight SEIS Lander Activity Files in ASCII Table Format</title>
+        <information_model_version>1.11.0.0</information_model_version>
+        <product_class>Product_Collection</product_class>
+        <Citation_Information>
+            <author_list>Weber, R.</author_list>
+            <publication_year>2020</publication_year>
+            <description>
+                The SEIS data_laf collection contains Lander Activity Files for the SEIS instrument
+                in ASCII CSV table format. 
+            </description>
+        </Citation_Information>
+        <Modification_History>
+            <Modification_Detail>
+                <modification_date>2020-09-09</modification_date>
+                <version_id>1.0</version_id>
+                <description>The first delivery of Lander Activity Files occurred with SEIS Release 6, 10/01/20.</description>
+            </Modification_Detail>
+            <Modification_Detail>
+                <modification_date>2020-12-10</modification_date>
+                <version_id>2.0</version_id>
+                <description>The second delivery of Lander Activity Files occurred with SEIS Release 7, 01/04/21.</description>
+            </Modification_Detail>
+            <Modification_Detail>
+                <modification_date>2021-03-18</modification_date>
+                <version_id>3.0</version_id>
+                <description>The third delivery of Lander Activity Files occurred with SEIS Release 8, 04/01/21.</description>
+            </Modification_Detail>
+            <Modification_Detail>
+                <modification_date>2021-06-09</modification_date>
+                <version_id>4.0</version_id>
+                <description>The fourth delivery of Lander Activity Files occurred with SEIS Release 9, 07/01/21.</description>
+            </Modification_Detail>
+        </Modification_History>
+    </Identification_Area>
+    <Context_Area>
+        <Time_Coordinates>
+            <start_date_time>2018-04-01Z</start_date_time>
+            <stop_date_time>2021-03-31Z</stop_date_time>
+        </Time_Coordinates>
+        <Primary_Result_Summary>
+            <purpose>Science</purpose>
+            <processing_level>Raw</processing_level>
+            <processing_level>Calibrated</processing_level>
+        </Primary_Result_Summary>
+        <Investigation_Area>
+            <name>Insight</name>
+            <type>Mission</type>
+            <Internal_Reference>
+                <lid_reference>urn:nasa:pds:context:investigation:mission.insight</lid_reference>
+                <reference_type>collection_to_investigation</reference_type>
+            </Internal_Reference>
+        </Investigation_Area>
+        <Observing_System>
+            <name>Insight</name>
+            <Observing_System_Component>
+                <name>Insight</name>
+                <type>Spacecraft</type>
+                <Internal_Reference>
+                    <lid_reference>urn:nasa:pds:context:instrument_host:spacecraft.insight</lid_reference>
+                    <reference_type>is_instrument_host</reference_type>
+                </Internal_Reference>
+            </Observing_System_Component>
+            <Observing_System_Component>
+                <name>Seismometer</name>
+                <type>Instrument</type>
+                <Internal_Reference>
+                    <lid_reference>urn:nasa:pds:context:instrument:seis.insight</lid_reference>
+                    <reference_type>is_instrument</reference_type>
+                </Internal_Reference>
+            </Observing_System_Component>
+        </Observing_System>
+        <Target_Identification>
+            <name>Mars</name>
+            <type>Planet</type>
+            <Internal_Reference>
+                <lid_reference>urn:nasa:pds:context:target:planet.mars</lid_reference>
+                <reference_type>collection_to_target</reference_type>
+            </Internal_Reference>
+        </Target_Identification>
+    </Context_Area>
+    <Reference_List>
+        <Internal_Reference>
+            <lid_reference>urn:nasa:pds:insight_documents:document_seis:seis_release_notes</lid_reference>
+            <reference_type>collection_to_document</reference_type>
+            <comment>The seis_release_notes document in the SEIS document collection
+            has notes and errata concerning each public release of SEIS data by PDS.</comment>
+        </Internal_Reference>
+        <External_Reference>
+            <doi>10.1007/s11214-018-0574-6</doi>
+            <reference_text>
+                Lognonne, P., Banerdt, W. B., Giardini, D., et al. (2019), SEIS: InSight's 
+                Seismic Experiment for Internal Structure of Mars, Space Sci. Rev. 215:12.
+            </reference_text>
+        </External_Reference>
+    </Reference_List>
+    <Collection>
+        <collection_type>Data</collection_type>
+    </Collection>
+    <File_Area_Inventory>
+        <File>
+            <file_name>collection_data_lander_inventory.csv</file_name>
+            <creation_date_time>2020-09-09</creation_date_time>
+        </File>
+        <Inventory>
+            <offset unit="byte">0</offset>
+            <parsing_standard_id>PDS DSV 1</parsing_standard_id>
+            <records>3</records>
+            <record_delimiter>Carriage-Return Line-Feed</record_delimiter>
+            <field_delimiter>Comma</field_delimiter>
+            <Record_Delimited>
+                <fields>2</fields>
+                <groups>0</groups>
+                <Field_Delimited>
+                    <name>Member Status</name>
+                    <field_number>1</field_number>
+                    <data_type>ASCII_String</data_type>
+                    <maximum_field_length unit="byte">1</maximum_field_length>
+                </Field_Delimited>
+                <Field_Delimited>
+                    <name>LIDVID_LID</name>
+                    <field_number>2</field_number>
+                    <data_type>ASCII_LIDVID_LID</data_type>
+                    <maximum_field_length unit="byte">255</maximum_field_length>
+                </Field_Delimited>
+            </Record_Delimited>
+            <reference_type>inventory_has_member_product</reference_type>
+        </Inventory>
+    </File_Area_Inventory>
+</Product_Collection>

--- a/src/test/resources/github408/valid/data/collection_data_lander_inventory.csv
+++ b/src/test/resources/github408/valid/data/collection_data_lander_inventory.csv
@@ -1,0 +1,3 @@
+P,urn:nasa:pds:insight_seis:data_laf:lander-activity_fsw.xb.elys0.2018.330.3::1.0
+P,urn:nasa:pds:insight_seis:data_laf:lander-activity_fsw.xb.elys0.2018.331.3::1.0
+P,urn:nasa:pds:insight_seis:data_laf:lander-activity_fsw.xb.elys0.2018.332.4::1.0

--- a/src/test/resources/github408/valid/data/collection_data_seed.xml
+++ b/src/test/resources/github408/valid/data/collection_data_seed.xml
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1B00.sch" 
+    schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<Product_Collection xmlns="http://pds.nasa.gov/pds4/pds/v1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1 https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1B00.xsd">
+    <Identification_Area>
+        <logical_identifier>urn:nasa:pds:insight_seis:data_seed</logical_identifier>
+        <version_id>10.0</version_id>
+        <title>InSight SEIS Data Collection in SEED Format</title>
+        <information_model_version>1.11.0.0</information_model_version>
+        <product_class>Product_Collection</product_class>
+        <Citation_Information>
+            <author_list>Weber, R.</author_list>
+            <publication_year>2020</publication_year>
+            <description>
+                The SEIS data_seed collection contains observations of the SEIS instrument
+                in dataless-SEED and mini-SEED format.
+            </description>
+        </Citation_Information>
+        <Modification_History>
+            <Modification_Detail>
+                <modification_date>2019-05-24</modification_date>
+                <version_id>1.0</version_id>
+                <description>Release 1a</description>
+            </Modification_Detail>
+            <Modification_Detail>
+                <modification_date>2019-06-26</modification_date>
+                <version_id>2.0</version_id>
+                <description>Release 1b</description>
+            </Modification_Detail>
+            <Modification_Detail>
+                <modification_date>2019-09-18</modification_date>
+                <version_id>3.0</version_id>
+                <description>Release 2</description>
+            </Modification_Detail>
+            <Modification_Detail>
+                <modification_date>2019-12-08</modification_date>
+                <version_id>4.0</version_id>
+                <description>Release 3</description>
+            </Modification_Detail>
+            <Modification_Detail>
+                <modification_date>2020-03-15</modification_date>
+                <version_id>5.0</version_id>
+                <description>Release 4</description>
+            </Modification_Detail>
+            <Modification_Detail>
+                <modification_date>2020-06-10</modification_date>
+                <version_id>6.0</version_id>
+                <description>Release 5</description>
+            </Modification_Detail>
+            <Modification_Detail>
+                <modification_date>2020-09-09</modification_date>
+                <version_id>7.0</version_id>
+                <description>Release 6</description>
+            </Modification_Detail>
+            <Modification_Detail>
+                <modification_date>2020-12-10</modification_date>
+                <version_id>8.0</version_id>
+                <description>Release 7</description>
+            </Modification_Detail>
+            <Modification_Detail>
+                <modification_date>2021-03-18</modification_date>
+                <version_id>9.0</version_id>
+                <description>Release 8</description>
+            </Modification_Detail>
+            <Modification_Detail>
+                <modification_date>2021-06-09</modification_date>
+                <version_id>10.0</version_id>
+                <description>Release 9</description>
+            </Modification_Detail>
+        </Modification_History>
+    </Identification_Area>
+    <Context_Area>
+        <Time_Coordinates>
+            <start_date_time>2018-04-01Z</start_date_time>
+            <stop_date_time>2021-03-31Z</stop_date_time>
+        </Time_Coordinates>
+        <Primary_Result_Summary>
+            <purpose>Science</purpose>
+            <processing_level>Raw</processing_level>
+            <processing_level>Calibrated</processing_level>
+        </Primary_Result_Summary>
+        <Investigation_Area>
+            <name>Insight</name>
+            <type>Mission</type>
+            <Internal_Reference>
+                <lid_reference>urn:nasa:pds:context:investigation:mission.insight</lid_reference>
+                <reference_type>collection_to_investigation</reference_type>
+            </Internal_Reference>
+        </Investigation_Area>
+        <Observing_System>
+            <name>Insight</name>
+            <Observing_System_Component>
+                <name>Insight</name>
+                <type>Spacecraft</type>
+                <Internal_Reference>
+                    <lid_reference>urn:nasa:pds:context:instrument_host:spacecraft.insight</lid_reference>
+                    <reference_type>is_instrument_host</reference_type>
+                </Internal_Reference>
+            </Observing_System_Component>
+            <Observing_System_Component>
+                <name>Seismometer</name>
+                <type>Instrument</type>
+                <Internal_Reference>
+                    <lid_reference>urn:nasa:pds:context:instrument:seis.insight</lid_reference>
+                    <reference_type>is_instrument</reference_type>
+                </Internal_Reference>
+            </Observing_System_Component>
+        </Observing_System>
+        <Target_Identification>
+            <name>Mars</name>
+            <type>Planet</type>
+            <Internal_Reference>
+                <lid_reference>urn:nasa:pds:context:target:planet.mars</lid_reference>
+                <reference_type>collection_to_target</reference_type>
+            </Internal_Reference>
+        </Target_Identification>
+    </Context_Area>
+    <Reference_List>
+        <Internal_Reference>
+            <lid_reference>urn:nasa:pds:insight_documents:document_seis:seis_release_notes</lid_reference>
+            <reference_type>collection_to_document</reference_type>
+            <comment>The seis_release_notes document in the SEIS document collection
+                has notes and errata concerning each public release of SEIS data by PDS.</comment>
+        </Internal_Reference>
+        <External_Reference>
+            <doi>10.1007/s11214-018-0574-6</doi>
+            <reference_text>
+                Lognonne, P., Banerdt, W. B., Giardini, D., et al. (2019), SEIS: InSight's 
+                Seismic Experiment for Internal Structure of Mars, Space Sci. Rev. 215:12.
+            </reference_text>
+        </External_Reference>
+    </Reference_List>
+    <Collection>
+        <collection_type>Data</collection_type>
+    </Collection>
+    <File_Area_Inventory>
+        <File>
+            <file_name>collection_data_seed_inventory.csv</file_name>
+            <creation_date_time>2020-03-15</creation_date_time>
+        </File>
+        <Inventory>
+            <offset unit="byte">0</offset>
+            <parsing_standard_id>PDS DSV 1</parsing_standard_id>
+            <records>4</records>
+            <record_delimiter>Carriage-Return Line-Feed</record_delimiter>
+            <field_delimiter>Comma</field_delimiter>
+            <Record_Delimited>
+                <fields>2</fields>
+                <groups>0</groups>
+                <Field_Delimited>
+                    <name>Member Status</name>
+                    <field_number>1</field_number>
+                    <data_type>ASCII_String</data_type>
+                    <maximum_field_length unit="byte">1</maximum_field_length>
+                </Field_Delimited>
+                <Field_Delimited>
+                    <name>LIDVID_LID</name>
+                    <field_number>2</field_number>
+                    <data_type>ASCII_LIDVID_LID</data_type>
+                    <maximum_field_length unit="byte">255</maximum_field_length>
+                </Field_Delimited>
+            </Record_Delimited>
+            <reference_type>inventory_has_member_product</reference_type>
+        </Inventory>
+    </File_Area_Inventory>
+</Product_Collection>

--- a/src/test/resources/github408/valid/data/collection_data_seed_2.xml
+++ b/src/test/resources/github408/valid/data/collection_data_seed_2.xml
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1B00.sch" 
+    schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<Product_Collection xmlns="http://pds.nasa.gov/pds4/pds/v1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1 https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1B00.xsd">
+    <Identification_Area>
+        <logical_identifier>urn:nasa:pds:insight_seis:data_seed</logical_identifier>
+        <version_id>9.0</version_id>
+        <title>InSight SEIS Data Collection in ASCII GeoCSV Table Format</title>
+        <information_model_version>1.11.0.0</information_model_version>
+        <product_class>Product_Collection</product_class>
+        <Citation_Information>
+            <author_list>Weber, R.</author_list>
+            <publication_year>2020</publication_year>
+            <description>
+                The SEIS data_table collection contains observations of the SEIS instrument
+                in ASCII GeoCSV table format, with metadata in ASCII StationXML format.
+            </description>
+        </Citation_Information>
+        <Modification_History>
+            <Modification_Detail>
+                <modification_date>2019-05-24</modification_date>
+                <version_id>1.0</version_id>
+                <description>Release 1a</description>
+            </Modification_Detail>
+            <Modification_Detail>
+                <modification_date>2019-06-26</modification_date>
+                <version_id>2.0</version_id>
+                <description>Release 1b</description>
+            </Modification_Detail>
+            <Modification_Detail>
+                <modification_date>2019-09-18</modification_date>
+                <version_id>3.0</version_id>
+                <description>Release 2</description>
+            </Modification_Detail>
+            <Modification_Detail>
+                <modification_date>2019-12-08</modification_date>
+                <version_id>4.0</version_id>
+                <description>Release 3</description>
+            </Modification_Detail>
+            <Modification_Detail>
+                <modification_date>2020-03-15</modification_date>
+                <version_id>5.0</version_id>
+                <description>Release 4</description>
+            </Modification_Detail>
+            <Modification_Detail>
+                <modification_date>2020-06-10</modification_date>
+                <version_id>6.0</version_id>
+                <description>Release 5</description>
+            </Modification_Detail>
+            <Modification_Detail>
+                <modification_date>2020-09-09</modification_date>
+                <version_id>7.0</version_id>
+                <description>Release 6</description>
+            </Modification_Detail>
+            <Modification_Detail>
+                <modification_date>2020-12-10</modification_date>
+                <version_id>8.0</version_id>
+                <description>Release 7</description>
+            </Modification_Detail>
+            <Modification_Detail>
+                <modification_date>2021-03-18</modification_date>
+                <version_id>9.0</version_id>
+                <description>Release 8</description>
+            </Modification_Detail>
+            <Modification_Detail>
+                <modification_date>2021-06-09</modification_date>
+                <version_id>10.0</version_id>
+                <description>Release 9</description>
+            </Modification_Detail>
+        </Modification_History>
+    </Identification_Area>
+    <Context_Area>
+        <Time_Coordinates>
+            <start_date_time>2018-04-01Z</start_date_time>
+            <stop_date_time>2021-03-31Z</stop_date_time>
+        </Time_Coordinates>
+        <Primary_Result_Summary>
+            <purpose>Science</purpose>
+            <processing_level>Raw</processing_level>
+            <processing_level>Calibrated</processing_level>
+        </Primary_Result_Summary>
+        <Investigation_Area>
+            <name>Insight</name>
+            <type>Mission</type>
+            <Internal_Reference>
+                <lid_reference>urn:nasa:pds:context:investigation:mission.insight</lid_reference>
+                <reference_type>collection_to_investigation</reference_type>
+            </Internal_Reference>
+        </Investigation_Area>
+        <Observing_System>
+            <name>Insight</name>
+            <Observing_System_Component>
+                <name>Insight</name>
+                <type>Spacecraft</type>
+                <Internal_Reference>
+                    <lid_reference>urn:nasa:pds:context:instrument_host:spacecraft.insight</lid_reference>
+                    <reference_type>is_instrument_host</reference_type>
+                </Internal_Reference>
+            </Observing_System_Component>
+            <Observing_System_Component>
+                <name>Seismometer</name>
+                <type>Instrument</type>
+                <Internal_Reference>
+                    <lid_reference>urn:nasa:pds:context:instrument:seis.insight</lid_reference>
+                    <reference_type>is_instrument</reference_type>
+                </Internal_Reference>
+            </Observing_System_Component>
+        </Observing_System>
+        <Target_Identification>
+            <name>Mars</name>
+            <type>Planet</type>
+            <Internal_Reference>
+                <lid_reference>urn:nasa:pds:context:target:planet.mars</lid_reference>
+                <reference_type>collection_to_target</reference_type>
+            </Internal_Reference>
+        </Target_Identification>
+    </Context_Area>
+    <Reference_List>
+        <Internal_Reference>
+            <lid_reference>urn:nasa:pds:insight_documents:document_seis:seis_release_notes</lid_reference>
+            <reference_type>collection_to_document</reference_type>
+            <comment>The seis_release_notes document in the SEIS document collection
+            has notes and errata concerning each public release of SEIS data by PDS.</comment>
+        </Internal_Reference>
+        <External_Reference>
+            <doi>10.1007/s11214-018-0574-6</doi>
+            <reference_text>
+                Lognonne, P., Banerdt, W. B., Giardini, D., et al. (2019), SEIS: InSight's 
+                Seismic Experiment for Internal Structure of Mars, Space Sci. Rev. 215:12.
+            </reference_text>
+        </External_Reference>
+    </Reference_List>
+    <Collection>
+        <collection_type>Data</collection_type>
+    </Collection>
+    <File_Area_Inventory>
+        <File>
+            <file_name>collection_data_table_inventory.csv</file_name>
+            <creation_date_time>2020-03-06</creation_date_time>
+        </File>
+        <Inventory>
+            <offset unit="byte">0</offset>
+            <parsing_standard_id>PDS DSV 1</parsing_standard_id>
+            <records>4</records>
+            <record_delimiter>Carriage-Return Line-Feed</record_delimiter>
+            <field_delimiter>Comma</field_delimiter>
+            <Record_Delimited>
+                <fields>2</fields>
+                <groups>0</groups>
+                <Field_Delimited>
+                    <name>Member Status</name>
+                    <field_number>1</field_number>
+                    <data_type>ASCII_String</data_type>
+                    <maximum_field_length unit="byte">1</maximum_field_length>
+                </Field_Delimited>
+                <Field_Delimited>
+                    <name>LIDVID_LID</name>
+                    <field_number>2</field_number>
+                    <data_type>ASCII_LIDVID_LID</data_type>
+                    <maximum_field_length unit="byte">255</maximum_field_length>
+                </Field_Delimited>
+            </Record_Delimited>
+            <reference_type>inventory_has_member_product</reference_type>
+        </Inventory>
+    </File_Area_Inventory>
+</Product_Collection>

--- a/src/test/resources/github408/valid/data/collection_data_seed_inventory.csv
+++ b/src/test/resources/github408/valid/data/collection_data_seed_inventory.csv
@@ -1,0 +1,4 @@
+P,urn:nasa:pds:insight_seis:data_seed:dataless.xb.elys0.2019.144::1.1
+P,urn:nasa:pds:insight_seis:data_seed:dataless.xb.elys0.2019.171::1.1
+P,urn:nasa:pds:insight_seis:data_seed:dataless.xb.elys0.2019.087::1.1
+P,urn:nasa:pds:insight_seis:data_seed:dataless.xb.elyhk.2019.170::1.1

--- a/src/test/resources/github408/valid/data/collection_data_table.xml
+++ b/src/test/resources/github408/valid/data/collection_data_table.xml
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1B00.sch" 
+    schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<Product_Collection xmlns="http://pds.nasa.gov/pds4/pds/v1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1 https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1B00.xsd">
+    <Identification_Area>
+        <logical_identifier>urn:nasa:pds:insight_seis:data_table</logical_identifier>
+        <version_id>10.0</version_id>
+        <title>InSight SEIS Data Collection in ASCII GeoCSV Table Format</title>
+        <information_model_version>1.11.0.0</information_model_version>
+        <product_class>Product_Collection</product_class>
+        <Citation_Information>
+            <author_list>Weber, R.</author_list>
+            <publication_year>2020</publication_year>
+            <description>
+                The SEIS data_table collection contains observations of the SEIS instrument
+                in ASCII GeoCSV table format, with metadata in ASCII StationXML format.
+            </description>
+        </Citation_Information>
+        <Modification_History>
+            <Modification_Detail>
+                <modification_date>2019-05-24</modification_date>
+                <version_id>1.0</version_id>
+                <description>Release 1a</description>
+            </Modification_Detail>
+            <Modification_Detail>
+                <modification_date>2019-06-26</modification_date>
+                <version_id>2.0</version_id>
+                <description>Release 1b</description>
+            </Modification_Detail>
+            <Modification_Detail>
+                <modification_date>2019-09-18</modification_date>
+                <version_id>3.0</version_id>
+                <description>Release 2</description>
+            </Modification_Detail>
+            <Modification_Detail>
+                <modification_date>2019-12-08</modification_date>
+                <version_id>4.0</version_id>
+                <description>Release 3</description>
+            </Modification_Detail>
+            <Modification_Detail>
+                <modification_date>2020-03-15</modification_date>
+                <version_id>5.0</version_id>
+                <description>Release 4</description>
+            </Modification_Detail>
+            <Modification_Detail>
+                <modification_date>2020-06-10</modification_date>
+                <version_id>6.0</version_id>
+                <description>Release 5</description>
+            </Modification_Detail>
+            <Modification_Detail>
+                <modification_date>2020-09-09</modification_date>
+                <version_id>7.0</version_id>
+                <description>Release 6</description>
+            </Modification_Detail>
+            <Modification_Detail>
+                <modification_date>2020-12-10</modification_date>
+                <version_id>8.0</version_id>
+                <description>Release 7</description>
+            </Modification_Detail>
+            <Modification_Detail>
+                <modification_date>2021-03-18</modification_date>
+                <version_id>9.0</version_id>
+                <description>Release 8</description>
+            </Modification_Detail>
+            <Modification_Detail>
+                <modification_date>2021-06-09</modification_date>
+                <version_id>10.0</version_id>
+                <description>Release 9</description>
+            </Modification_Detail>
+        </Modification_History>
+    </Identification_Area>
+    <Context_Area>
+        <Time_Coordinates>
+            <start_date_time>2018-04-01Z</start_date_time>
+            <stop_date_time>2021-03-31Z</stop_date_time>
+        </Time_Coordinates>
+        <Primary_Result_Summary>
+            <purpose>Science</purpose>
+            <processing_level>Raw</processing_level>
+            <processing_level>Calibrated</processing_level>
+        </Primary_Result_Summary>
+        <Investigation_Area>
+            <name>Insight</name>
+            <type>Mission</type>
+            <Internal_Reference>
+                <lid_reference>urn:nasa:pds:context:investigation:mission.insight</lid_reference>
+                <reference_type>collection_to_investigation</reference_type>
+            </Internal_Reference>
+        </Investigation_Area>
+        <Observing_System>
+            <name>Insight</name>
+            <Observing_System_Component>
+                <name>Insight</name>
+                <type>Spacecraft</type>
+                <Internal_Reference>
+                    <lid_reference>urn:nasa:pds:context:instrument_host:spacecraft.insight</lid_reference>
+                    <reference_type>is_instrument_host</reference_type>
+                </Internal_Reference>
+            </Observing_System_Component>
+            <Observing_System_Component>
+                <name>Seismometer</name>
+                <type>Instrument</type>
+                <Internal_Reference>
+                    <lid_reference>urn:nasa:pds:context:instrument:seis.insight</lid_reference>
+                    <reference_type>is_instrument</reference_type>
+                </Internal_Reference>
+            </Observing_System_Component>
+        </Observing_System>
+        <Target_Identification>
+            <name>Mars</name>
+            <type>Planet</type>
+            <Internal_Reference>
+                <lid_reference>urn:nasa:pds:context:target:planet.mars</lid_reference>
+                <reference_type>collection_to_target</reference_type>
+            </Internal_Reference>
+        </Target_Identification>
+    </Context_Area>
+    <Reference_List>
+        <Internal_Reference>
+            <lid_reference>urn:nasa:pds:insight_documents:document_seis:seis_release_notes</lid_reference>
+            <reference_type>collection_to_document</reference_type>
+            <comment>The seis_release_notes document in the SEIS document collection
+            has notes and errata concerning each public release of SEIS data by PDS.</comment>
+        </Internal_Reference>
+        <External_Reference>
+            <doi>10.1007/s11214-018-0574-6</doi>
+            <reference_text>
+                Lognonne, P., Banerdt, W. B., Giardini, D., et al. (2019), SEIS: InSight's 
+                Seismic Experiment for Internal Structure of Mars, Space Sci. Rev. 215:12.
+            </reference_text>
+        </External_Reference>
+    </Reference_List>
+    <Collection>
+        <collection_type>Data</collection_type>
+    </Collection>
+    <File_Area_Inventory>
+        <File>
+            <file_name>collection_data_table_inventory.csv</file_name>
+            <creation_date_time>2020-03-06</creation_date_time>
+        </File>
+        <Inventory>
+            <offset unit="byte">0</offset>
+            <parsing_standard_id>PDS DSV 1</parsing_standard_id>
+            <records>5</records>
+            <record_delimiter>Carriage-Return Line-Feed</record_delimiter>
+            <field_delimiter>Comma</field_delimiter>
+            <Record_Delimited>
+                <fields>2</fields>
+                <groups>0</groups>
+                <Field_Delimited>
+                    <name>Member Status</name>
+                    <field_number>1</field_number>
+                    <data_type>ASCII_String</data_type>
+                    <maximum_field_length unit="byte">1</maximum_field_length>
+                </Field_Delimited>
+                <Field_Delimited>
+                    <name>LIDVID_LID</name>
+                    <field_number>2</field_number>
+                    <data_type>ASCII_LIDVID_LID</data_type>
+                    <maximum_field_length unit="byte">255</maximum_field_length>
+                </Field_Delimited>
+            </Record_Delimited>
+            <reference_type>inventory_has_member_product</reference_type>
+        </Inventory>
+    </File_Area_Inventory>
+</Product_Collection>

--- a/src/test/resources/github408/valid/data/collection_data_table_2.xml
+++ b/src/test/resources/github408/valid/data/collection_data_table_2.xml
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1B00.sch" 
+    schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<Product_Collection xmlns="http://pds.nasa.gov/pds4/pds/v1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1 https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1B00.xsd">
+    <Identification_Area>
+        <logical_identifier>urn:nasa:pds:insight_seis:data_table</logical_identifier>
+        <version_id>9.0</version_id>
+        <title>InSight SEIS Data Collection in ASCII GeoCSV Table Format</title>
+        <information_model_version>1.11.0.0</information_model_version>
+        <product_class>Product_Collection</product_class>
+        <Citation_Information>
+            <author_list>Weber, R.</author_list>
+            <publication_year>2020</publication_year>
+            <description>
+                The SEIS data_table collection contains observations of the SEIS instrument
+                in ASCII GeoCSV table format, with metadata in ASCII StationXML format.
+            </description>
+        </Citation_Information>
+        <Modification_History>
+            <Modification_Detail>
+                <modification_date>2019-05-24</modification_date>
+                <version_id>1.0</version_id>
+                <description>Release 1a</description>
+            </Modification_Detail>
+            <Modification_Detail>
+                <modification_date>2019-06-26</modification_date>
+                <version_id>2.0</version_id>
+                <description>Release 1b</description>
+            </Modification_Detail>
+            <Modification_Detail>
+                <modification_date>2019-09-18</modification_date>
+                <version_id>3.0</version_id>
+                <description>Release 2</description>
+            </Modification_Detail>
+            <Modification_Detail>
+                <modification_date>2019-12-08</modification_date>
+                <version_id>4.0</version_id>
+                <description>Release 3</description>
+            </Modification_Detail>
+            <Modification_Detail>
+                <modification_date>2020-03-15</modification_date>
+                <version_id>5.0</version_id>
+                <description>Release 4</description>
+            </Modification_Detail>
+            <Modification_Detail>
+                <modification_date>2020-06-10</modification_date>
+                <version_id>6.0</version_id>
+                <description>Release 5</description>
+            </Modification_Detail>
+            <Modification_Detail>
+                <modification_date>2020-09-09</modification_date>
+                <version_id>7.0</version_id>
+                <description>Release 6</description>
+            </Modification_Detail>
+            <Modification_Detail>
+                <modification_date>2020-12-10</modification_date>
+                <version_id>8.0</version_id>
+                <description>Release 7</description>
+            </Modification_Detail>
+            <Modification_Detail>
+                <modification_date>2021-03-18</modification_date>
+                <version_id>9.0</version_id>
+                <description>Release 8</description>
+            </Modification_Detail>
+            <Modification_Detail>
+                <modification_date>2021-06-09</modification_date>
+                <version_id>10.0</version_id>
+                <description>Release 9</description>
+            </Modification_Detail>
+        </Modification_History>
+    </Identification_Area>
+    <Context_Area>
+        <Time_Coordinates>
+            <start_date_time>2018-04-01Z</start_date_time>
+            <stop_date_time>2021-03-31Z</stop_date_time>
+        </Time_Coordinates>
+        <Primary_Result_Summary>
+            <purpose>Science</purpose>
+            <processing_level>Raw</processing_level>
+            <processing_level>Calibrated</processing_level>
+        </Primary_Result_Summary>
+        <Investigation_Area>
+            <name>Insight</name>
+            <type>Mission</type>
+            <Internal_Reference>
+                <lid_reference>urn:nasa:pds:context:investigation:mission.insight</lid_reference>
+                <reference_type>collection_to_investigation</reference_type>
+            </Internal_Reference>
+        </Investigation_Area>
+        <Observing_System>
+            <name>Insight</name>
+            <Observing_System_Component>
+                <name>Insight</name>
+                <type>Spacecraft</type>
+                <Internal_Reference>
+                    <lid_reference>urn:nasa:pds:context:instrument_host:spacecraft.insight</lid_reference>
+                    <reference_type>is_instrument_host</reference_type>
+                </Internal_Reference>
+            </Observing_System_Component>
+            <Observing_System_Component>
+                <name>Seismometer</name>
+                <type>Instrument</type>
+                <Internal_Reference>
+                    <lid_reference>urn:nasa:pds:context:instrument:seis.insight</lid_reference>
+                    <reference_type>is_instrument</reference_type>
+                </Internal_Reference>
+            </Observing_System_Component>
+        </Observing_System>
+        <Target_Identification>
+            <name>Mars</name>
+            <type>Planet</type>
+            <Internal_Reference>
+                <lid_reference>urn:nasa:pds:context:target:planet.mars</lid_reference>
+                <reference_type>collection_to_target</reference_type>
+            </Internal_Reference>
+        </Target_Identification>
+    </Context_Area>
+    <Reference_List>
+        <Internal_Reference>
+            <lid_reference>urn:nasa:pds:insight_documents:document_seis:seis_release_notes</lid_reference>
+            <reference_type>collection_to_document</reference_type>
+            <comment>The seis_release_notes document in the SEIS document collection
+            has notes and errata concerning each public release of SEIS data by PDS.</comment>
+        </Internal_Reference>
+        <External_Reference>
+            <doi>10.1007/s11214-018-0574-6</doi>
+            <reference_text>
+                Lognonne, P., Banerdt, W. B., Giardini, D., et al. (2019), SEIS: InSight's 
+                Seismic Experiment for Internal Structure of Mars, Space Sci. Rev. 215:12.
+            </reference_text>
+        </External_Reference>
+    </Reference_List>
+    <Collection>
+        <collection_type>Data</collection_type>
+    </Collection>
+    <File_Area_Inventory>
+        <File>
+            <file_name>collection_data_table_inventory.csv</file_name>
+            <creation_date_time>2020-03-06</creation_date_time>
+        </File>
+        <Inventory>
+            <offset unit="byte">0</offset>
+            <parsing_standard_id>PDS DSV 1</parsing_standard_id>
+            <records>5</records>
+            <record_delimiter>Carriage-Return Line-Feed</record_delimiter>
+            <field_delimiter>Comma</field_delimiter>
+            <Record_Delimited>
+                <fields>2</fields>
+                <groups>0</groups>
+                <Field_Delimited>
+                    <name>Member Status</name>
+                    <field_number>1</field_number>
+                    <data_type>ASCII_String</data_type>
+                    <maximum_field_length unit="byte">1</maximum_field_length>
+                </Field_Delimited>
+                <Field_Delimited>
+                    <name>LIDVID_LID</name>
+                    <field_number>2</field_number>
+                    <data_type>ASCII_LIDVID_LID</data_type>
+                    <maximum_field_length unit="byte">255</maximum_field_length>
+                </Field_Delimited>
+            </Record_Delimited>
+            <reference_type>inventory_has_member_product</reference_type>
+        </Inventory>
+    </File_Area_Inventory>
+</Product_Collection>

--- a/src/test/resources/github408/valid/data/collection_data_table_inventory.csv
+++ b/src/test/resources/github408/valid/data/collection_data_table_inventory.csv
@@ -1,0 +1,5 @@
+P,urn:nasa:pds:insight_seis:data_table:stationxml.xb.elyh0.2019.032::1.1
+P,urn:nasa:pds:insight_seis:data_table:stationxml.xb.elyh0.2019.171::1.1
+P,urn:nasa:pds:insight_seis:data_table:stationxml.xb.elyhk.2019.077::1.1
+P,urn:nasa:pds:insight_seis:data_table:stationxml.xb.elyhk.2019.170::1.1
+P,urn:nasa:pds:insight_seis:data_table:stationxml.xb.elyhk.2019.245::1.1


### PR DESCRIPTION
1. Add test resources : src/test/resources/github408
2. Correct logic of getLatestVersion() function to handle multiple collections : src/main/java/gov/nasa/pds/tools/util/LidVid.java
3. Add debug printing : src/main/java/gov/nasa/pds/tools/util/ReferentialIntegrityUtil.java
4. Correct logic to find latest collection files, remove multiple reporting of skip file and check for null-ness and size of otherCollectionIdList variable to avoid null pointer exception : src/main/java/gov/nasa/pds/tools/validate/BundleManager.java
5. Add stack trace printing to help debugging when exception occurs : src/main/java/gov/nasa/pds/validate/ValidateLauncher.java
6. Add new test : src/test/resources/features/validate.feature

Refs:

https://github.com/nasa-pds/validate/issues/408 Validate 2.1.0-SNAPSHOT skips a collection XML label

Closes https://github.com/nasa-pds/validate/issues/408 Validate 2.1.0-SNAPSHOT skips a collection XML label

User had reported that a collection was skipped in error.  As it turns out, multiple collections may have different versions for the same
collection.  Also, there was a bug with the logic of sorting of the versions.  When sorting based on character, "9.0" is larger than "10.0", which is not correct.
The fix was to sort the version using number order by creating a separate float array of the versions.
Code is fixed now and should only skip collection files that are of older versions.  The latest collection
is defined as the collection with the largest version_id value.
User also reported an extra validation of a collection that was supposively skipped.  It should not happen now.

Tested in DEV:

Case 1:
Running validate against a valid bundle with multiple collections with two collections with multiple versions.
The size of the test files (.csv) have been reduced to just a few records to reduce the size of the repository.
Also note that the content of the bundle in github408 resource is not the same as the URL reported in the ticket.  The
bundle contains just a few collections with smaller data files to allow the testing of multiple collections.

```
validate -R pds4.bundle --skip-content-validation -r report_github408_bundle_valid.json  -s json -t src/test/resources/github408/valid/bundle_insight_seis.xml
```

There should be 2 SKIP messages for 2 labels because the "extra" collection files have lower version number than the original collection:

```
{pds-dev3.jpl.nasa.gov}/home/qchau/sandbox/validate 138 % grep -A 4 SKIP report_github408_bundle_valid.json
      "status": "SKIP",
      "label": "file:/home/qchau/sandbox/validate/src/test/resources/github408/valid/data/collection_data_seed_2.xml",
      "messages": [
        {
          "severity": "INFO",
--
      "status": "SKIP",
      "label": "file:/home/qchau/sandbox/validate/src/test/resources/github408/valid/data/collection_data_table_2.xml",
      "messages": [
        {
          "severity": "INFO",
```


The collection files that ends with "_2.xml" contains a smaller version than the ones without, which should now be skipped by validate.

```
{pds-dev3.jpl.nasa.gov}/home/qchau/sandbox/validate 111 % egrep -A 1 "logical_ide" src/test/resources/github408/valid/data/*collection*.xml
src/test/resources/github408/valid/data/collection_data_lander.xml:        <logical_identifier>urn:nasa:pds:insight_seis:data_laf</logical_identifier>
src/test/resources/github408/valid/data/collection_data_lander.xml-        <version_id>4.0</version_id>
--
src/test/resources/github408/valid/data/collection_data_seed_2.xml:        <logical_identifier>urn:nasa:pds:insight_seis:data_seed</logical_identifier>
src/test/resources/github408/valid/data/collection_data_seed_2.xml-        <version_id>9.0</version_id>
--
src/test/resources/github408/valid/data/collection_data_seed.xml:        <logical_identifier>urn:nasa:pds:insight_seis:data_seed</logical_identifier>
src/test/resources/github408/valid/data/collection_data_seed.xml-        <version_id>10.0</version_id>
--
src/test/resources/github408/valid/data/collection_data_table_2.xml:        <logical_identifier>urn:nasa:pds:insight_seis:data_table</logical_identifier>
src/test/resources/github408/valid/data/collection_data_table_2.xml-        <version_id>9.0</version_id>
--
src/test/resources/github408/valid/data/collection_data_table.xml:        <logical_identifier>urn:nasa:pds:insight_seis:data_table</logical_identifier>
src/test/resources/github408/valid/data/collection_data_table.xml-        <version_id>10.0</version_id>
```
                                                                                                                                                           