### PR TITLE
CodeQL Action v1 deprecated, move to v2

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -47,7 +47,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -60,7 +60,7 @@ jobs:
 #       mvn clean compile site -DskipTests
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2
       
     - run: |
         pip install nasa-scrub


### PR DESCRIPTION
## 🗒️ Summary
Properly move to v2 in all references used as previous PR #560 did not fully move _all_ of CodeQL Actions to v2.

## ⚙️ Test Data and/or Report
This change should hopefully avoid deprecation warnings such as the ones listed in https://github.com/NASA-PDS/validate/actions/runs/4034510858.

Ref:
https://github.blog/changelog/2023-01-18-code-scanning-codeql-action-v1-is-now-deprecated/#what-do-i-need-to-change-in-my-workflow