### PR TITLE
issue #1: command-line option to support content validation for every N products

### DIFF
--- a/src/main/java/gov/nasa/pds/tools/label/LocationValidator.java
+++ b/src/main/java/gov/nasa/pds/tools/label/LocationValidator.java
@@ -429,8 +429,11 @@ public class LocationValidator {
     this.validationRule = ruleName;
   }
 
+  public void setEveryN(int value) {
+	ruleContext.setEveryN(value);
+  }
   public void setSpotCheckData(int value) {
-    ruleContext.setSpotCheckData(value);
+	ruleContext.setSpotCheckData(value);
   }
 
   public void setAllowUnlabeledFiles(boolean flag) {

--- a/src/main/java/gov/nasa/pds/tools/util/EveryNCounter.java
+++ b/src/main/java/gov/nasa/pds/tools/util/EveryNCounter.java
@@ -2,7 +2,7 @@ package gov.nasa.pds.tools.util;
 
 public class EveryNCounter {
   private static EveryNCounter myself = null;
-  private static Integer lock = Integer.valueOf(0);
+  private static Integer lock = new Object();
   private int current = 0;
   private EveryNCounter(){
 	}

--- a/src/main/java/gov/nasa/pds/tools/util/EveryNCounter.java
+++ b/src/main/java/gov/nasa/pds/tools/util/EveryNCounter.java
@@ -2,7 +2,7 @@ package gov.nasa.pds.tools.util;
 
 public class EveryNCounter {
   private static EveryNCounter myself = null;
-  private static Integer lock = new Object();
+  private static Object lock = new Object();
   private int current = 0;
   private EveryNCounter(){
 	}

--- a/src/main/java/gov/nasa/pds/tools/util/EveryNCounter.java
+++ b/src/main/java/gov/nasa/pds/tools/util/EveryNCounter.java
@@ -1,0 +1,17 @@
+package gov.nasa.pds.tools.util;
+
+public class EveryNCounter {
+  private static EveryNCounter myself = null;
+  private static Integer lock = Integer.valueOf(0);
+  private int current = 0;
+  private EveryNCounter(){
+	}
+  public static EveryNCounter getInstance(){
+	synchronized (lock) {
+      if (myself == null) myself = new EveryNCounter();
+	}
+	return myself;
+  }
+  public int getValueThenIncrement() { return this.current++; }
+}
+

--- a/src/main/java/gov/nasa/pds/tools/util/EveryNCounter.java
+++ b/src/main/java/gov/nasa/pds/tools/util/EveryNCounter.java
@@ -3,7 +3,7 @@ package gov.nasa.pds.tools.util;
 public class EveryNCounter {
   private static EveryNCounter myself = null;
   private static Integer lock = Integer.valueOf(0);
-  private int current = 0;
+  private int current = -1;
   private EveryNCounter(){
 	}
   public static EveryNCounter getInstance(){
@@ -12,6 +12,7 @@ public class EveryNCounter {
 	}
 	return myself;
   }
-  public int getValueThenIncrement() { return this.current++; }
+  public int getValue() { return this.current; }
+  public void increment() { this.current++; }
 }
 

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/RuleContext.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/RuleContext.java
@@ -122,6 +122,10 @@ public class RuleContext extends ContextBase {
   /**
    * The key used to indicate how many lines or records to skip during content validation.
    */
+  public static final String EVERY_N_KEY = "validate.every-n";
+  /**
+   * The key used to indicate how many lines or records to skip during content validation.
+   */
   public static final String SPOT_CHECK_DATA_KEY = "validate.spot-check";
 
   /**
@@ -394,12 +398,20 @@ public class RuleContext extends ContextBase {
     putContextValue(CHECK_DATA_KEY, flag);
   }
 
+  public int getEveryN() {
+	return getContextValue(EVERY_N_KEY, Integer.class);
+  }
+
+  public void setEveryN(int value) {
+	putContextValue(EVERY_N_KEY, value);
+  }
+
   public int getSpotCheckData() {
-    return getContextValue(SPOT_CHECK_DATA_KEY, Integer.class);
+	return getContextValue(SPOT_CHECK_DATA_KEY, Integer.class);
   }
 
   public void setSpotCheckData(int value) {
-    putContextValue(SPOT_CHECK_DATA_KEY, value);
+	  putContextValue(SPOT_CHECK_DATA_KEY, value);
   }
 
   public boolean getAllowUnlabeledFiles() {

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/RuleContext.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/RuleContext.java
@@ -399,7 +399,7 @@ public class RuleContext extends ContextBase {
   }
 
   public int getEveryN() {
-	return getContextValue(EVERY_N_KEY, Integer.class);
+	return getContextValue(EVERY_N_KEY, Integer.class) == null ? 1 : getContextValue(EVERY_N_KEY, Integer.class);
   }
 
   public void setEveryN(int value) {

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/ArrayValidator.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/ArrayValidator.java
@@ -74,7 +74,7 @@ public class ArrayValidator implements DataObjectValidator {
 
   @Override
   public boolean validateDataObjectContents() throws InvalidTableException, IOException {
-	if (EveryNCounter.getInstance().getValueThenIncrement() % this.context.getEveryN() != 0) return true;
+	if (EveryNCounter.getInstance().getValue() % this.context.getEveryN() != 0) return true;
 
     URL target = this.context.getTarget();
     String targetFileName = target.toString().substring(target.toString().lastIndexOf("/") + 1);

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/ArrayValidator.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/ArrayValidator.java
@@ -24,6 +24,7 @@ import gov.nasa.pds.label.object.ArrayObject;
 import gov.nasa.pds.objectAccess.DataType.NumericDataType;
 import gov.nasa.pds.objectAccess.InvalidTableException;
 import gov.nasa.pds.tools.label.ExceptionType;
+import gov.nasa.pds.tools.util.EveryNCounter;
 import gov.nasa.pds.tools.util.FileSizesUtil;
 import gov.nasa.pds.tools.validate.ProblemDefinition;
 import gov.nasa.pds.tools.validate.ProblemListener;
@@ -35,8 +36,6 @@ import gov.nasa.pds.tools.validate.rule.RuleContext;
 
 public class ArrayValidator implements DataObjectValidator {
   private static final Logger LOG = LoggerFactory.getLogger(ArrayValidator.class);
-
-  private static int every_n_counter = 0;
 
   // #548: @jpl-jengelke wants a return to human-based indexing when reporting problems
   private int arrayIndex = 1;
@@ -75,7 +74,7 @@ public class ArrayValidator implements DataObjectValidator {
 
   @Override
   public boolean validateDataObjectContents() throws InvalidTableException, IOException {
-	if (ArrayValidator.every_n_counter++ % this.context.getEveryN() != 0) return true;
+	if (EveryNCounter.getInstance().getValueThenIncrement() % this.context.getEveryN() != 0) return true;
 
     URL target = this.context.getTarget();
     String targetFileName = target.toString().substring(target.toString().lastIndexOf("/") + 1);

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/ArrayValidator.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/ArrayValidator.java
@@ -36,6 +36,8 @@ import gov.nasa.pds.tools.validate.rule.RuleContext;
 public class ArrayValidator implements DataObjectValidator {
   private static final Logger LOG = LoggerFactory.getLogger(ArrayValidator.class);
 
+  private static int every_n_counter = 0;
+
   // #548: @jpl-jengelke wants a return to human-based indexing when reporting problems
   private int arrayIndex = 1;
 
@@ -73,6 +75,8 @@ public class ArrayValidator implements DataObjectValidator {
 
   @Override
   public boolean validateDataObjectContents() throws InvalidTableException, IOException {
+	if (ArrayValidator.every_n_counter++ % this.context.getEveryN() != 0) return true;
+
     URL target = this.context.getTarget();
     String targetFileName = target.toString().substring(target.toString().lastIndexOf("/") + 1);
     long t0 = System.currentTimeMillis();

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/DataDefinitionAndContentValidationRule.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/DataDefinitionAndContentValidationRule.java
@@ -24,6 +24,8 @@ public class DataDefinitionAndContentValidationRule extends AbstractValidationRu
   private static final Logger LOG =
       LoggerFactory.getLogger(DataDefinitionAndContentValidationRule.class);
 
+  private static int every_n_counter = 0;
+
   public DataDefinitionAndContentValidationRule() {}
 
   @Override
@@ -36,6 +38,9 @@ public class DataDefinitionAndContentValidationRule extends AbstractValidationRu
     int objectCounter = 0;
     Label label = null;
     String objectIdentifier = "";
+    
+    if (DataDefinitionAndContentValidationRule.every_n_counter % this.getContext().getEveryN() != 0) return;
+
     try {
       URL target = getTarget();
       String targetFileName = target.toString().substring(target.toString().lastIndexOf("/") + 1);

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/DataDefinitionAndContentValidationRule.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/DataDefinitionAndContentValidationRule.java
@@ -24,8 +24,6 @@ public class DataDefinitionAndContentValidationRule extends AbstractValidationRu
   private static final Logger LOG =
       LoggerFactory.getLogger(DataDefinitionAndContentValidationRule.class);
 
-  private static int every_n_counter = 0;
-
   public DataDefinitionAndContentValidationRule() {}
 
   @Override
@@ -39,8 +37,6 @@ public class DataDefinitionAndContentValidationRule extends AbstractValidationRu
     Label label = null;
     String objectIdentifier = "";
     
-    if (DataDefinitionAndContentValidationRule.every_n_counter++ % this.getContext().getEveryN() != 0) return;
-
     try {
       URL target = getTarget();
       String targetFileName = target.toString().substring(target.toString().lastIndexOf("/") + 1);

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/DataDefinitionAndContentValidationRule.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/DataDefinitionAndContentValidationRule.java
@@ -39,7 +39,6 @@ public class DataDefinitionAndContentValidationRule extends AbstractValidationRu
     try {
       URL target = getTarget();
       String targetFileName = target.toString().substring(target.toString().lastIndexOf("/") + 1);
-      long t0 = System.currentTimeMillis();
 
       LOG.debug("START definition/content validation: {}", targetFileName);
 

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/DataDefinitionAndContentValidationRule.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/DataDefinitionAndContentValidationRule.java
@@ -39,7 +39,7 @@ public class DataDefinitionAndContentValidationRule extends AbstractValidationRu
     Label label = null;
     String objectIdentifier = "";
     
-    if (DataDefinitionAndContentValidationRule.every_n_counter % this.getContext().getEveryN() != 0) return;
+    if (++DataDefinitionAndContentValidationRule.every_n_counter % this.getContext().getEveryN() != 0) return;
 
     try {
       URL target = getTarget();

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/DataDefinitionAndContentValidationRule.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/DataDefinitionAndContentValidationRule.java
@@ -14,6 +14,7 @@ import gov.nasa.pds.label.object.TableObject;
 import gov.nasa.pds.objectAccess.InvalidTableException;
 import gov.nasa.pds.objectAccess.ParseException;
 import gov.nasa.pds.tools.label.ExceptionType;
+import gov.nasa.pds.tools.util.EveryNCounter;
 import gov.nasa.pds.tools.validate.ProblemDefinition;
 import gov.nasa.pds.tools.validate.ProblemType;
 import gov.nasa.pds.tools.validate.ValidationProblem;
@@ -53,6 +54,7 @@ public class DataDefinitionAndContentValidationRule extends AbstractValidationRu
       DataObjectValidator validator = null;
 
       URL previousDataFile = null;
+      EveryNCounter.getInstance().increment();
       for (DataObject obj : label.getObjects()) {
         objectIdentifier = getObjectIdentifier(obj);
         LOG.debug("Checking DataObject #{} '{}'", objectCounter, obj.getName());

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/DataDefinitionAndContentValidationRule.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/DataDefinitionAndContentValidationRule.java
@@ -39,7 +39,7 @@ public class DataDefinitionAndContentValidationRule extends AbstractValidationRu
     Label label = null;
     String objectIdentifier = "";
     
-    if (++DataDefinitionAndContentValidationRule.every_n_counter % this.getContext().getEveryN() != 0) return;
+    if (DataDefinitionAndContentValidationRule.every_n_counter++ % this.getContext().getEveryN() != 0) return;
 
     try {
       URL target = getTarget();

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/TableValidator.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/TableValidator.java
@@ -51,6 +51,9 @@ import gov.nasa.pds.validate.constants.Constants;
  */
 public class TableValidator implements DataObjectValidator {
   private static final Logger LOG = LoggerFactory.getLogger(TableValidator.class);
+
+  private static int every_n_counter = 0;
+
   private int progressCounter = 0;
   private long currentObjectRecordCounter = 0;
 
@@ -121,6 +124,7 @@ public class TableValidator implements DataObjectValidator {
 
   @Override
   public boolean validateDataObjectContents() throws InvalidTableException, IOException, Exception {
+		if (TableValidator.every_n_counter++ % this.context.getEveryN() != 0) return true;
 
     LOG.debug("START table content validation");
     LOG.debug("validateTableDataContents:getTarget() {}", this.context.getTarget());

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/TableValidator.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/TableValidator.java
@@ -32,6 +32,7 @@ import gov.nasa.pds.objectAccess.table.TableAdapter;
 import gov.nasa.pds.objectAccess.table.TableBinaryAdapter;
 import gov.nasa.pds.objectAccess.table.TableDelimitedAdapter;
 import gov.nasa.pds.tools.label.ExceptionType;
+import gov.nasa.pds.tools.util.EveryNCounter;
 import gov.nasa.pds.tools.util.FileService;
 import gov.nasa.pds.tools.util.TableCharacterUtil;
 import gov.nasa.pds.tools.validate.ProblemListener;
@@ -51,8 +52,6 @@ import gov.nasa.pds.validate.constants.Constants;
  */
 public class TableValidator implements DataObjectValidator {
   private static final Logger LOG = LoggerFactory.getLogger(TableValidator.class);
-
-  private static int every_n_counter = 0;
 
   private int progressCounter = 0;
   private long currentObjectRecordCounter = 0;
@@ -124,7 +123,7 @@ public class TableValidator implements DataObjectValidator {
 
   @Override
   public boolean validateDataObjectContents() throws InvalidTableException, IOException, Exception {
-		if (TableValidator.every_n_counter++ % this.context.getEveryN() != 0) return true;
+		if (EveryNCounter.getInstance().getValueThenIncrement() % this.context.getEveryN() != 0) return true;
 
     LOG.debug("START table content validation");
     LOG.debug("validateTableDataContents:getTarget() {}", this.context.getTarget());

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/TableValidator.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/TableValidator.java
@@ -123,7 +123,7 @@ public class TableValidator implements DataObjectValidator {
 
   @Override
   public boolean validateDataObjectContents() throws InvalidTableException, IOException, Exception {
-		if (EveryNCounter.getInstance().getValueThenIncrement() % this.context.getEveryN() != 0) return true;
+		if (EveryNCounter.getInstance().getValue() % this.context.getEveryN() != 0) return true;
 
     LOG.debug("START table content validation");
     LOG.debug("validateTableDataContents:getTarget() {}", this.context.getTarget());

--- a/src/main/java/gov/nasa/pds/validate/ValidateLauncher.java
+++ b/src/main/java/gov/nasa/pds/validate/ValidateLauncher.java
@@ -326,7 +326,7 @@ public class ValidateLauncher {
       setEveryN(Integer.valueOf(line.getOptionValue("everyN", "1")).intValue());
       if (this.everyN < 1)
         throw new InvalidOptionException(
-          "Value must be <= 1 not '" + line.getOptionValue("everyN", "1") + "'");
+          "Value must be greater than or equal to 1 not '" + line.getOptionValue("everyN", "1") + "'");
     } catch (IllegalArgumentException a) {
       throw new InvalidOptionException(
         "Could not parse value '" + line.getOptionValue("everyN", "1") + "': " + a.getMessage());

--- a/src/main/java/gov/nasa/pds/validate/ValidateLauncher.java
+++ b/src/main/java/gov/nasa/pds/validate/ValidateLauncher.java
@@ -306,15 +306,14 @@ public class ValidateLauncher {
    * @throws Exception If an error occurred while processing the command-line options.
    */
   public void query(CommandLine line) throws Exception {
-	int count = 0, every = Integer.valueOf(line.getOptionValue("everyN", "1")).intValue();
+	this.spotCheckData = Integer.valueOf(line.getOptionValue("everyN", "-1")).intValue();
     List<Option> processedOptions = Arrays.asList(line.getOptions());
     List<String> targetList = new ArrayList<>();
     // Gets the implicit targets
     for (java.util.Iterator<String> i = line.getArgList().iterator(); i.hasNext();) {
       String[] values = i.next().split(",");
       for (String value : values) {
-        if ((count % every) == 0) targetList.add(value.trim());
-        count++;
+        targetList.add(value.trim());
       }
     }
 

--- a/src/main/java/gov/nasa/pds/validate/ValidateLauncher.java
+++ b/src/main/java/gov/nasa/pds/validate/ValidateLauncher.java
@@ -306,13 +306,15 @@ public class ValidateLauncher {
    * @throws Exception If an error occurred while processing the command-line options.
    */
   public void query(CommandLine line) throws Exception {
+	int count = 0, every = Integer.valueOf(line.getOptionValue("everyN", "1")).intValue();
     List<Option> processedOptions = Arrays.asList(line.getOptions());
     List<String> targetList = new ArrayList<>();
     // Gets the implicit targets
     for (java.util.Iterator<String> i = line.getArgList().iterator(); i.hasNext();) {
       String[] values = i.next().split(",");
       for (String value : values) {
-        targetList.add(value.trim());
+        if ((count % every) == 0) targetList.add(value.trim());
+        count++;
       }
     }
 

--- a/src/main/java/gov/nasa/pds/validate/ValidateLauncher.java
+++ b/src/main/java/gov/nasa/pds/validate/ValidateLauncher.java
@@ -324,9 +324,12 @@ public class ValidateLauncher {
 
     try {
       setEveryN(Integer.valueOf(line.getOptionValue("everyN", "1")).intValue());
+      if (this.everyN < 1)
+        throw new InvalidOptionException(
+          "Value must be <= 1 not '" + line.getOptionValue("everyN", "1") + "'");
     } catch (IllegalArgumentException a) {
       throw new InvalidOptionException(
-          "Could not parse value '" + line.getOptionValue("everyN", "1") + "': " + a.getMessage());
+        "Could not parse value '" + line.getOptionValue("everyN", "1") + "': " + a.getMessage());
     }
 
     for (Option o : processedOptions) {

--- a/src/main/java/gov/nasa/pds/validate/commandline/options/ConfigKey.java
+++ b/src/main/java/gov/nasa/pds/validate/commandline/options/ConfigKey.java
@@ -114,6 +114,11 @@ public class ConfigKey {
   /**
    * Property to specify how many lines or records to skip during content validation.
    */
+  public static final String EVERY_N = "validate.everyN";
+
+  /**
+   * Property to specify how many lines or records to skip during content validation.
+   */
   public static final String SPOT_CHECK_DATA = "validate.spotCheckData";
 
   /**

--- a/src/main/java/gov/nasa/pds/validate/commandline/options/Flag.java
+++ b/src/main/java/gov/nasa/pds/validate/commandline/options/Flag.java
@@ -66,6 +66,7 @@ public enum Flag {
   EXTENSION("e", "label-extension", "xml|lblx", String.class, true,
       "Specify file extension for the labels files. Default: xml. NOTE: Support for intermingled bundles where collections have differing label file extensions is not yet supported."),
 
+  EVERY_N(null, "everyN", "value", int.class, "Process every N files with the default being every file."),
   /**
    * DEPRECATED: Flag to force the tool to perform validation against the schema and schematron
    * specified in a given label.

--- a/src/main/java/gov/nasa/pds/validate/commandline/options/FlagOptions.java
+++ b/src/main/java/gov/nasa/pds/validate/commandline/options/FlagOptions.java
@@ -52,6 +52,7 @@ public class FlagOptions {
     options.addOption(new ToolsOption(Flag.CONFIG));
     options.addOption(new ToolsOption(Flag.MAX_ERRORS));
     options.addOption(new ToolsOption(Flag.EXTENSION));
+    options.addOption(new ToolsOption(Flag.EVERY_N));
     options.addOption(new ToolsOption(Flag.HELP));
     options.addOption(new ToolsOption(Flag.REPORT));
     options.addOption(new ToolsOption(Flag.TARGET));


### PR DESCRIPTION
## 🗒️ Summary
Added a command line option to process every Nth file rather than all of them.

## ⚙️ Test Data and/or Report
Tested using 

```
validate --everyN 2 src/test/resources/github531/success/b.xml src/test/resources/github531/fail/b.xml src/test/resources/github531/success/b.xml src/test/resources/github531/fail/b.xml

>< snip ><

  Product Validation Summary:
    2          product(s) passed
    0          product(s) failed
    0          product(s) skipped
```

## ♻️ Related Issues
#1