### PR TITLE
Dockerize validate 556

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,8 +34,8 @@ FROM openjdk:15-slim
 ARG validate_version=3.0.3
 
 # Install curl (to download the validate binary)
-RUN apt-get update -y
-RUN apt-get install curl -y
+RUN apt-get update -y \
+    && apt-get install -y curl
 
 ENV VALIDATE_IMAGE_PATH=https://github.com/NASA-PDS/validate/releases/download/v${validate_version}/validate-${validate_version}-bin.tar.gz
 
@@ -43,9 +43,10 @@ ENV VALIDATE_IMAGE_PATH=https://github.com/NASA-PDS/validate/releases/download/v
 ADD $VALIDATE_IMAGE_PATH /tmp/validate-bin.tar.gz
 RUN  mkdir /opt/validate  \
      && tar xzf /tmp/validate-bin.tar.gz  -C /opt/validate --strip-components 1 \
-     && rm -f /tmp/validate-bin.tar.gz
+     && rm -f /tmp/validate-bin.tar.gz \
+     && apt-get remove --purge \
+     && rm -rf /var/lib/apt/lists/*
+
 ENV PATH="$PATH:/opt/validate/bin"
 
-# Pass default arguments to validate tool
-#CMD validate $DEFAULT_ARGS
 ENTRYPOINT ["validate"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,50 @@
+# Copyright 2022, California Institute of Technology ("Caltech").
+# U.S. Government sponsorship acknowledged.
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+# * Redistributions must reproduce the above copyright notice, this list of
+# conditions and the following disclaimer in the documentation and/or other
+# materials provided with the distribution.
+# * Neither the name of Caltech nor its operating division, the Jet Propulsion
+# Laboratory, nor the names of its contributors may be used to endorse or
+# promote products derived from this software without specific prior written
+# permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+FROM openjdk:15-slim
+
+# Set following arguments with the required validate tool version
+ARG validate_version=3.0.3
+
+# Install curl (to download the validate binary)
+RUN apt-get update -y
+RUN apt-get install curl -y
+
+ENV VALIDATE_IMAGE_PATH=https://github.com/NASA-PDS/validate/releases/download/v${validate_version}/validate-${validate_version}-bin.tar.gz
+
+# Install Validate tool
+ADD $VALIDATE_IMAGE_PATH /tmp/validate-bin.tar.gz
+RUN  mkdir /opt/validate  \
+     && tar xzf /tmp/validate-bin.tar.gz  -C /opt/validate --strip-components 1 \
+     && rm -f /tmp/validate-bin.tar.gz
+ENV PATH="$PATH:/opt/validate/bin"
+
+# Pass default arguments to validate tool
+CMD validate $DEFAULT_ARGS

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -47,4 +47,5 @@ RUN  mkdir /opt/validate  \
 ENV PATH="$PATH:/opt/validate/bin"
 
 # Pass default arguments to validate tool
-CMD validate $DEFAULT_ARGS
+#CMD validate $DEFAULT_ARGS
+ENTRYPOINT ["validate"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,7 +30,7 @@
 
 FROM openjdk:15-slim
 
-# Set following arguments with the required validate tool version
+# Set following argument with the required validate tool version
 ARG validate_version=3.0.3
 
 # Install curl (to download the validate binary)

--- a/docker/README.md
+++ b/docker/README.md
@@ -27,16 +27,16 @@ ARG validate_version=3.0.3
 
 3. Open a terminal and change the current working directory to `validate/docker`.
 
-4. Build the docker image as follows.
+4. Build the docker image as follows (make sure that docker is installed and running in your computer).
 
 ```
-    docker image build -t nasapds/validate .
+    docker image build --tag nasapds/validate .
 ```
 
 5. Test the `nasapds/validate` docker image as follows.
 
 ```
-    docker container run nasapds/validate --help
+    docker container run --rm nasapds/validate --help
 ```
 The above command should display the help content of the Validate Tool.
 
@@ -65,7 +65,7 @@ A PDS bundle can be validated with Validate Tool as follows as per the
 However, when using the dockerized Validate Tool, above command can be updated as follows.
 
 ```shell
-docker container run --name validate \
+docker container run \
                  --rm \
                  --volume "${HOME}/pds/bundle":/tmp/pds \
                  --volume "${HOME}/pds/bundle/checksum-manifest.txt":/tmp/pds/checksum-manifest.txt \

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,130 @@
+# 🪐 Docker Image and Container for Validate Tool
+
+The docker image of Validate Tool provides an easy way to deploy the Validate Tool, without having to 
+worry about the Java/JDK versions installed and operating systems supported. Also, this helps to 
+easily use the Validate Tool in other execution environments such as docker compose and Amazon ECS.
+
+The only prerequisite to use the dockerized Validate Tool is the availability of docker software in the host computer.
+At the time of writing this, the Validate Tool was tested with Docker version 20.10.12.
+
+## 🏃 Steps to build the docker image of the Validate Tool
+
+1. Clone the GIT Repository containing the validate tool.
+```shell
+git clone https://github.com/NASA-PDS/validate.git
+```
+
+2. Update (if required) the following version in the `Dockerfile` with the required Validate Tool version.
+
+| Variable            | Description |
+| ------------------- | ------------|
+| validate_version     | The version of the Validate Tool release to be included in the docker image |
+
+```    
+# Set following argument with the required validate tool version
+ARG validate_version=3.0.3
+```
+
+3. Open a terminal and change the current working directory to `validate/docker`.
+
+4. Build the docker image as follows.
+
+```
+    docker image build -t nasapds/validate .
+```
+
+5. Test the `nasapds/validate` docker image as follows.
+
+```
+    docker container run nasapds/validate --help
+```
+The above command should display the help content of the Validate Tool.
+
+
+## 🏃 Steps to run a docker container of the Validate Tool
+
+The [Operation documentation](https://nasa-pds.github.io/validate/operate/index.html) of the Validate 
+tool provides a detailed guide on executing the Validate Tool.
+
+The same commandline arguments can be used to execute the docker container of the Validate Tool with 
+the following docker specific change.
+
+- Docker containers cannot directly see the files and directories in the host machine. Therefore, it is required to map 
+the files and directories as volumes, so the docker container can access them.
+- Read more about docker volumes at https://docs.docker.com/storage/volumes/ 
+
+For example:
+
+A PDS bundle can be validated with Validate Tool as follows as per the 
+[Operation documentation](https://nasa-pds.github.io/validate/operate/index.html) of the Validate tool.
+
+```shell
+% validate $HOME/pds/bundle -M checksum-manifest.txt -r validate-report.txt -R pds4.bundle
+```
+
+However, when using the dockerized Validate Tool, above command can be updated as follows.
+
+```shell
+docker container run --name validate \
+                 --rm \
+                 --volume "${HOME}/pds/bundle":/tmp/pds \
+                 --volume "${HOME}/pds/bundle/checksum-manifest.txt":/tmp/pds/checksum-manifest.txt \
+                 --volume "${HOME}/validate-report":/tmp/validate-report \
+                 nasapds/validate /tmp/pds -M /tmp/pds/checksum-manifest.txt -r /tmp/validate-report/validate-report.txt -R pds4.bundle
+```
+
+
+## 🏃 Steps to execute the run.sh with default arguments
+
+An example shell script called `run.sh` is provided in the docker directory of Validate repository. 
+This script provides an easier way execute the dockerized Validate Tool to validate a PDS bundle with default arguments. 
+It is possible to make copies of this `run.sh` script, modify the default arguments and execute those 
+scripts as a simplified shell script based option.
+
+1. To use the `run.sh`, update the following environment variables (if necessary) in the `run.sh`.
+
+
+| Variable                    | Description |
+| --------------------------- | ----------- |
+| PDS_BUNDLE_PATH             | PDS bundle directory location in the host machine, which is used to execute the dockerized Validate Tool |
+| CHECKSUM_MANIFEST_FILE_NAME | Checksum file name provided for the PDS bundle |
+| VALIDATE_REPORT_PATH        | Validate report directory path |
+| VALIDATE_REPORT_FILE_NAME   | Validate report file name |
+| DEFAULT_ARGS                | Default arguments provided as an array. This can be updated based on the requirements. |
+
+```    
+# Update following environment variable to match with your environment
+
+# PDS bundle directory location in the host machine, which is used to execute the dockerized Validate Tool
+PDS_BUNDLE_PATH=${HOME}/urn-nasa-pds-insight_rad
+
+# Checksum file name provided for the PDS bundle
+CHECKSUM_MANIFEST_FILE_NAME=urn-nasa-pds-insight_rad.md5
+
+# Validate report directory path
+VALIDATE_REPORT_PATH=${HOME}
+
+# Validate report file name
+VALIDATE_REPORT_FILE_NAME=validate-report.txt
+
+# Default arguments provided as an array. This can be updated based on the requirements.
+DEFAULT_ARGS=(/tmp/pds -M /tmp/pds/${CHECKSUM_MANIFEST_FILE_NAME} -r /tmp/validate-report/${VALIDATE_REPORT_FILE_NAME} -R pds4.bundle)
+
+```
+
+2. Open a terminal and change the current working directory to `validate/docker`.
+
+3. If executing for the first time, change the execution permissions of `run.sh` file as follows.
+
+```
+chmod u+x run.sh
+```
+
+4. Execute the `run.sh` as follows.
+
+```
+./run.sh
+```
+
+Above steps will execute a docker container of the Validate Tool with default arguments provided in 
+the `run.sh` file.

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -54,7 +54,7 @@ DEFAULT_ARGS=(/tmp/pds -M /tmp/pds/${CHECKSUM_MANIFEST_FILE_NAME} -r /tmp/valida
 echo "Executing: validate ${DEFAULT_ARGS[*]}"
 
 # Execute validate docker container with default arguments
-docker container run --name validate \
+docker container run \
                  --rm \
                  --volume "${PDS_BUNDLE_PATH}":/tmp/pds \
                  --volume "${PDS_BUNDLE_PATH}"/"${CHECKSUM_MANIFEST_FILE_NAME}":/tmp/pds/"${CHECKSUM_MANIFEST_FILE_NAME}" \

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -30,13 +30,25 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-# Update following environment variable to match with your environment
-export PDS_BUNDLE_PATH= #<ADD PDS BUNDLE PATH>
-export CHECKSUM_MANIFEST_FILE_NAME=urn-nasa-pds-insight_rad.md5
-export VALIDATE_REPORT_PATH=/tmp
-export VALIDATE_REPORT_FILE_NAME=validate-report.txt
+# This is an example shell script called run.sh provided in the docker directory of Validate repository to make it
+# easier to execute the dockerized Validate Tool validate a PDS bundle with default arguments. It is possible to make copies
+# of this run.sh file, modify the default arguments and execute those scripts as a simplified shell script based option.
 
-# Provide default arguments as an array
+# Update following environment variable to match with your environment
+
+# PDS bundle directory location in the host machine, which is used to execute the dockerized Validate Tool
+PDS_BUNDLE_PATH=${HOME}/urn-nasa-pds-insight_rad
+
+# Checksum file name provided for the PDS bundle
+CHECKSUM_MANIFEST_FILE_NAME=urn-nasa-pds-insight_rad.md5
+
+# Validate report directory path
+VALIDATE_REPORT_PATH=${HOME}
+
+# Validate report file name
+VALIDATE_REPORT_FILE_NAME=validate-report.txt
+
+# Default arguments provided as an array. This can be updated based on the requirements.
 DEFAULT_ARGS=(/tmp/pds -M /tmp/pds/${CHECKSUM_MANIFEST_FILE_NAME} -r /tmp/validate-report/${VALIDATE_REPORT_FILE_NAME} -R pds4.bundle)
 
 echo "Executing: validate ${DEFAULT_ARGS[*]}"
@@ -46,7 +58,7 @@ docker container run --name validate \
                  --rm \
                  --volume "${PDS_BUNDLE_PATH}":/tmp/pds \
                  --volume "${PDS_BUNDLE_PATH}"/"${CHECKSUM_MANIFEST_FILE_NAME}":/tmp/pds/"${CHECKSUM_MANIFEST_FILE_NAME}" \
-                 --volume "${VALIDATE_REPORT_PATH}":/tmp/validate-report/ \
+                 --volume "${VALIDATE_REPORT_PATH}":/tmp/validate-report \
                  nasapds/validate "${DEFAULT_ARGS[@]}"
 
 echo "The validate report is available at: ${VALIDATE_REPORT_PATH}/${VALIDATE_REPORT_FILE_NAME}"

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# Update following environment variable to match with your environment
+export PDS_BUNDLE_PATH= #<ADD PDS BUNDLE PATH>
+export CHECKSUM_MANIFEST_FILE_NAME=urn-nasa-pds-insight_rad.md5
+export VALIDATE_REPORT_PATH=/tmp/
+
+export DEFAULT_ARGS="/tmp/pds -M /tmp/pds/"${CHECKSUM_MANIFEST_FILE_NAME}" -r /tmp/validate-report/validate-report.txt -R pds4.bundle"
+
+docker container run --name validate \
+                 --rm \
+                 --volume "${PDS_BUNDLE_PATH}":/tmp/pds \
+                 --volume "${PDS_BUNDLE_PATH}"/"${CHECKSUM_MANIFEST_FILE_NAME}":/tmp/pds/"${CHECKSUM_MANIFEST_FILE_NAME}" \
+                 --volume "${VALIDATE_REPORT_PATH}":/tmp/validate-report/ \
+                 --env DEFAULT_ARGS="${DEFAULT_ARGS}" \
+                 nasapds/validate           

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Copyright 2022, California Institute of Technology ("Caltech").
 # U.S. Government sponsorship acknowledged.

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -49,7 +49,7 @@ VALIDATE_REPORT_PATH=${HOME}
 VALIDATE_REPORT_FILE_NAME=validate-report.txt
 
 # Default arguments provided as an array. This can be updated based on the requirements.
-DEFAULT_ARGS=(/tmp/pds -M /tmp/pds/${CHECKSUM_MANIFEST_FILE_NAME} -r /tmp/validate-report/${VALIDATE_REPORT_FILE_NAME} -R pds4.bundle)
+DEFAULT_ARGS=(/tmp/pds -M /tmp/pds/"${CHECKSUM_MANIFEST_FILE_NAME}" -r /tmp/validate-report/"${VALIDATE_REPORT_FILE_NAME}" -R pds4.bundle)
 
 echo "Executing: validate ${DEFAULT_ARGS[*]}"
 

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,16 +1,52 @@
 #!/bin/sh
 
+# Copyright 2022, California Institute of Technology ("Caltech").
+# U.S. Government sponsorship acknowledged.
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+# * Redistributions must reproduce the above copyright notice, this list of
+# conditions and the following disclaimer in the documentation and/or other
+# materials provided with the distribution.
+# * Neither the name of Caltech nor its operating division, the Jet Propulsion
+# Laboratory, nor the names of its contributors may be used to endorse or
+# promote products derived from this software without specific prior written
+# permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
 # Update following environment variable to match with your environment
 export PDS_BUNDLE_PATH= #<ADD PDS BUNDLE PATH>
 export CHECKSUM_MANIFEST_FILE_NAME=urn-nasa-pds-insight_rad.md5
-export VALIDATE_REPORT_PATH=/tmp/
+export VALIDATE_REPORT_PATH=/tmp
+export VALIDATE_REPORT_FILE_NAME=validate-report.txt
 
-export DEFAULT_ARGS="/tmp/pds -M /tmp/pds/"${CHECKSUM_MANIFEST_FILE_NAME}" -r /tmp/validate-report/validate-report.txt -R pds4.bundle"
+# Provide default arguments as an array
+DEFAULT_ARGS=(/tmp/pds -M /tmp/pds/${CHECKSUM_MANIFEST_FILE_NAME} -r /tmp/validate-report/${VALIDATE_REPORT_FILE_NAME} -R pds4.bundle)
 
+echo "Executing: validate ${DEFAULT_ARGS[*]}"
+
+# Execute validate docker container with default arguments
 docker container run --name validate \
                  --rm \
                  --volume "${PDS_BUNDLE_PATH}":/tmp/pds \
                  --volume "${PDS_BUNDLE_PATH}"/"${CHECKSUM_MANIFEST_FILE_NAME}":/tmp/pds/"${CHECKSUM_MANIFEST_FILE_NAME}" \
                  --volume "${VALIDATE_REPORT_PATH}":/tmp/validate-report/ \
-                 --env DEFAULT_ARGS="${DEFAULT_ARGS}" \
-                 nasapds/validate           
+                 nasapds/validate "${DEFAULT_ARGS[@]}"
+
+echo "The validate report is available at: ${VALIDATE_REPORT_PATH}/${VALIDATE_REPORT_FILE_NAME}"


### PR DESCRIPTION
## 🗒️ Summary
This pull request is created to Dockerize the Validate tool. The docker image of Validate Tool provides an easy way to deploy the Validate Tool, without having to  worry about the Java/JDK versions installed and operating systems supported. Also, this helps to  easily use the Validate Tool in other execution environments such as docker compose and Amazon ECS.

## ♻️ Related Issues
NASA-PDS/validate#556

