### PR TITLE
#474: Fix issue with validate not properly traversing directories

### DIFF
--- a/src/main/java/gov/nasa/pds/tools/util/ImageUtil.java
+++ b/src/main/java/gov/nasa/pds/tools/util/ImageUtil.java
@@ -5,6 +5,8 @@ import java.io.RandomAccessFile;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.Paths;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -82,7 +84,7 @@ public class ImageUtil {
     LOG.debug("isJPEG:,parent,jpegBase {},{}", parent, jpegBase);
 
     // Build the full pathname of the file.
-    String jpegRef = parent + File.separator + jpegBase;
+    String jpegRef = Paths.get(parent, jpegBase).toString();
     LOG.debug("isJPEG:parent,jpegBase,jpegRef [{}],[{}],[{}]", parent, jpegBase, jpegRef);
 
     File jpegFile = new File(jpegRef);

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/FileReferenceValidationRule.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/FileReferenceValidationRule.java
@@ -682,7 +682,7 @@ public class FileReferenceValidationRule extends AbstractValidationRule {
     DocumentsChecker check = new DocumentsChecker();
     if (check.isMimeTypeCorrect(fileRef.toString(), "PDF/A")) {
       // The parent is also needed for validateFileStandardConformity function.
-      pdfValidateFlag = this.pdfUtil.validateFileStandardConformity(pdfName, parent);
+      pdfValidateFlag = this.pdfUtil.validateFileStandardConformity(pdfName, new URL(parent, directory));
 
       // Report an error if the PDF file is not PDF/A compliant.
       if (!pdfValidateFlag) {
@@ -742,7 +742,7 @@ public class FileReferenceValidationRule extends AbstractValidationRule {
       this.imageUtil = new ImageUtil(fileRef);
     }
 
-    jpegValidateFlag = this.imageUtil.isJPEG(jpegName, parent);
+    jpegValidateFlag = this.imageUtil.isJPEG(jpegName, new URL(parent, directory));
 
     // Report a warning if the JPEG file is not compliant.
     if (!jpegValidateFlag) {
@@ -786,7 +786,7 @@ public class FileReferenceValidationRule extends AbstractValidationRule {
       this.imageUtil = new ImageUtil(fileRef);
     }
 
-    validateFlag = this.imageUtil.isPNG(pngName, parent);
+    validateFlag = this.imageUtil.isPNG(pngName, new URL(parent, directory));
 
     // Report a warning if the PNG file is not compliant.
     if (!validateFlag) {


### PR DESCRIPTION
## 🗒️ Summary
When reworked this class a month ago, did not propagate the full path so error reflected what was happening but not what was being asked to happen. Propagated the directories all the way to the handle<file type>().

## ⚙️ Test Data and/or Report
CLI: `validate document_rise\ -R pds4.folder -r validate_report.txt`

validate_report.txt:
```
PDS Validate Tool Report

Configuration:
   Version                       3.1.0-SNAPSHOT
   Date                          2022-12-21T20:46:04Z

Parameters:
   Targets                       [file:/tmp/document_rise/]
   Rule Type                     pds4.folder
   Severity Level                WARNING
   Recurse Directories           true
   File Filters Used             [*.xml, *.XML]
   Data Content Validation       on
   Product Level Validation      on
   Max Errors                    100000
   Registered Contexts File      /home/niessner/Projects/PDS/validate/src/main/resources/util/registered_context_products.json



Product Level Validation Results

  PASS: file:/tmp/document_rise/RISE_InSight_SIS_Raw.xml
        1 product validation(s) completed

Summary:

  0 error(s)
  0 warning(s)

  Product Validation Summary:
    1          product(s) passed
    0          product(s) failed
    0          product(s) skipped

  Referential Integrity Check Summary:
    0          check(s) passed
    0          check(s) failed
    0          check(s) skipped


End of Report
```

## ♻️ Related Issues
#474 
