### PR TITLE
Skip checksum handling if no checksum check is possible

### DIFF
--- a/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/FileReferenceValidationRule.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/FileReferenceValidationRule.java
@@ -501,8 +501,8 @@ public class FileReferenceValidationRule extends AbstractValidationRule {
       String checksumInLabel) throws Exception {
     LOG.debug("handleChecksum:target,urlRef,checksumInLabel {},{},{}", target, urlRef,
         checksumInLabel);
-    if (checksumManifest.isEmpty() && (checksumInLabel == null || checksumInLabel.isEmpty())) {
-      String message = "No checksum found in the manifest for '" + urlRef + "'";
+    if (!checksumManifest.containsKey(urlRef) && (checksumInLabel == null || checksumInLabel.isEmpty())) {
+      String message = "No checksum found in the manifest for '" + urlRef + "' and not checksum label in product";
       LOG.debug("handleChecksum:" + message);
 
       // If there is no checksumManifest and no checksum in the label, we don't need to do anything

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/FileReferenceValidationRule.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/FileReferenceValidationRule.java
@@ -504,6 +504,10 @@ public class FileReferenceValidationRule extends AbstractValidationRule {
     if (checksumManifest.isEmpty() && (checksumInLabel == null || checksumInLabel.isEmpty())) {
       String message = "No checksum found in the manifest for '" + urlRef + "'";
       LOG.debug("handleChecksum:" + message);
+
+      // If there is no checksumManifest and no checksum in the label, we don't need to do anything
+      // with a checksum for this urlRef
+      return;
     }
 
     String generatedChecksum = MD5Checksum.getMD5Checksum(urlRef);


### PR DESCRIPTION
If we know there is no checksum manifest or a checksum in the label, we don't need to handle any checksums.

Previous functionality would continue through this method and generate a checksum, significantly slowing down execution (especially for very large files).

With debugging enabled, here is some of the output that include the generation of a checksum for the file:

```
[main] DEBUG gov.nasa.pds.tools.util.MD5Checksum - createChecksum:url,bytesRead file:/Users/jpadams/test/geo_issue_20221201/s_07171001_sim.img,10240
[main] DEBUG gov.nasa.pds.tools.util.MD5Checksum - createChecksum:url,bytesRead file:/Users/jpadams/test/geo_issue_20221201/s_07171001_sim.img,10240
[main] DEBUG gov.nasa.pds.tools.util.MD5Checksum - createChecksum:url,bytesRead file:/Users/jpadams/test/geo_issue_20221201/s_07171001_sim.img,10240
[main] DEBUG gov.nasa.pds.tools.util.MD5Checksum - createChecksum:url,bytesRead file:/Users/jpadams/test/geo_issue_20221201/s_07171001_sim.img,10240
[main] DEBUG gov.nasa.pds.tools.util.MD5Checksum - createChecksum:url,bytesRead file:/Users/jpadams/test/geo_issue_20221201/s_07171001_sim.img,10240
[main] DEBUG gov.nasa.pds.tools.util.MD5Checksum - createChecksum:url,bytesRead file:/Users/jpadams/test/geo_issue_20221201/s_07171001_sim.img,10240
[main] DEBUG gov.nasa.pds.tools.util.MD5Checksum - createChecksum:url,bytesRead file:/Users/jpadams/test/geo_issue_20221201/s_07171001_sim.img,10240
```
followed by a note that we don't do anything with it:
```
[main] DEBUG gov.nasa.pds.tools.validate.rule.pds4.FileReferenceValidationRule - handleChecksum:No checksum to compare against in the product label for 'file:/Users/jpadams/test/geo_issue_20221201/s_07171001_sim.img'
```

new functionality now eliminates the generation of a checksum for the file for no reason.