### PR TITLE
Upgrade to verapdf 1.20.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -189,7 +189,7 @@ POSSIBILITY OF SUCH DAMAGE.
     <dependency>
       <groupId>org.verapdf</groupId>
       <artifactId>pdfbox-validation-model</artifactId>
-      <version>1.16.1</version>
+      <version>1.20.1</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
In a crazy turn of events, verapdf 1.16.1 no longer compiled because
it appears they pulled some of their dependencies from maven central.

from the regression tests, looks like everything runs nominally.

resolves #470
