### PR TITLE
Add product metadata check audio/video files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -389,6 +389,11 @@ POSSIBILITY OF SUCH DAMAGE.
       <artifactId>opensearch-rest-high-level-client</artifactId>
       <version>2.5.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.mp4parser</groupId>
+      <artifactId>isoparser</artifactId>
+      <version>1.9.56</version>
+    </dependency>
   </dependencies>
 
   <!-- Inherit from parent -->

--- a/src/main/java/gov/nasa/pds/tools/validate/ProblemType.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/ProblemType.java
@@ -196,6 +196,8 @@ public enum ProblemType {
 
   UNLABELED_FILE("warning.file.not_referenced_in_label"),
 
+  NOT_MP4_FILE("warning.file.not_mp4_m4a_compliant"),
+
   NON_JPEG_FILE("warning.file.not_jpeg_compliant"),
 
   NON_PNG_FILE("warning.file.not_png_compliant"),

--- a/src/main/java/gov/nasa/pds/tools/validate/ProblemType.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/ProblemType.java
@@ -196,11 +196,11 @@ public enum ProblemType {
 
   UNLABELED_FILE("warning.file.not_referenced_in_label"),
 
-  NOT_MP4_FILE("warning.file.not_mp4_m4a_compliant"),
+  NOT_MP4_FILE("error.file.not_mp4_m4a_compliant"),
 
-  NON_JPEG_FILE("warning.file.not_jpeg_compliant"),
+  NON_JPEG_FILE("error.file.not_jpeg_compliant"),
 
-  NON_PNG_FILE("warning.file.not_png_compliant"),
+  NON_PNG_FILE("error.file.not_png_compliant"),
 
   NON_HTML_FILE("warning.file.not_html_mimetype"),
 

--- a/src/main/java/gov/nasa/pds/tools/validate/content/AudioVideo.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/content/AudioVideo.java
@@ -28,7 +28,7 @@ public class AudioVideo {
       MovieBox movie = content.getMovieBox();
       if (movie == null) {
         this.listener.addProblem(new ValidationProblem(
-            new ProblemDefinition(ExceptionType.WARNING, ProblemType.NOT_MP4_FILE,
+            new ProblemDefinition(ExceptionType.ERROR, ProblemType.NOT_MP4_FILE,
                 "Does not look like an MP4/M4A because no boxes found within: " + urlRef.toString()),
             target));
       } else {
@@ -40,13 +40,13 @@ public class AudioVideo {
       content.close();
       if (a != audio) {
         this.listener.addProblem(new ValidationProblem(
-            new ProblemDefinition(ExceptionType.WARNING, ProblemType.NOT_MP4_FILE,
+            new ProblemDefinition(ExceptionType.ERROR, ProblemType.NOT_MP4_FILE,
                 "Does not look like an MP4/M4A because expected audio but found none: " + urlRef.toString()),
             target));
       }
       if (v != video) {
         this.listener.addProblem(new ValidationProblem(
-            new ProblemDefinition(ExceptionType.WARNING, ProblemType.NOT_MP4_FILE,
+            new ProblemDefinition(ExceptionType.ERROR, ProblemType.NOT_MP4_FILE,
                 "Does not look like an MP4/M4A because expected video but found none: " + urlRef.toString()),
             target));
       }

--- a/src/main/java/gov/nasa/pds/tools/validate/content/AudioVideo.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/content/AudioVideo.java
@@ -1,0 +1,42 @@
+package gov.nasa.pds.tools.validate.content;
+
+import gov.nasa.pds.tools.label.ExceptionType;
+import gov.nasa.pds.tools.validate.ProblemDefinition;
+import gov.nasa.pds.tools.validate.ProblemListener;
+import gov.nasa.pds.tools.validate.ProblemType;
+import gov.nasa.pds.tools.validate.ValidationProblem;
+import gov.nasa.pds.tools.validate.ValidationTarget;
+import java.net.URL;
+import org.apache.commons.io.FilenameUtils;
+import org.mp4parser.IsoFile;
+import org.mp4parser.boxes.iso14496.part12.MovieBox;
+
+public class AudioVideo {
+  final private ProblemListener listener;
+  final private URL urlRef;
+  final private ValidationTarget target;
+  public AudioVideo (ProblemListener listener, ValidationTarget target, URL urlRef) {
+    this.listener = listener;
+    this.target = target;
+    this.urlRef = urlRef;
+  }
+  public void checkMetadata (boolean audio, boolean video) {
+    try {
+      IsoFile content = new IsoFile(this.urlRef.getPath());
+      MovieBox movie = content.getMovieBox();
+      if (movie == null) {
+        this.listener.addProblem(new ValidationProblem(
+            new ProblemDefinition(ExceptionType.WARNING, ProblemType.NOT_MP4_FILE,
+                "Does not look like an MP4/M4A because no boxes found within: " + urlRef.toString()),
+            target));
+      }
+      content.close();
+    } catch (Exception e) {
+      ProblemDefinition def =
+          new ProblemDefinition(ExceptionType.ERROR, ProblemType.INTERNAL_ERROR,
+              "Error occurred while processing MP4/M4A file content for "
+                  + FilenameUtils.getName(urlRef.toString()) + ": " + e.getMessage());
+      this.listener.addProblem(new ValidationProblem(def, this.target));
+    }
+  }
+}

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/FileReferenceValidationRule.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/FileReferenceValidationRule.java
@@ -808,7 +808,7 @@ public class FileReferenceValidationRule extends AbstractValidationRule {
         urlRef = new URL(parent, jpegName);
       }
       LOG.error("handleJPEG:" + urlRef.toString() + " is not valid JPEG file");
-      ProblemDefinition def = new ProblemDefinition(ExceptionType.WARNING,
+      ProblemDefinition def = new ProblemDefinition(ExceptionType.ERROR,
           ProblemType.NON_JPEG_FILE, urlRef.toString() + " is not valid JPEG file");
       getListener().addProblem(new ValidationProblem(def, target, lineNumber, -1));
     }
@@ -852,7 +852,7 @@ public class FileReferenceValidationRule extends AbstractValidationRule {
         urlRef = new URL(parent, pngName);
       }
       LOG.error("handlePNG:" + urlRef.toString() + " is not valid PNG file");
-      ProblemDefinition def = new ProblemDefinition(ExceptionType.WARNING, ProblemType.NON_PNG_FILE,
+      ProblemDefinition def = new ProblemDefinition(ExceptionType.ERROR, ProblemType.NON_PNG_FILE,
           urlRef.toString() + " is not valid PNG file");
       getListener().addProblem(new ValidationProblem(def, target, lineNumber, -1));
     }

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/FileReferenceValidationRule.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/FileReferenceValidationRule.java
@@ -49,6 +49,7 @@ import gov.nasa.pds.tools.validate.ProblemDefinition;
 import gov.nasa.pds.tools.validate.ProblemType;
 import gov.nasa.pds.tools.validate.ValidationProblem;
 import gov.nasa.pds.tools.validate.ValidationTarget;
+import gov.nasa.pds.tools.validate.content.AudioVideo;
 import gov.nasa.pds.tools.validate.rule.AbstractValidationRule;
 import gov.nasa.pds.tools.validate.rule.ValidationTest;
 import net.sf.saxon.om.DocumentInfo;
@@ -270,6 +271,9 @@ public class FileReferenceValidationRule extends AbstractValidationRule {
               }
               if ("encoding_standard_id".equals(child.getLocalPart())) {
                 encodingStandardId = child.getStringValue();
+                if (this.fileMapping.get(name).equals("")) {
+                  this.fileMapping.put (name, encodingStandardId);
+                }
               }
               if ("file_name".equals(child.getLocalPart())) {
                 name = child.getStringValue();
@@ -459,6 +463,12 @@ public class FileReferenceValidationRule extends AbstractValidationRule {
                   .addProblem(new ValidationProblem(def, target, fileObject.getLineNumber(), -1));
               return false;
             }
+          } else if (doctype.equalsIgnoreCase("MP4/H.264/AAC")){
+            new AudioVideo(this.getListener(), target, urlRef).checkMetadata (true, true);
+          } else if (doctype.equalsIgnoreCase("MP4/H.264")){
+            new AudioVideo(this.getListener(), target, urlRef).checkMetadata (false, true);
+          } else if (doctype.equalsIgnoreCase("M4A/AAC") || doctype.equalsIgnoreCase("WAV")){
+            new AudioVideo(this.getListener(), target, urlRef).checkMetadata (true, false);
           } else if (!doctype.equalsIgnoreCase("UTF-8 Text")
               && !doctype.equalsIgnoreCase("7-Bit ASCII Text")
               && !doctype.equalsIgnoreCase("Rich Text")) {


### PR DESCRIPTION
## 🗒️ Summary
Added checks in FileReferenceValidationRule that if an A/V file then to check with its metadata that there is the correct video and/or audio track. Like using FFMPEG to find errors it will process any valid A/V file. It cannot really tell the difference between H.264 and H.265 or 266 or other supported encoding. Same applies with audio. The mp4parser library used for this work currently only supports MP4 H.264 and AAC. Not to say that will not change in the future.

## ⚙️ Test Data and/or Report
See unit tests (604 and 605 specifically)

## ♻️ Related Issues
Closes #664 


