### PR TITLE
Fix bug for PDF errors identifying wrong files

### DIFF
--- a/src/main/java/gov/nasa/pds/validate/ValidateLauncher.java
+++ b/src/main/java/gov/nasa/pds/validate/ValidateLauncher.java
@@ -333,7 +333,7 @@ public class ValidateLauncher {
       throw new InvalidOptionException(
         "Could not parse value '" + line.getOptionValue("everyN", "1") + "': " + a.getMessage());
     }
-    setPDFErrorDir(line.getOptionValue("pdf-errors", ""));
+    setPDFErrorDir(line.getOptionValue("pdf-error-dir", ""));
     File dir = new File(pdfErrorDir);
     if (!this.pdfErrorDir.isEmpty() && !dir.isDirectory()) {
       throw new InvalidOptionException(


### PR DESCRIPTION
## 🗒️ Summary
The root problem is the error messages identified the wrong file for containing the errors. Once the correct files were identified, the user was able to correct the offending PDFs. Update the code to report the correct files.

## ⚙️ Test Data and/or Report
Unit testing cannot validate this level of change (text in an error message) so doing the old fashion way. Old messages:
```
  FAIL: file:/home/niessner/Projects/PDS/validate/src/test/resources/github479/M2020_SuperCam_EDR_RDR_SIS.xml
      ERROR  [error.pdf.file.not_pdfa_compliant]   Validation failed for flavour PDF/A-1b.  Detailed error output can be found at /tmp/M2020_SuperCam_EDR_RDR_SIS.pdf.1b.error.csv
      ERROR  [error.pdf.file.not_pdfa_compliant]   Validation failed for flavour PDF/A-1b.  Detailed error output can be found at /tmp/M2020_SuperCam_EDR_RDR_SIS.pdf.1b.error.csv
```

New messages:
```
  FAIL: file:/home/niessner/Projects/PDS/validate/src/test/resources/github479/M2020_SuperCam_EDR_RDR_SIS.xml
      ERROR  [error.pdf.file.not_pdfa_compliant]   Validation failed for flavour PDF/A-1b in file mars2020_supercam_labels_sort_pds.pdf.  Detailed error output can be found at /tmp/mars2020_supercam_labels_sort_pds.pdf.1b.error.csv
      ERROR  [error.pdf.file.not_pdfa_compliant]   Validation failed for flavour PDF/A-1b in file mars2020_supercam_labels_sort_vicar.pdf.  Detailed error output can be found at /tmp/mars2020_supercam_labels_sort_vicar.pdf.1b.error.csv
```

## ♻️ Related Issues
Closes #479 

