### PR TITLE
validate-bundle needs quotes around $REPORT_DIR

### DIFF
--- a/src/main/resources/bin/validate-bundle
+++ b/src/main/resources/bin/validate-bundle
@@ -102,7 +102,7 @@ if [ "$PRODUCT_DIR" == "" ]; then
 fi
 
 # If the user has provided the REPORT_DIR (not a blank space), append the unique directory.
-if [ $REPORT_DIR != "" ]; then
+if [ "$REPORT_DIR" != "" ]; then
     REPORT_DIR=$REPORT_DIR/$DEFAULT_UNIQUE_REPORT_DIR_STEM
 fi
 # If the user has not provided the REPORT_FILE (not a blank space), set to unique file beneath the default dir.


### PR DESCRIPTION
validate-bundle needs quotes around $REPORT_DIR on line 105

When $REPORT_DIR has no value, the comparison is invalid without quotes.