### PR TITLE
Set context products object later in execution

### DIFF
--- a/src/main/java/gov/nasa/pds/validate/ValidateLauncher.java
+++ b/src/main/java/gov/nasa/pds/validate/ValidateLauncher.java
@@ -1274,6 +1274,10 @@ public class ValidateLauncher {
     public boolean doValidation(Map<URL, String> checksumManifest) throws Exception {
         boolean success = true;
         long t0 = System.currentTimeMillis();
+
+        // Set the registered context products prior to looping through the targets
+        setRegisteredProducts();
+        
         // Initialize the Factory Class
         List<DocumentValidator> docValidators = new ArrayList<DocumentValidator>();
         factory = ValidatorFactory.getInstance();
@@ -1619,7 +1623,6 @@ public class ValidateLauncher {
                 }
             }
             if (!(invalidSchemas) && !(invalidSchematron)) {
-                setRegisteredProducts();
                 if (!doValidation(checksumManifestMap)) success = false;
             }
             printReportFooter();


### PR DESCRIPTION
Executing `setRegisteredProducts` in `processMain` doesn't make sense for someone trying to call this class through the API.

Solution is the execution in the `doValidation` method, which encapsulates a lot of setup prior to executing validation.

Alternative would be to make `setRegisteredProducts` public.

Resolves #526
