### PR TITLE
Update DocumentUtil to fix string split

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -224,11 +224,17 @@ POSSIBILITY OF SUCH DAMAGE.
       <artifactId>commons-io</artifactId>
       <version>2.7</version>
     </dependency>
-   <dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>1.7.28</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-nop</artifactId>
       <version>1.7.28</version>
-    </dependency>         
+    </dependency>
     <dependency>
       <groupId>com.jamesmurty.utils</groupId>
       <artifactId>java-xmlbuilder</artifactId>

--- a/src/main/java/gov/nasa/pds/tools/util/DocumentUtil.java
+++ b/src/main/java/gov/nasa/pds/tools/util/DocumentUtil.java
@@ -57,10 +57,6 @@ public class DocumentUtil {
       // if we will be using the getProblemType() function below.
   }
 
-  private boolean isClassInitialized() {
-      return(this.classInitialized);
-  }
-
   private void initialize() {
     // Create a map to go from a document type to a ProblemType.
     // The map consists of two arrays, one to hold the docType and one to hold the enumerated ProblemType.
@@ -158,7 +154,6 @@ public class DocumentUtil {
    * @return The content of the file as String.
    */
   public String readFile(URL fileUrl) {
-    String fileName = fileUrl.getPath();
     BufferedReader reader = null;
 
     // Note: The function FilenameUtils.getPath() doesn't seem to work correctly.
@@ -176,20 +171,20 @@ public class DocumentUtil {
     //
     // Using alternative method to get the parent.
     String parent = "";
-    if (fileUrl.getPath().lastIndexOf(File.separator) >= 0) {
-        parent = fileUrl.getPath().substring(0,fileUrl.getPath().lastIndexOf(File.separator));
+    if (fileUrl.getPath().lastIndexOf("/") >= 0) {
+        parent = fileUrl.getPath().substring(0,fileUrl.getPath().lastIndexOf("/"));
     } else {
-        LOG.error("The path does not contain a file separator {}",fileUrl.getPath());
+        LOG.error("The path does not contain a file separator {}", fileUrl.getPath());
         return(null);
     }
-    LOG.debug("readFile:fileUrl,parent,FilenameUtils.getName(fileUrl) {},{},{}",fileUrl,parent,FilenameUtils.getName(fileUrl.toString()));
+    LOG.debug("readFile:fileUrl,parent,FilenameUtils.getName(fileUrl) {},{},{}", fileUrl, parent, FilenameUtils.getName(fileUrl.toString()));
 
     // Combine the parent and the file name together so sonatype-lift won't complain.
     // https://find-sec-bugs.github.io/bugs.htm#PATH_TRAVERSAL_IN
     try {
         reader = new BufferedReader(new FileReader(parent + File.separator + FilenameUtils.getName(fileUrl.toString())));
     } catch (FileNotFoundException ex) {
-        LOG.error("readFile: Cannot find file {}",fileUrl);
+        LOG.error("readFile: Cannot find file {}", fileUrl);
         ex.printStackTrace();
     }
 
@@ -204,7 +199,7 @@ public class DocumentUtil {
 
         return stringBuilder.toString();
     } catch (IOException ex) {
-        LOG.error("readFile: Cannot read file {}",fileUrl);
+        LOG.error("readFile: Cannot read file {}", fileUrl);
         ex.printStackTrace();
     }
 


### PR DESCRIPTION
## 🗒️ Summary
URL objects for files or URLs are operating system agnostic (forward-slash).

resolves #464

## ⚙️ Test Data and/or Report
NOTE: Tested on Windows Parallels. Bug is only applicable on Windows OS.

<img width="1221" alt="Screen Shot 2021-12-21 at 2 03 53 PM" src="https://user-images.githubusercontent.com/33492486/147003404-6b752d2c-cb58-4d0c-a960-a72092fe7f8d.png">
