### PR TITLE
Check that files with label extension are actually labels to avoid errors on floating XML files

### DIFF
--- a/src/main/java/gov/nasa/pds/tools/util/ReferentialIntegrityUtil.java
+++ b/src/main/java/gov/nasa/pds/tools/util/ReferentialIntegrityUtil.java
@@ -799,7 +799,7 @@ public class ReferentialIntegrityUtil {
         // local_identifier and lid_reference or lidvid_reference tags.
         url = child.getUrl();
 
-        if (url.toString().endsWith("." + getContext().getLabelExtension())) {
+        if (url.toString().endsWith("." + getContext().getLabelExtension()) && TargetExaminer.isTargetALabel(url)) {
 
           // Check this URL has been parsed before. If yes, skip this file.
           if (ReferentialIntegrityUtil.urlsParsedCumulative.contains(url)) {

--- a/src/main/java/gov/nasa/pds/tools/validate/TargetExaminer.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/TargetExaminer.java
@@ -221,4 +221,37 @@ public class TargetExaminer extends Target {
 
     return (fieldContent);
   }
+  public static boolean isTargetALabel(URL url) {
+    try {
+      InputSource source = Utility.getInputSourceByURL(url);
+      SAXSource saxSource = new SAXSource(source);
+      saxSource.setSystemId(url.toString());
+      DocumentInfo docInfo = LabelParser.parse(saxSource); // Parses a label.
+      @SuppressWarnings("unused")
+      List<TinyNodeImpl> xmlModels = new ArrayList<>();
+      XMLExtractor extractor = new XMLExtractor(docInfo);
+      xmlModels = extractor.getNodesFromDoc("logical_identifier");
+      return true;
+    } catch (Throwable t) {
+      return false;
+    }
+  }
+  /**
+   * Modifies the input array and returns it so the same call can be used
+   * as a function or as a procedure.
+   * @param targets
+   * @return
+   */
+  public static List<Target> removeNonLabels(List<Target> targets) {
+    ArrayList<Target> nons = new ArrayList<Target>();
+    for (Target t : targets) {
+      if (!isTargetALabel (t.getUrl())) {
+        nons.add (t);
+      }
+    }
+    for (Target t : nons) {
+      targets.remove (t);
+    }
+    return targets;
+  }
 }

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/LabelInFolderRule.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/LabelInFolderRule.java
@@ -31,6 +31,7 @@ import gov.nasa.pds.tools.validate.AdditionalTarget;
 import gov.nasa.pds.tools.validate.ProblemDefinition;
 import gov.nasa.pds.tools.validate.ProblemType;
 import gov.nasa.pds.tools.validate.Target;
+import gov.nasa.pds.tools.validate.TargetExaminer;
 import gov.nasa.pds.tools.validate.ValidationProblem;
 import gov.nasa.pds.tools.validate.crawler.Crawler;
 import gov.nasa.pds.tools.validate.rule.AbstractValidationRule;
@@ -132,6 +133,7 @@ public class LabelInFolderRule extends AbstractValidationRule {
       } else {
         targetList = crawler.crawl(target, false, getContext().getFileFilters());
       }
+      TargetExaminer.removeNonLabels (targetList);
 
       if (targetList.size() > 0) {
         getListener().addProblem(new ValidationProblem(new ProblemDefinition(ExceptionType.DEBUG,


### PR DESCRIPTION
## 🗒️ Summary
Add a check that files that have the label extension really are labels and remove them from the target list if they are not preventing lots of SAX parsing exceptions. Files that are "floating" like this show up as un-referenced warnings by the bundle or collection. If given as the target, it will still blow up making it obvious to the user.

## ⚙️ Test Data and/or Report
See automate unit tests below (specifically 482).

## ♻️ Related Issues
Closes #679 