### PR TITLE
Resolve #548

### DIFF
--- a/src/main/java/gov/nasa/pds/tools/validate/content/array/ArrayContentValidator.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/content/array/ArrayContentValidator.java
@@ -259,8 +259,14 @@ public class ArrayContentValidator {
         loc = loc.replaceAll("\\[", "");
         loc = loc.replaceAll("\\]", "");
       }
-      throw new IOException("Error occurred while trying to " + "read data at location " + loc
-          + ": " + ee.getMessage());
+
+      // #544: @jpl-jengelke reports that validate used to produce a detailed error message but now just
+      // says `null`. @jordanpadams says the calculation is no longer completed by the software and didn't
+      // make sense, but that said, `null` is not intuitive.
+      String message = "Error occurred while trying to " + "read data at location " + loc;
+      if (ee.getMessage() != null)
+        message += ": " + ee.getMessage();
+      throw new IOException(message);
     }
 
     boolean isSpecialConstant = false;

--- a/src/main/java/gov/nasa/pds/tools/validate/content/array/ArrayContentValidator.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/content/array/ArrayContentValidator.java
@@ -263,7 +263,7 @@ public class ArrayContentValidator {
       // #544: @jpl-jengelke reports that validate used to produce a detailed error message but now just
       // says `null`. @jordanpadams says the calculation is no longer completed by the software and didn't
       // make sense, but that said, `null` is not intuitive.
-      String message = "Error occurred while trying to " + "read data at location " + loc;
+      String message = "Error occurred while trying to " + "read data at location " + loc + ". Verify possible mismatch in file size and expected array size.";
       if (ee.getMessage() != null)
         message += ": " + ee.getMessage();
       throw new IOException(message);

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/ArrayValidator.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/ArrayValidator.java
@@ -35,7 +35,9 @@ import gov.nasa.pds.tools.validate.rule.RuleContext;
 
 public class ArrayValidator implements DataObjectValidator {
   private static final Logger LOG = LoggerFactory.getLogger(ArrayValidator.class);
-  private int arrayIndex;
+
+  // #548: @jpl-jengelke wants a return to human-based indexing when reporting problems
+  private int arrayIndex = 1;
 
   private ProblemListener listener = null;
   private RuleContext context = null;


### PR DESCRIPTION
## 🗒️ Summary

Merge this to resolve #548 by addressing two specific points made:

- Error reporting went from human-centric (1-based) to computer-centric (0-based) in recent changes; this puts it back to 1-based.
- A detail message changed to `null`; we can't put that back as the [calculation is no longer done and didn't make sense](https://github.com/NASA-PDS/validate/issues/548#issuecomment-1312860355); this at least removes the useless `null` detail message.

## ⚙️ Test Data and/or Report

```
[INFO] Scanning for projects...
[INFO] Inspecting build with total of 1 modules...
[INFO] Installing Nexus Staging features:
```
![Quite some time later](https://user-images.githubusercontent.com/814813/201957411-4dce5ff2-8a85-440f-a0e6-6538cbd0cfc8.gif)
```
[INFO] Tests run: 160, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 257.202 s - in cucumber.CucumberTest
[INFO] 
[INFO] Results:
[INFO] 
[WARNING] Tests run: 161, Failures: 0, Errors: 0, Skipped: 1
```

## ♻️ Related Issues

- #548 
