### PR TITLE
Update open/close of object reader

### DIFF
--- a/src/main/java/gov/nasa/pds/tools/validate/content/array/ArrayContentValidator.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/content/array/ArrayContentValidator.java
@@ -119,6 +119,7 @@ public class ArrayContentValidator {
     LOG.debug("validate:tableNameReportStr {}", tableNameReportStr);
 
     try {
+      arrayObject.open();
       process(array, arrayObject, dimensions, new int[dimensions.length], 0, dimensions.length - 1);
 
     } catch (Exception e) {
@@ -141,7 +142,6 @@ public class ArrayContentValidator {
       System.out.print(".");
     }
 
-    arrayObject.open();
     for (int i = 0; i < dimensions[depth];) {
       if (depth < maxDepth) { // max depth not reached, do another recursion
         position[depth] = i;
@@ -162,7 +162,6 @@ public class ArrayContentValidator {
         }
       }
     }
-    arrayObject.close();
   }
 
   private void validatePosition(Array array, ArrayObject arrayObject, ArrayLocation location,
@@ -260,10 +259,11 @@ public class ArrayContentValidator {
         loc = loc.replaceAll("\\]", "");
       }
 
-      // #544: @jpl-jengelke reports that validate used to produce a detailed error message but now just
-      // says `null`. @jordanpadams says the calculation is no longer completed by the software and didn't
-      // make sense, but that said, `null` is not intuitive.
-      String message = "Error occurred while trying to " + "read data at location " + loc + ". Verify possible mismatch in file size and expected array size.";
+      // #544: @jpl-jengelke reports that validate used to produce a detailed error message but now
+      // just says `null`. @jordanpadams says the calculation is no longer completed by the software
+      // and didn't make sense, but that said, `null` is not intuitive.
+      String message = "Error occurred while trying to " + "read data at location " + loc
+          + ". Verify possible mismatch in data type and/or file size versus array size.";
       if (ee.getMessage() != null)
         message += ": " + ee.getMessage();
       throw new IOException(message);


### PR DESCRIPTION
Previous functionality opened and closed the reader within a recursive method. Moved thie open/close up a level in execution.

Resolves #564

## ⚙️ Test Data and/or Report
```
$ validate-3.1.0-SNAPSHOT/bin/validate -t ~/test/geo_issue_20221201/s_07171001_sim.xml

PDS Validate Tool Report

Configuration:
   Version                       3.1.0-SNAPSHOT
   Date                          2022-12-01T17:26:25Z

Parameters:
   Targets                       [file:/Users/jpadams/test/geo_issue_20221201/s_07171001_sim.xml]
   Severity Level                WARNING
   Recurse Directories           true
   File Filters Used             [*.xml, *.XML]
   Data Content Validation       on
   Product Level Validation      on
   Max Errors                    100000
   Registered Contexts File      /Users/jpadams/proj/pds/pdsen/workspace/validate/validate-3.1.0-SNAPSHOT/resources/registered_context_products.json



Product Level Validation Results

  PASS: file:/Users/jpadams/test/geo_issue_20221201/s_07171001_sim.xml
        1 product validation(s) completed

Summary:

  0 error(s)
  0 warning(s)

  Product Validation Summary:
    1          product(s) passed
    0          product(s) failed
    0          product(s) skipped

  Referential Integrity Check Summary:
    0          check(s) passed
    0          check(s) failed
    0          check(s) skipped


End of Report
Completed execution in 9730 ms
```

Test data emailed to reviewers via LFT