### PR TITLE
Check if provided directory is absolute and only check MIME type if i…

### DIFF
--- a/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/FileReferenceValidationRule.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/FileReferenceValidationRule.java
@@ -329,10 +329,13 @@ public class FileReferenceValidationRule extends AbstractValidationRule {
               } else if ("directory_path_name".equals(child.getLocalPart())) {
                 directory = child.getStringValue();
                 LOG.debug("FileReferenceValidationRule:validate:directory {}",directory);
+                LOG.debug("FileReferenceValidationRule:validate:getName [{}]",FilenameUtils.getName(directory));
+                LOG.debug("FileReferenceValidationRule:validate:getFullPath [{}]",FilenameUtils.getFullPath(directory));
 
                 // Check to make sure the directory name is NOT absolute.
                 // https://github.com/NASA-PDS/validate/issues/349 validate allows absolute path in directory_path_name but shouldn't 
-                Path p = Paths.get(directory); 
+
+                Path p = Paths.get(FilenameUtils.getFullPath(directory));  // Use getFullPath() function to get the actual name to avoid sonatype-lift complains.
                 if (p.isAbsolute()) {
                     LOG.error("The directory name {} for tag 'directory_path_name' cannot be absolute",directory);
                     ProblemDefinition def = new ProblemDefinition(

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/FileReferenceValidationRule.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/FileReferenceValidationRule.java
@@ -18,6 +18,8 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -327,6 +329,19 @@ public class FileReferenceValidationRule extends AbstractValidationRule {
               } else if ("directory_path_name".equals(child.getLocalPart())) {
                 directory = child.getStringValue();
                 LOG.debug("FileReferenceValidationRule:validate:directory {}",directory);
+
+                // Check to make sure the directory name is NOT absolute.
+                // https://github.com/NASA-PDS/validate/issues/349 validate allows absolute path in directory_path_name but shouldn't 
+                Path p = Paths.get(directory); 
+                if (p.isAbsolute()) {
+                    LOG.error("The directory name {} for tag 'directory_path_name' cannot be absolute",directory);
+                    ProblemDefinition def = new ProblemDefinition(
+                        ExceptionType.ERROR, ProblemType.UNALLOWED_DIRECTORY_NAME, 
+                        "The directory name " + directory + " for tag 'directory_path_name' cannot be absolute.");
+                    problems.add(new ValidationProblem(def, target, 
+                        fileObject.getLineNumber(), -1));
+                    passFlag = false;
+                }
               } else if ("file_size".equals(child.getLocalPart())) { // Fetch the file_size value from label.
                 filesize = child.getStringValue();
                 LOG.debug("FileReferenceValidationRule:validate:filesize {}",filesize);
@@ -343,7 +358,7 @@ public class FileReferenceValidationRule extends AbstractValidationRule {
             } else {
               URL urlRef = null;
               if (!directory.isEmpty()) {
-                urlRef = new URL(parent, directory + "/" + name);
+                urlRef = new URL(parent, directory + File.separator + name);  // Switch from '/' to a system-independent file separator.
               } else {
                 urlRef = new URL(parent, name);
               }
@@ -878,8 +893,15 @@ public class FileReferenceValidationRule extends AbstractValidationRule {
             this.documentsChecker = new DocumentsChecker();
         }
 
-        mimeTypeIsCorrectFlag = this.documentsChecker.isMimeTypeCorrect(textName,documentStandardId);
-        LOG.debug("handleGenericDocument:textName,documentStandardId,mimeTypeIsCorrectFlag {},{},{}",textName,documentStandardId,mimeTypeIsCorrectFlag);
+
+        // https://github.com/NASA-PDS/validate/issues/419 validate 2.2.0-SNAPSHOT warns about a pretty benign bundle + readme.txt
+        // Due to the mime type may not be specified in the label, only perform the check if documentStandardId is not null.
+        if (documentStandardId != null) {
+            mimeTypeIsCorrectFlag = this.documentsChecker.isMimeTypeCorrect(textName,documentStandardId);
+            LOG.debug("handleGenericDocument:textName,documentStandardId,mimeTypeIsCorrectFlag {},{},{}",textName,documentStandardId,mimeTypeIsCorrectFlag);
+        } else {
+            mimeTypeIsCorrectFlag = true; // Set to true even though the label does not have the documentStandardId set to anything.
+        }
 
         // Report a  warning if the mime type is not correct
         if (!mimeTypeIsCorrectFlag) {

--- a/src/test/resources/features/validate.feature
+++ b/src/test/resources/features/validate.feature
@@ -287,6 +287,16 @@ Scenario Outline: Execute validate command for tests below.
  |"NASA-PDS/validate#416 VALID_2" | "github416" | 0 | "0 error messages expected" | "totalErrors" | "src/test/resources" | "target/test" | "-R pds4.label -r {reportDir}/report_github416_label_valid_2.json -s json -t {resourceDir}/github416/phe_misc_temperature_reference_20190524.xml" | "report_github416_label_valid_2.json" |
  |"NASA-PDS/validate#416 INVALID_2" | "github416" | 1 | "1 ((FIELDS_MISMATCH) error messages expected" | "FIELDS_MISMATCH" | "src/test/resources" | "target/test" | "-R pds4.label -r {reportDir}/report_github416_label_invalid_2.json -s json -t {resourceDir}/github416/phe_misc_temperature_reference_20190524_invalid.xml" | "report_github416_label_invalid_2.json" |
 
+# https://github.com/NASA-PDS/validate/issues/349 validate allows absolute path in directory_path_name but shouldn't
+
+ |"NASA-PDS/validate#349 VALID" | "github349" | 0 | "0 error messages expected" | "totalErrors" | "src/test/resources" | "target/test" | "-R pds4.label -r {reportDir}/report_github349_label_valid.json -s json -t {resourceDir}/github349/valid/datasetgood.xml" | "report_github349_label_valid.json" |
+ |"NASA-PDS/validate#349 INVALID" | "github349" | 2 | "2 error messages expected" | "totalErrors" | "src/test/resources" | "target/test" | "-R pds4.label -r {reportDir}/report_github349_label_invalid.json -s json -t {resourceDir}/github349/invalid/datasetbad.xml" | "report_github349_label_invalid.json" |
+
+# https://github.com/NASA-PDS/validate/issues/419 validate 2.2.0-SNAPSHOT warns about a pretty benign bundle + readme.txt 
+
+
+ |"NASA-PDS/validate#419 VALID" | "github419" | 0 | "0 warning messages expected" | "totalWarnings" | "src/test/resources" | "target/test" | "-R pds4.label -r {reportDir}/report_github419_label_valid.json -s json -t {resourceDir}/github419/bundle_astromat_chem.xml" | "report_github419_label_valid.json" |
+
 # BIG_NOTE: Add new tests that doesn't involve a catalog above this line.
 # https://github.com/NASA-PDS/validate/issues/297 Content validation of ASCII_Integer field does not accept value with leading zeroes
  |"NASA-PDS/validate#297 VALID" | "github297" | 0 | "0 errors message expected" | "totalErrors" | "src/test/resources" | "target/test" | "--skip-context-validation -R pds4.label -r {reportDir}/report_github297_label_valid.json  -s json -t {resourceDir}/github297/valid/rimfax_rdr_0081_example.xml" | "report_github297_label_valid.json" |

--- a/src/test/resources/github349/01/dataset.txt
+++ b/src/test/resources/github349/01/dataset.txt
@@ -1,0 +1,66 @@
+PDS3_DATA_SET_ID               = VG1-S-CRS-4-SUMM-D1/D2-192SEC-V1.0           
+DATA_SET_NAME                  = VG1 SAT CRS RESAMPLED SUMMARY D1 RATE        
+                                      ELEC 192SEC V1.0                        
+START_TIME                     = 1980-11-11T16:01:36.000                      
+STOP_TIME                      = 1980-11-14T22:01:36.000                      
+ORIGINAL_DATA_SET_RELEASE_DATE = 1996-07-01                                   
+PRODUCER_FULL_NAME             = RICHARD S. SELESNICK                         
+                                                                              
+REFERENCE:                                                                    
+                                                                              
+Stone, E.C., R.E. Vogt, F.B. McDonald, B.J. Teegarden, J.H. Trainor,          
+J.R. Jokipii, and W.R. Webber, Cosmic ray investigation for the Voyager       
+missions; energetic particle studies in the outer heliosphere--and beyond,    
+Space Sci. Rev., 12, No. 3, 355-376, Dec. 1977.                               
+                                                                              
+                                                                              
+    DATA_SET_DESCRIPTION                                                      
+                                                                              
+    Data Set Overview                                                         
+   ====================                                                       
+This data set describes the counting rate data from detectors D1 and D2       
+in the Cosmic Ray System (CRS) electron telescope (TET) on Voyager 1 during   
+the Saturn encounter. The D1 detector nominally responds to electrons with    
+kinetic energies above approximately 1 MeV, and the D2 detector, above        
+approximately 2.5 MeV (see detector description for details).                 
+                                                                              
+Note that the instrument is saturated near the maximum of counting            
+rate of approximately 50,000 counts/sec. When data are near saturation,       
+the counting rates should be corrected for deadtime according to the formula  
+in the DATA_SET_OR_INST_PARM_DESC:                                            
+{corrected rate} = {uncorrected rate/(1+deadtime*{uncorrected rate}).         
+                                                                              
+    Parameters                                                                
+    ===============                                                           
+                                                                              
+    SAMPLING_PARAMETER_RESOLUTION  = 192.0                                    
+    MINIMUM_SAMPLING_PARAMETER     = N/A                                      
+    MAXIMUM_SAMPLING_PARAMETER     = N/A                                      
+    SAMPLING_PARAMETER_INTERVAL    = 192.0                                    
+    MINIMUM_AVAILABLE_SAMPLING_INT = 192.0                                    
+    SAMPLING_PARAMETER_UNIT        = SECOND                                   
+    DATA_SET_PARAMETER_NAME        = D1/D2 RATE                               
+    NOISE_LEVEL                    = 0.000                                    
+    DATA_SET_PARAMETER_UNIT        = COUNTS/SECOND                            
+                                                                              
+                                                                              
+    CONFIDENCE_LEVEL_NOTE =                                                   
+    Confidence Level                                                          
+    =================                                                         
+Each data point represents a six-second accumulation, so that the             
+statistical uncertainty is obtained according to Poisson statistics by        
+taking the square root of one sixth of the counting rate.  However,           
+larger uncertainties are associated with the conversion from counting         
+rate to flux (see the DATA_SET_OR_INST_PARM_DESC).                            
+                                                                              
+    Data Coverage                                                             
+    =============                                                             
+    Filename Records Start                     Stop                           
+    ----------------------------------------------------------------------    
+    Volume ID: VG_1601                                                        
+    D1D2.TAB  1310  1980-11-11T16:01:36.000Z  1980-11-14T22:01:36.000Z        
+                                                                              
+    Missing Data Flag                                                         
+    ==================                                                        
+    Any data column whose value is -9.999e+10 is a missing data value.        
+                                                                              

--- a/src/test/resources/github349/invalid/datasetbad.xml
+++ b/src/test/resources/github349/invalid/datasetbad.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1D00.sch" 
+    schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<Product_Document xmlns="http://pds.nasa.gov/pds4/pds/v1"
+    xmlns:pds="http://pds.nasa.gov/pds4/pds/v1"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1 https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1D00.xsd">
+    <Identification_Area>
+        <logical_identifier>urn:nasa:pds:vg1-sat-crs-d1-d2-192sec:document:dataset</logical_identifier>
+        <version_id>1.0</version_id>
+        <title>Voyager 1 Saturn CRS Averaged D1/D2 192 Second Counting Rate Dataset Description</title>
+        <information_model_version>1.13.0.0</information_model_version>
+        <product_class>Product_Document</product_class>
+                <Citation_Information>
+            <author_list>Selesnick, R. S.</author_list>
+            <publication_year>2021</publication_year>
+                    <description>Document containing a description of the  Voyager 1 Saturn CRS Averaged D1/D2 192 Second Counting Rate Dataset</description>
+        </Citation_Information>
+        <Modification_History>
+            <Modification_Detail>
+                <modification_date>2021-04-02</modification_date>
+                <version_id>1.0</version_id>
+                <description>Original VG1_SAT_CRS_D1D2_DS.CAT from the PDS3 VG1-S-CRS-4-SUMM-D1/D2-192SEC-V1.0 dataset, originally released 1996-07-01, converted 
+                    to PDS4. This is the first version of this product converted to PDS4.</description>
+            </Modification_Detail>
+        </Modification_History>
+    </Identification_Area>
+    <Context_Area>
+        <Investigation_Area>
+            <name>Voyager</name>
+            <type>Mission</type>
+            <Internal_Reference>
+                <lid_reference>urn:nasa:pds:context:investigation:mission.voyager</lid_reference>
+                <reference_type>document_to_investigation</reference_type>
+            </Internal_Reference>
+        </Investigation_Area>
+        <Observing_System>
+            <Observing_System_Component>
+                <name>Voyager 1</name>
+                <type>Spacecraft</type>
+                <Internal_Reference>
+                    <lid_reference>urn:nasa:pds:context:instrument_host:spacecraft.vg1</lid_reference>
+                    <reference_type>is_instrument_host</reference_type>
+                </Internal_Reference>
+            </Observing_System_Component>
+            <Observing_System_Component>
+                <name>Cosmic Ray Subsystem</name>
+                <type>Instrument</type>
+                <Internal_Reference>
+                    <lid_reference>urn:nasa:pds:context:instrument:crs.vg1</lid_reference>
+                    <reference_type>is_instrument</reference_type>
+                </Internal_Reference>
+            </Observing_System_Component>
+        </Observing_System>
+        <Target_Identification>
+            <name>Saturn</name>
+            <type>Planet</type>
+            <Internal_Reference>
+                <lid_reference>urn:nasa:pds:context:target:planet.saturn</lid_reference>
+                <reference_type>document_to_target</reference_type>
+            </Internal_Reference>
+        </Target_Identification> 
+        <Target_Identification>
+            <name>Titan</name>
+            <type>Satellite</type> 
+            <Internal_Reference>
+                <lid_reference>urn:nasa:pds:context:target:satellite.saturn.titan</lid_reference>
+                <reference_type>document_to_target</reference_type>
+            </Internal_Reference>
+        </Target_Identification>  
+    </Context_Area>
+    <Document>
+        <document_name>Voyager 1 Saturn CRS Averaged D1/D2 192 Second Counting Rate Dataset Description</document_name>
+        <publication_date>1996-07-01</publication_date>
+        <document_editions>1</document_editions>
+        <Document_Edition>
+            <edition_name>Test edition of Voyager 1 Saturn CRS Averaged D1/D2 192 Second Counting Rate Dataset Description </edition_name>
+            <language>English</language>
+            <files>1</files>
+            <Document_File>
+                <file_name>dataset.txt</file_name>
+                <creation_date_time>2021-04-02</creation_date_time>
+                <file_size unit="byte">5280</file_size>
+                <md5_checksum>e1e2b614f654fd8c0c9e725030abbe38</md5_checksum>
+                <directory_path_name>/tmp/01/</directory_path_name>
+                <document_standard_id>7-Bit ASCII Text</document_standard_id>
+            </Document_File>
+        </Document_Edition>
+    </Document>
+</Product_Document>

--- a/src/test/resources/github349/valid/datasetgood.xml
+++ b/src/test/resources/github349/valid/datasetgood.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1D00.sch" 
+    schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<Product_Document xmlns="http://pds.nasa.gov/pds4/pds/v1"
+    xmlns:pds="http://pds.nasa.gov/pds4/pds/v1"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1 https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1D00.xsd">
+    <Identification_Area>
+        <logical_identifier>urn:nasa:pds:vg1-sat-crs-d1-d2-192sec:document:dataset</logical_identifier>
+        <version_id>1.0</version_id>
+        <title>Voyager 1 Saturn CRS Averaged D1/D2 192 Second Counting Rate Dataset Description</title>
+        <information_model_version>1.13.0.0</information_model_version>
+        <product_class>Product_Document</product_class>
+                <Citation_Information>
+            <author_list>Selesnick, R. S.</author_list>
+            <publication_year>2021</publication_year>
+                    <description>Document containing a description of the  Voyager 1 Saturn CRS Averaged D1/D2 192 Second Counting Rate Dataset</description>
+        </Citation_Information>
+        <Modification_History>
+            <Modification_Detail>
+                <modification_date>2021-04-02</modification_date>
+                <version_id>1.0</version_id>
+                <description>Original VG1_SAT_CRS_D1D2_DS.CAT from the PDS3 VG1-S-CRS-4-SUMM-D1/D2-192SEC-V1.0 dataset, originally released 1996-07-01, converted 
+                    to PDS4. This is the first version of this product converted to PDS4.</description>
+            </Modification_Detail>
+        </Modification_History>
+    </Identification_Area>
+    <Context_Area>
+        <Investigation_Area>
+            <name>Voyager</name>
+            <type>Mission</type>
+            <Internal_Reference>
+                <lid_reference>urn:nasa:pds:context:investigation:mission.voyager</lid_reference>
+                <reference_type>document_to_investigation</reference_type>
+            </Internal_Reference>
+        </Investigation_Area>
+        <Observing_System>
+            <Observing_System_Component>
+                <name>Voyager 1</name>
+                <type>Spacecraft</type>
+                <Internal_Reference>
+                    <lid_reference>urn:nasa:pds:context:instrument_host:spacecraft.vg1</lid_reference>
+                    <reference_type>is_instrument_host</reference_type>
+                </Internal_Reference>
+            </Observing_System_Component>
+            <Observing_System_Component>
+                <name>Cosmic Ray Subsystem</name>
+                <type>Instrument</type>
+                <Internal_Reference>
+                    <lid_reference>urn:nasa:pds:context:instrument:crs.vg1</lid_reference>
+                    <reference_type>is_instrument</reference_type>
+                </Internal_Reference>
+            </Observing_System_Component>
+        </Observing_System>
+        <Target_Identification>
+            <name>Saturn</name>
+            <type>Planet</type>
+            <Internal_Reference>
+                <lid_reference>urn:nasa:pds:context:target:planet.saturn</lid_reference>
+                <reference_type>document_to_target</reference_type>
+            </Internal_Reference>
+        </Target_Identification> 
+        <Target_Identification>
+            <name>Titan</name>
+            <type>Satellite</type> 
+            <Internal_Reference>
+                <lid_reference>urn:nasa:pds:context:target:satellite.saturn.titan</lid_reference>
+                <reference_type>document_to_target</reference_type>
+            </Internal_Reference>
+        </Target_Identification>  
+    </Context_Area>
+    <Document>
+        <document_name>Voyager 1 Saturn CRS Averaged D1/D2 192 Second Counting Rate Dataset Description</document_name>
+        <publication_date>1996-07-01</publication_date>
+        <document_editions>1</document_editions>
+        <Document_Edition>
+            <edition_name>Test edition of Voyager 1 Saturn CRS Averaged D1/D2 192 Second Counting Rate Dataset Description </edition_name>
+            <language>English</language>
+            <files>1</files>
+            <Document_File>
+                <file_name>dataset.txt</file_name>
+                <creation_date_time>2021-04-02</creation_date_time>
+                <file_size unit="byte">5280</file_size>
+                <md5_checksum>e1e2b614f654fd8c0c9e725030abbe38</md5_checksum>
+                <directory_path_name>../01/</directory_path_name>
+                <document_standard_id>7-Bit ASCII Text</document_standard_id>
+            </Document_File>
+        </Document_Edition>
+    </Document>
+</Product_Document>

--- a/src/test/resources/github349/valid/hvt41.cfg
+++ b/src/test/resources/github349/valid/hvt41.cfg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<harvest nodeName="PDS_RMS">
+
+  <directories>
+    <path>/tmp/00</path>
+  </directories>
+
+  <!-- 
+      NOTE: By default only lid, vid, lidvid, title and product class are exported. 
+      If you want more metadata to be exported, provide additional configuration
+      elements, such as xpathMaps, internalRefs, autogenFields, fileInfo, fileRef.
+  -->
+  <fileInfo />
+
+  <!-- Extract all fields. Field names always go 2 deep: <namespace>.<class_name>.<namespace>.<attribute_name> -->
+  <autogenFields/>
+
+  <!--internalRefs obsolete in 11.1; internal references always included -->
+
+</harvest>

--- a/src/test/resources/github419/bundle_astromat_chem.xml
+++ b/src/test/resources/github419/bundle_astromat_chem.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1E00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+
+<Product_Bundle xmlns="http://pds.nasa.gov/pds4/pds/v1"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1 https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1E00.xsd">
+
+    <Identification_Area>
+        <logical_identifier>urn:nasa:pds:astromat</logical_identifier>
+        <version_id>1.0</version_id>
+        <title>Astro Material Database Archive, chemical analytic data from extraterrestrial materials</title>
+        <information_model_version>1.14.0.0</information_model_version>
+        <product_class>Product_Bundle</product_class>
+        <Citation_Information>
+            <author_list>Lehnert, Kerstin; Ji, Peng</author_list>
+            <publication_year>2021</publication_year>
+            <doi>10.17189/1523010</doi>
+            <keyword>chemistry</keyword>
+            <description>This is an archive of laboratory data acquired on astromaterials samples; Archive assembled by S.M. Richard and Peng Ji</description>
+        </Citation_Information>
+        <Modification_History>
+            <Modification_Detail>
+                <modification_date>2021-06-28</modification_date>
+                <version_id>1.0</version_id>
+                <description>Assembled ... </description>
+            </Modification_Detail>
+        </Modification_History>
+    </Identification_Area>
+    <Context_Area>
+        <Time_Coordinates>
+            <start_date_time>2004-08-13Z</start_date_time>
+            <stop_date_time>2020-10-13Z</stop_date_time>
+        </Time_Coordinates>
+        <Investigation_Area>
+            <name>Extraterrestrial materials chemistry</name>
+            <type>Other Investigation</type>
+            <Internal_Reference>
+                <lid_reference>urn:nasa:pds:context:investigation:other_investigation.astromat_data</lid_reference>
+                <reference_type>bundle_to_investigation</reference_type>
+            </Internal_Reference>
+        </Investigation_Area>
+        <Observing_System>
+            <name>Laboratory instruments</name>
+            <description>Various laboratory instruments used to determine chemical compositions of materials</description>
+            <Observing_System_Component>
+                <name>Electron Microprobe</name>
+                <type>Instrument</type>
+            </Observing_System_Component>
+        </Observing_System>
+        <Target_Identification>
+            <name>Lunar Sample</name>
+            <type>Satellite</type>
+            <description>Samples returned from the moon by the Apollo missions</description>
+            <Internal_Reference>
+                <lid_reference>urn:nasa:pds:context:target:satellite.earth.moon</lid_reference>
+                <reference_type>bundle_to_target</reference_type>
+            </Internal_Reference>
+        </Target_Identification>
+    </Context_Area>
+    <Bundle>
+        <bundle_type>Archive</bundle_type>
+    </Bundle>
+    <File_Area_Text>
+        <File>      
+            <file_name>readme.txt</file_name>
+            <creation_date_time>2021-10-04T00:00:00</creation_date_time>
+        </File>
+        <Stream_Text>
+            <offset unit="byte">0</offset>
+            <parsing_standard_id>UTF-8 Text</parsing_standard_id>
+            <record_delimiter>Carriage-Return Line-Feed</record_delimiter>
+        </Stream_Text>
+    </File_Area_Text>
+    <Bundle_Member_Entry>
+        <lid_reference>urn:nasa:pds:astromat:data</lid_reference>
+        <member_status>Primary</member_status>
+        <reference_type>bundle_has_data_collection</reference_type>
+    </Bundle_Member_Entry>
+</Product_Bundle>

--- a/src/test/resources/github419/readme.txt
+++ b/src/test/resources/github419/readme.txt
@@ -1,0 +1,3 @@
+﻿AstroMaterials PDS Archive Description
+Stephen M. Richard
+2021-06-28


### PR DESCRIPTION
…t is provided

1. Add test resources for #349 : src/test/resources/github349
2. Add test resources for #419 : src/test/resources/github419
3. Add check if provided directory is absolute and only check MIME type if it is provided : src/main/java/gov/nasa/pds/tools/validate/rule/pds4/FileReferenceValidationRule.java
4. Add new regression tests : src/test/resources/features/validate.feature

Refs:

https://github.com/nasa-pds/validate/issues/349 validate allows absolute path in directory_path_name but should not
https://github.com/NASA-PDS/validate/issues/419 validate 2.2.0-SNAPSHOT warns about a pretty benign bundle + readme.txt

Closes https://github.com/nasa-pds/validate/issues/349 validate allows absolute path in directory_path_name but should not
Closes https://github.com/nasa-pds/validate/issues/419 validate 2.2.0-SNAPSHOT warns about a pretty benign bundle + readme.txt

The value of directory_path_name in a label should not be absolute.
The check for MIME type should only be done if it is provided in the label.

Tested in DEV:

Case 1:

Running validate against a valid label.  No error expected.

```
% validate -R pds4.label -r report_github349_label_valid_1.json  -s json -t src/test/resources/github349/valid/datasetgood.xml
```

Case 2:

Running validate against a label with the directory_path_name as absolute.  One error should be reported.

```
validate -R pds4.label -r report_github349_label_invalid.json  -s json -t src/test/resources/github349/invalid/datasetbad.xml

      "status": "FAIL",
      "label": "file:/home/qchau/sandbox/validate/src/test/resources/github349/invalid/datasetbad.xml",
      "messages": [
        {
          "severity": "ERROR",
          "type": "error.directory.unallowed_name",
          "message": "The directory name /tmp/01/ for tag 'directory_path_name' cannot be absolute."
        },
```



Case 3:

Running validate against the bundle (validated as a label).  No warning is expected because the MIME type is not provided in the label.

```
% validate -R pds4.label -r report_github419_label_valid.json  -s json -t src/test/resources/github419/bundle_astromat_chem.xml
```


- Fixes #419 