### PR TITLE
products are now distributed to "deinterlaced" partitions rather than block partitions

### DIFF
--- a/src/main/resources/bin/validate-bundle
+++ b/src/main/resources/bin/validate-bundle
@@ -182,8 +182,14 @@ echo "    ($FILES_PER_VALIDATE files per group)"
 echo "  +--------------------+----------------+"
 echo "  |       Group        |   # in Group   |"
 echo "  +--------------------+----------------+"
-split -l${FILES_PER_VALIDATE} validate_all_files.txt validate_set_
-for line in $(find . -name 'validate_set*'); do 
+
+PRODUCT_IDX=0
+find $PRODUCT_DIR -name "*.xml" -type f -print0 | while IFS= read -r -d '' LABEL_FILEPATH; do
+  echo $LABEL_FILEPATH >> ./validate_set_$((PRODUCT_IDX % NUM_GROUPS))
+  ((PRODUCT_IDX++))
+done
+
+for line in $(find . -name 'validate_set*'); do
      echo "  | $line  |  " `cat $line | wc -l`
 done
 echo "  +--------------------+-----------------"


### PR DESCRIPTION
@jordanpadams per earlier discussion

## 🗒️ Summary
This minimizes the chance of workload disparity between partitions, for example where one partition contains only browses and another contains only large images, which reduces efficiency.

Testing on a Mars2020 MEDA bundle resulted in runtime reduction from 7min to 5min. 

N.B. this changes the suffix for per-partition files from a two-char alpha id to an integer id

## ⚙️ Test Data and/or Report
No tests exist for `validate-bundle`, that I can see

## ♻️ Related Issues
n/a

