### PR TITLE
issue 511: fix radix problem

### DIFF
--- a/src/main/java/gov/nasa/pds/tools/validate/content/table/FieldValueValidator.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/content/table/FieldValueValidator.java
@@ -790,7 +790,7 @@ public class FieldValueValidator {
             throw new NumberFormatException("Value must be unsigned.");
           }
         } else if (specifier.equals("x")) {
-          BigInteger bi = new BigInteger(value.trim());
+          BigInteger bi = new BigInteger(value.trim(),16);
           if (bi.signum() == -1) {
             throw new NumberFormatException("Value must be unsigned.");
           }


### PR DESCRIPTION
## 🗒️ Summary
Given the code around the fix, it seems like an x specifier means hex. Added the 16 radix to BigInteger constructor and all works well.

## ⚙️ Test Data and/or Report

`validate failCharacter.xml  failDelimited.xml`

```
PDS Validate Tool Report

Configuration:
   Version                       3.1.0-SNAPSHOT
   Date                          2022-12-22T18:49:31Z

Parameters:
   Targets                       [file:/tmp/test/failCharacter.xml, file:/tmp/test/failDelimited.xml]
   Severity Level                WARNING
   Recurse Directories           true
   File Filters Used             [*.xml, *.XML]
   Data Content Validation       on
   Product Level Validation      on
   Max Errors                    100000
   Registered Contexts File      /home/niessner/Projects/PDS/validate/src/main/resources/util/registered_context_products.json



Product Level Validation Results

  PASS: file:/tmp/test/failCharacter.xml
        1 product validation(s) completed

  PASS: file:/tmp/test/failDelimited.xml
        2 product validation(s) completed

Summary:

  0 error(s)
  0 warning(s)

  Product Validation Summary:
    2          product(s) passed
    0          product(s) failed
    0          product(s) skipped

  Referential Integrity Check Summary:
    0          check(s) passed
    0          check(s) failed
    0          check(s) skipped


End of Report
Completed execution in 5466 ms
```

## ♻️ Related Issues
#511 