### PR TITLE
Upgrade net.sf.saxon:Saxon-HE from 9.9.1-7 to 12.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@ POSSIBILITY OF SUCH DAMAGE.
     <plugins>
        <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.1.2</version>
+          <version>3.0.0-M3</version>
           
           <configuration>
           <argLine>-Dorg.slf4j.simpleLogger.defaultLogLevel=ERROR</argLine>
@@ -200,7 +200,7 @@ POSSIBILITY OF SUCH DAMAGE.
     <dependency>
       <groupId>net.sf.saxon</groupId>
       <artifactId>Saxon-HE</artifactId>
-      <version>9.9.1-7</version>
+      <version>12.3</version>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>
@@ -315,7 +315,7 @@ POSSIBILITY OF SUCH DAMAGE.
     <dependency>
       <groupId>org.apache.solr</groupId>
       <artifactId>solr-solrj</artifactId>
-      <version>9.3.0</version>
+      <version>7.7.2</version>
     </dependency>
     <dependency>
         <groupId>org.junit.jupiter</groupId>

--- a/src/main/java/gov/nasa/pds/tools/label/LabelValidator.java
+++ b/src/main/java/gov/nasa/pds/tools/label/LabelValidator.java
@@ -84,7 +84,7 @@ import gov.nasa.pds.tools.validate.ProblemType;
 import gov.nasa.pds.tools.validate.TargetExaminer;
 import gov.nasa.pds.tools.validate.ValidationProblem;
 import gov.nasa.pds.validate.constants.Constants;
-import net.sf.saxon.om.DocumentInfo;
+import net.sf.saxon.om.TreeInfo;
 import net.sf.saxon.trans.XPathException;
 
 /**
@@ -252,7 +252,7 @@ public class LabelValidator {
     resolver.setPreferPublic(true);
     resolver.setCatalogList(catalogFiles);
     useLabelSchematron = true;
-    LOG.debug("setCatalogs:catalogFiles {}", catalogFiles);
+    LOG.debug("setCatalogs:catalogFiles {}", (Object[])catalogFiles);
     LOG.debug("setCatalogs:useLabelSchematron explitly set to true");
   }
 
@@ -658,9 +658,9 @@ public class LabelValidator {
 
         SAXSource saxSource = new SAXSource(Utility.getInputSourceByURL(url));
         saxSource.setSystemId(url.toString());
-        DocumentInfo docInfo = LabelParser.parse(saxSource);
+        TreeInfo docInfo = LabelParser.parse(saxSource);
         for (DocumentValidator dv : documentValidators) {
-          dv.validate(handler, docInfo);
+          dv.validate(handler, docInfo.getRootNode());
         }
       }
     }

--- a/src/main/java/gov/nasa/pds/tools/label/SchematronTransformer.java
+++ b/src/main/java/gov/nasa/pds/tools/label/SchematronTransformer.java
@@ -22,6 +22,7 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.util.HashMap;
 import java.util.Map;
+import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.Source;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerConfigurationException;
@@ -60,6 +61,7 @@ public class SchematronTransformer {
     // Use saxon for schematron (i.e. the XSLT generation).
     System.setProperty("javax.xml.transform.TransformerFactory",
         "net.sf.saxon.TransformerFactoryImpl");
+    DocumentBuilderFactory.newInstance().setNamespaceAware(true);
     TransformerFactory isoFactory = TransformerFactory.newInstance();
     // Set the resolver that will look in the jar for imports
     isoFactory.setURIResolver(new XslURIResolver());

--- a/src/main/java/gov/nasa/pds/tools/util/LabelParser.java
+++ b/src/main/java/gov/nasa/pds/tools/util/LabelParser.java
@@ -17,7 +17,7 @@ import javax.xml.transform.Source;
 import javax.xml.transform.TransformerException;
 import net.sf.saxon.Configuration;
 import net.sf.saxon.lib.ParseOptions;
-import net.sf.saxon.om.DocumentInfo;
+import net.sf.saxon.om.TreeInfo;
 import net.sf.saxon.xpath.XPathEvaluator;
 
 public class LabelParser {
@@ -29,15 +29,15 @@ public class LabelParser {
    * @return a DocumentInfo object.
    * @throws TransformerException
    */
-  public static DocumentInfo parse(Source source) throws TransformerException {
+  public static TreeInfo parse(Source source) throws TransformerException {
     XPathEvaluator xpath = new XPathEvaluator();
     Configuration configuration = xpath.getConfiguration();
     configuration.setLineNumbering(true);
     configuration.setXIncludeAware(Utility.supportXincludes());
     ParseOptions options = new ParseOptions();
-    options.setErrorListener(new XMLErrorListener());
-    options.setLineNumbering(true);
-    options.setXIncludeAware(Utility.supportXincludes());
-    return configuration.buildDocument(source, options);
+    options.withErrorHandler(new XMLErrorListener());
+    options.withLineNumbering(true);
+    options.withXIncludeAware(Utility.supportXincludes());
+    return configuration.buildDocumentTree(source, options);
   }
 }

--- a/src/main/java/gov/nasa/pds/tools/util/ReferentialIntegrityUtil.java
+++ b/src/main/java/gov/nasa/pds/tools/util/ReferentialIntegrityUtil.java
@@ -702,7 +702,7 @@ public class ReferentialIntegrityUtil {
     List<Target> children = new ArrayList<>();
     try {
       if (getContext().getCrawler() != null) {
-        children = getContext().getCrawler().crawl(parentURL, false); // Get also the directories.
+        children = getContext().getCrawler().crawl(parentURL, false, getContext().getFileFilters()); // Get also the directories.
       } else {
         LOG.warn("crawlParentForBundleLabel:getContext().getCrawler() is null for URL {}",
             crawlTarget);
@@ -771,7 +771,7 @@ public class ReferentialIntegrityUtil {
     try {
       List<Target> children = new ArrayList<>();
       if (getContext().getCrawler() != null) {
-        children = getContext().getCrawler().crawl(crawlTarget, true); // Get also the directories.
+        children = getContext().getCrawler().crawl(crawlTarget, true, getContext().getFileFilters()); // Get also the directories.
       } else {
         LOG.warn("additionalReferentialIntegrityChecks:getContext().getCrawler() is null");
       }

--- a/src/main/java/gov/nasa/pds/tools/util/Utility.java
+++ b/src/main/java/gov/nasa/pds/tools/util/Utility.java
@@ -90,6 +90,19 @@ public class Utility {
     }
     return valTarget;
   }
+  public static ValidationTarget getValidationTarget(URL source, URL label) {
+    if (source == null) {
+      // for backwards-compatability with previous code, supporting the null case.
+      // This seems to be null in the additional context products case.
+      return new ValidationTarget(null);
+    }
+    ValidationTarget valTarget = cachedTargets.get(source.toString());
+    if (valTarget == null) {
+      valTarget = new ValidationTarget(source, label);
+      cachedTargets.put(source.toString(), valTarget);
+    }
+    return valTarget;
+  }
 
   /**
    * Method that opens a connection. Supports redirects.
@@ -290,6 +303,23 @@ public class Utility {
     }
     if (TargetExaminer.isTargetCollectionType (url, true)) {
       return TargetType.COLLECTION;
+    }
+    return TargetType.FILE;
+  }
+  public static TargetType getTargetType(URL source, URL label) {
+    int extIndex = source.getPath().lastIndexOf(".");
+    if (isDir(source)) {
+      return TargetType.DIRECTORY;
+    }
+    if (label != null 
+        && -1 < extIndex
+        && label.getPath().toLowerCase().endsWith(source.getPath().substring(extIndex).toLowerCase())) {
+      if (TargetExaminer.isTargetBundleType (source, true)) {
+        return TargetType.BUNDLE;
+      }
+      if (TargetExaminer.isTargetCollectionType (source, true)) {
+        return TargetType.COLLECTION;
+      }
     }
     return TargetType.FILE;
   }

--- a/src/main/java/gov/nasa/pds/tools/util/XMLErrorListener.java
+++ b/src/main/java/gov/nasa/pds/tools/util/XMLErrorListener.java
@@ -15,6 +15,9 @@ package gov.nasa.pds.tools.util;
 
 import javax.xml.transform.ErrorListener;
 import javax.xml.transform.TransformerException;
+import org.xml.sax.ErrorHandler;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
 
 /**
  * Class that handles errors while parsing an XML file.
@@ -22,8 +25,7 @@ import javax.xml.transform.TransformerException;
  * @author mcayanan
  *
  */
-public class XMLErrorListener implements ErrorListener {
-
+public class XMLErrorListener implements ErrorListener,ErrorHandler {
   /**
    * Method is called when an error is encountered.
    *
@@ -61,4 +63,18 @@ public class XMLErrorListener implements ErrorListener {
     throw new TransformerException(exception);
   }
 
+  @Override
+  public void warning(SAXParseException exception) throws SAXException {
+    throw exception;
+  }
+
+  @Override
+  public void error(SAXParseException exception) throws SAXException {
+    throw exception;
+  }
+
+  @Override
+  public void fatalError(SAXParseException exception) throws SAXException {
+    throw exception;
+  }
 }

--- a/src/main/java/gov/nasa/pds/tools/util/XMLExtractor.java
+++ b/src/main/java/gov/nasa/pds/tools/util/XMLExtractor.java
@@ -26,6 +26,7 @@ import javax.xml.xpath.XPathExpressionException;
 import org.xml.sax.InputSource;
 import net.sf.saxon.Configuration;
 import net.sf.saxon.lib.ParseOptions;
+import net.sf.saxon.om.NamespaceUri;
 import net.sf.saxon.om.TreeInfo;
 import net.sf.saxon.trans.XPathException;
 import net.sf.saxon.tree.tiny.TinyNodeImpl;
@@ -66,7 +67,7 @@ public class XMLExtractor {
     configuration.setLineNumbering(true);
     configuration.setXIncludeAware(Utility.supportXincludes());
     String definedNamespace = getValueFromDoc("namespace-uri(/*)");
-    xpath.getStaticContext().setDefaultElementNamespace(definedNamespace);
+    xpath.getStaticContext().setDefaultElementNamespace(NamespaceUri.of (definedNamespace));
   }
 
   /**
@@ -83,11 +84,11 @@ public class XMLExtractor {
     configuration.setLineNumbering(true);
     configuration.setXIncludeAware(Utility.supportXincludes());
     ParseOptions options = new ParseOptions();
-    options.setErrorListener(new XMLErrorListener());
+    options.withErrorHandler(new XMLErrorListener());
     try {
-      xml = configuration.buildDocument(new SAXSource(Utility.getInputSourceByURL(url)), options);
+      xml = configuration.buildDocumentTree(new SAXSource(Utility.getInputSourceByURL(url)), options).getRootNode();
       String definedNamespace = getValueFromDoc("namespace-uri(/*)");
-      xpath.getStaticContext().setDefaultElementNamespace(definedNamespace);
+      xpath.getStaticContext().setDefaultElementNamespace(NamespaceUri.of (definedNamespace));
     } catch (IOException io) {
       throw new XPathException("Error while reading input: " + io.getMessage());
     }
@@ -99,10 +100,10 @@ public class XMLExtractor {
     configuration.setLineNumbering(true);
     configuration.setXIncludeAware(Utility.supportXincludes());
     ParseOptions options = new ParseOptions();
-    options.setErrorListener(new XMLErrorListener());
-    xml = configuration.buildDocument(new SAXSource(source), options);
+    options.withErrorHandler(new XMLErrorListener());
+    xml = configuration.buildDocumentTree(new SAXSource(source), options).getRootNode();
     String definedNamespace = getValueFromDoc("namespace-uri(/*)");
-    xpath.getStaticContext().setDefaultElementNamespace(definedNamespace);
+    xpath.getStaticContext().setDefaultElementNamespace(NamespaceUri.of(definedNamespace));
   }
 
   public XMLExtractor(File file)

--- a/src/main/java/gov/nasa/pds/tools/util/XslURIResolver.java
+++ b/src/main/java/gov/nasa/pds/tools/util/XslURIResolver.java
@@ -47,8 +47,9 @@ public class XslURIResolver implements URIResolver {
       ClassLoader cl = this.getClass().getClassLoader();
       InputStream in = cl.getResourceAsStream("schematron/" + href);
       InputSource xslInputSource = new InputSource(in);
-      Document xslDoc =
-          DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(xslInputSource);
+      DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+      factory.setNamespaceAware(true);
+      Document xslDoc = factory.newDocumentBuilder().parse(xslInputSource);
       DOMSource xslDomSource = new DOMSource(xslDoc);
       xslDomSource.setSystemId("schematron/" + href);
       return xslDomSource;

--- a/src/main/java/gov/nasa/pds/tools/validate/ContentProblem.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/ContentProblem.java
@@ -33,7 +33,7 @@ public class ContentProblem extends ValidationProblem {
    * @param label url of the label file.
    */
   public ContentProblem(ProblemDefinition defn, URL source, URL label) {
-    super(defn, source);
+    super(defn, source, label);
     this.label = label;
   }
 

--- a/src/main/java/gov/nasa/pds/tools/validate/TargetExaminer.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/TargetExaminer.java
@@ -24,7 +24,7 @@ import org.xml.sax.InputSource;
 import gov.nasa.pds.tools.util.LabelParser;
 import gov.nasa.pds.tools.util.Utility;
 import gov.nasa.pds.tools.util.XMLExtractor;
-import net.sf.saxon.om.DocumentInfo;
+import net.sf.saxon.om.TreeInfo;
 import net.sf.saxon.tree.tiny.TinyNodeImpl;
 
 /**
@@ -123,15 +123,18 @@ public class TargetExaminer extends Target {
     LOG.debug("tagMatches:url,tagCheck {},{}", url, tagCheck);
     boolean tagMatchedFlag = false;
 
+    if (!url.getPath().endsWith(".xml")) {
+      tagMatchedFlag = false;
+    }
     try {
       InputSource source = Utility.getInputSourceByURL(url);
       SAXSource saxSource = new SAXSource(source);
       saxSource.setSystemId(url.toString());
-      DocumentInfo docInfo = LabelParser.parse(saxSource); // Parses a label.
+      TreeInfo docInfo = LabelParser.parse(saxSource); // Parses a label.
       LOG.debug("tagMatches:docInfo {},{}", docInfo, docInfo.getClass());
       List<TinyNodeImpl> xmlModels = new ArrayList<>();
       try {
-        XMLExtractor extractor = new XMLExtractor(docInfo);
+        XMLExtractor extractor = new XMLExtractor(docInfo.getRootNode());
         xmlModels = extractor.getNodesFromDoc(tagCheck);
         LOG.debug("tagMatches:url,tagCheck,xmlModels.size() {},{},{}", url, tagCheck,
             xmlModels.size());
@@ -181,11 +184,11 @@ public class TargetExaminer extends Target {
       InputSource source = Utility.getInputSourceByURL(url);
       SAXSource saxSource = new SAXSource(source);
       saxSource.setSystemId(url.toString());
-      DocumentInfo docInfo = LabelParser.parse(saxSource); // Parses a label.
+      TreeInfo docInfo = LabelParser.parse(saxSource); // Parses a label.
       LOG.debug("getTargetContent:docInfo {},{}", docInfo, docInfo.getClass());
       List<TinyNodeImpl> xmlModels = new ArrayList<>();
       try {
-        XMLExtractor extractor = new XMLExtractor(docInfo);
+        XMLExtractor extractor = new XMLExtractor(docInfo.getRootNode());
         xmlModels = extractor.getNodesFromDoc(nodeCheck);
         LOG.debug("getTargetContent:url,nodeCheck,xmlModels.size() {},{},{}", url, nodeCheck,
             xmlModels.size());
@@ -226,10 +229,10 @@ public class TargetExaminer extends Target {
       InputSource source = Utility.getInputSourceByURL(url);
       SAXSource saxSource = new SAXSource(source);
       saxSource.setSystemId(url.toString());
-      DocumentInfo docInfo = LabelParser.parse(saxSource); // Parses a label.
+      TreeInfo docInfo = LabelParser.parse(saxSource); // Parses a label.
       @SuppressWarnings("unused")
       List<TinyNodeImpl> xmlModels = new ArrayList<>();
-      XMLExtractor extractor = new XMLExtractor(docInfo);
+      XMLExtractor extractor = new XMLExtractor(docInfo.getRootNode());
       xmlModels = extractor.getNodesFromDoc("logical_identifier");
       return true;
     } catch (Throwable t) {

--- a/src/main/java/gov/nasa/pds/tools/validate/ValidationProblem.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/ValidationProblem.java
@@ -68,6 +68,9 @@ public class ValidationProblem {
   public ValidationProblem(ProblemDefinition defn, URL target) {
     this(defn, Utility.getValidationTarget(target));
   }
+  public ValidationProblem(ProblemDefinition defn, URL source, URL label) {
+    this(defn, Utility.getValidationTarget(source, label));
+  }
 
   public ValidationProblem(ProblemDefinition defn, ValidationTarget target) {
     this(defn, target, -1, -1, null);

--- a/src/main/java/gov/nasa/pds/tools/validate/ValidationTarget.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/ValidationTarget.java
@@ -38,10 +38,16 @@ public class ValidationTarget implements Comparable<ValidationTarget> {
    * @param target the target file or directory
    */
   public ValidationTarget(URL target) {
+    this(target, null);
+  }
+  public ValidationTarget(URL target, URL label) {
     this.url = target;
     if (target != null) {
-      type = Utility.getTargetType(target);
-
+      if (label == null) {
+        type = Utility.getTargetType(target);
+      } else {
+        type = Utility.getTargetType(target, label);
+      }
       location = target.toString();
       // In case we have a directory, we need to remove the backslash at the end
       // to properly get the name

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/RegisterTargets.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/RegisterTargets.java
@@ -14,7 +14,6 @@
 package gov.nasa.pds.tools.validate.rule;
 
 import java.net.URISyntaxException;
-import java.util.Arrays;
 import gov.nasa.pds.tools.util.Utility;
 import gov.nasa.pds.tools.validate.Target;
 import gov.nasa.pds.tools.validate.TargetRegistrar;
@@ -49,9 +48,6 @@ public class RegisterTargets extends AbstractValidationRule {
       try {
         Crawler crawler = getContext().getCrawler();
         WildcardOSFilter fileFilter = getContext().getFileFilters();
-        if (!"PDS4 Directory".equalsIgnoreCase(getContext().getRule().getCaption())) {
-          fileFilter = new WildcardOSFilter(Arrays.asList(new String[] {"*"}));
-        }
         for (Target child : crawler.crawl(getTarget(), getContext().isRecursive(), fileFilter)) {
           try {
             String childLocation = child.getUrl().toURI().normalize().toString();

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/BundleReferentialIntegrityRule.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/BundleReferentialIntegrityRule.java
@@ -84,7 +84,7 @@ public class BundleReferentialIntegrityRule extends AbstractValidationRule {
 
     URL bundleURL = null;
     try {
-      List<Target> children = getContext().getCrawler().crawl(getTarget());
+      List<Target> children = getContext().getCrawler().crawl(getTarget(), getContext().getFileFilters());
       LOG.debug("bundleReferentialIntegrityRule:getTarget() {}", getTarget());
       LOG.debug("bundleReferentialIntegrityRule:children.size():afor_reduced: {}", children.size());
 

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/FileReferenceValidationRule.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/FileReferenceValidationRule.java
@@ -52,7 +52,8 @@ import gov.nasa.pds.tools.validate.ValidationTarget;
 import gov.nasa.pds.tools.validate.content.AudioVideo;
 import gov.nasa.pds.tools.validate.rule.AbstractValidationRule;
 import gov.nasa.pds.tools.validate.rule.ValidationTest;
-import net.sf.saxon.om.DocumentInfo;
+import net.sf.saxon.om.NodeInfo;
+import net.sf.saxon.om.TreeInfo;
 import net.sf.saxon.tree.tiny.TinyNodeImpl;
 
 /**
@@ -111,9 +112,9 @@ public class FileReferenceValidationRule extends AbstractValidationRule {
     DOMSource source = new DOMSource(label);
     source.setSystemId(uri.toString());
     try {
-      DocumentInfo xml = LabelParser.parse(source);
+      TreeInfo xml = LabelParser.parse(source);
       LOG.debug("FileReferenceValidationRule:validateFileReferences:uri {}", uri);
-      validate(xml);
+      validate(xml.getRootNode());
     } catch (TransformerException te) {
       ProblemDefinition pd =
           new ProblemDefinition(ExceptionType.ERROR, ProblemType.INTERNAL_ERROR, te.getMessage());
@@ -153,7 +154,7 @@ public class FileReferenceValidationRule extends AbstractValidationRule {
     }
   }
 
-  private boolean validate(DocumentInfo xml) {
+  private boolean validate(NodeInfo xml) {
     this.target = new ValidationTarget(getTarget());
 
     try {

--- a/src/main/resources/util/registered_context_products.json
+++ b/src/main/resources/util/registered_context_products.json
@@ -101,69 +101,6 @@
           },
           {
                "name": [
-                    "49036 PELION"
-               ],
-               "type": [
-                    "CENTAUR"
-               ],
-               "lidvid": "urn:nasa:pds:context:target:centaur.49036_pelion::1.0"
-          },
-          {
-               "name": [
-                    "(182933) 2002 GZ31"
-               ],
-               "type": [
-                    "TRANS-NEPTUNIAN OBJECT"
-               ],
-               "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.182933_2002_gz31::1.0"
-          },
-          {
-               "name": [
-                    "(243) IDA I (DACTYL)"
-               ],
-               "type": [
-                    "ASTEROID"
-               ],
-               "lidvid": "urn:nasa:pds:context:target:satellite.243_ida.dactyl::1.0"
-          },
-          {
-               "name": [
-                    "20 MASSALIA"
-               ],
-               "type": [
-                    "ASTEROID"
-               ],
-               "lidvid": "urn:nasa:pds:context:target:asteroid.20_massalia::1.1"
-          },
-          {
-               "name": [
-                    "65489 CETO"
-               ],
-               "type": [
-                    "TRANS-NEPTUNIAN OBJECT"
-               ],
-               "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.65489_ceto::1.1"
-          },
-          {
-               "name": [
-                    "SURFACE ELECTRIC SOUNDING AND ACOUSTIC MONITORING EXPERIMENT"
-               ],
-               "type": [
-                    "N/A"
-               ],
-               "lidvid": "urn:esa:psa:context:instrument:rl.sesame::1.0"
-          },
-          {
-               "name": [
-                    "ALNILAM"
-               ],
-               "type": [
-                    "STAR"
-               ],
-               "lidvid": "urn:nasa:pds:context:target:star.eps_ori::1.0"
-          },
-          {
-               "name": [
                     "GALILEO ORBITER STAR SCANNER"
                ],
                "type": [
@@ -6239,39 +6176,57 @@
           },
           {
                "name": [
-                    "FRONT HAZARD AVOIDANCE CAMERA LEFT STRING A"
+                    "2006 HW122"
                ],
                "type": [
-                    "IMAGER"
+                    "TRANS-NEPTUNIAN OBJECT"
                ],
-               "lidvid": "urn:nasa:pds:context:instrument:fhaz_left_a.msl::1.0"
+               "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2006_hw122::1.0"
           },
           {
                "name": [
-                    "THERMO NICOLET NEXUS 870 FTIR WITH PIKE AUTODIFF DIFFUSE REFLECTANCE ACCESSORY"
+                    "D/1993 F2-G (SHOEMAKER-LEVY 9-G)"
                ],
                "type": [
-                    "SPECTROMETER"
+                    "COMET"
                ],
-               "lidvid": "urn:nasa:pds:context:instrument:relab.bcf-ftir2::1.0"
+               "lidvid": "urn:nasa:pds:context:target:comet.d1993_f2-g_shoemaker-levy_9-g::1.0"
           },
           {
                "name": [
-                    "N/A"
+                    "MINI-RF LRO"
                ],
                "type": [
-                    "N/A"
+                    "RADIO-RADAR"
                ],
-               "lidvid": "urn:nasa:pds:context:telescope:ctio-cerro_tololo.smarts_1m0::1.0"
+               "lidvid": "urn:nasa:pds:context:instrument:mrflro.lro::1.0"
           },
           {
                "name": [
-                    "N/A"
+                    "106P/SCHUSTER"
+               ],
+               "type": [
+                    "COMET"
+               ],
+               "lidvid": "urn:nasa:pds:context:target:comet.106p_schuster::1.0"
+          },
+          {
+               "name": [
+                    "ION PROPULSION SYSTEM DIAGNOSTIC SUBSYSTEM"
+               ],
+               "type": [
+                    "PLASMA WAVE SPECTROMETER"
+               ],
+               "lidvid": "urn:nasa:pds:context:instrument:ids.ds1::1.0"
+          },
+          {
+               "name": [
+                    "PORTABLE METEROLOGICAL STATION (RALPH LORENZ DESIGN)"
                ],
                "type": [
                     "N/A"
                ],
-               "lidvid": "urn:nasa:pds:context:telescope:ctio-cerro_tololo.victorblanco_4m0::1.0"
+               "lidvid": "urn:nasa:pds:context:instrument:no-host.lorenz_met_station::1.0"
           },
           {
                "name": [
@@ -12959,24 +12914,6 @@
           },
           {
                "name": [
-                    "N/A"
-               ],
-               "type": [
-                    "N/A"
-               ],
-               "lidvid": "urn:nasa:pds:context_pds3:node:node.en::1.0"
-          },
-          {
-               "name": [
-                    "N/A"
-               ],
-               "type": [
-                    "N/A"
-               ],
-               "lidvid": "urn:nasa:pds:context_pds3:node:node.pds-mgt::1.0"
-          },
-          {
-               "name": [
                     "C/1979 S1 (MEIER)"
                ],
                "type": [
@@ -13037,6 +12974,24 @@
                     "COMET"
                ],
                "lidvid": "urn:nasa:pds:context:target:comet.132p_helin-roman-alu_2::1.0"
+          },
+          {
+               "name": [
+                    "N/A"
+               ],
+               "type": [
+                    "N/A"
+               ],
+               "lidvid": "urn:nasa:pds:context_pds3:node:node.en::1.0"
+          },
+          {
+               "name": [
+                    "N/A"
+               ],
+               "type": [
+                    "N/A"
+               ],
+               "lidvid": "urn:nasa:pds:context_pds3:node:node.pds-mgt::1.0"
           },
           {
                "name": [
@@ -19501,6 +19456,69 @@
           },
           {
                "name": [
+                    "49036 PELION"
+               ],
+               "type": [
+                    "CENTAUR"
+               ],
+               "lidvid": "urn:nasa:pds:context:target:centaur.49036_pelion::1.0"
+          },
+          {
+               "name": [
+                    "(182933) 2002 GZ31"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
+               "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.182933_2002_gz31::1.0"
+          },
+          {
+               "name": [
+                    "(243) IDA I (DACTYL)"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
+               "lidvid": "urn:nasa:pds:context:target:satellite.243_ida.dactyl::1.0"
+          },
+          {
+               "name": [
+                    "20 MASSALIA"
+               ],
+               "type": [
+                    "ASTEROID"
+               ],
+               "lidvid": "urn:nasa:pds:context:target:asteroid.20_massalia::1.1"
+          },
+          {
+               "name": [
+                    "65489 CETO"
+               ],
+               "type": [
+                    "TRANS-NEPTUNIAN OBJECT"
+               ],
+               "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.65489_ceto::1.1"
+          },
+          {
+               "name": [
+                    "SURFACE ELECTRIC SOUNDING AND ACOUSTIC MONITORING EXPERIMENT"
+               ],
+               "type": [
+                    "N/A"
+               ],
+               "lidvid": "urn:esa:psa:context:instrument:rl.sesame::1.0"
+          },
+          {
+               "name": [
+                    "ALNILAM"
+               ],
+               "type": [
+                    "STAR"
+               ],
+               "lidvid": "urn:nasa:pds:context:target:star.eps_ori::1.0"
+          },
+          {
+               "name": [
                     "15810 ARAWN"
                ],
                "type": [
@@ -23114,57 +23132,39 @@
           },
           {
                "name": [
-                    "2006 HW122"
+                    "FRONT HAZARD AVOIDANCE CAMERA LEFT STRING A"
                ],
                "type": [
-                    "TRANS-NEPTUNIAN OBJECT"
+                    "IMAGER"
                ],
-               "lidvid": "urn:nasa:pds:context:target:trans-neptunian_object.2006_hw122::1.0"
+               "lidvid": "urn:nasa:pds:context:instrument:fhaz_left_a.msl::1.0"
           },
           {
                "name": [
-                    "D/1993 F2-G (SHOEMAKER-LEVY 9-G)"
+                    "THERMO NICOLET NEXUS 870 FTIR WITH PIKE AUTODIFF DIFFUSE REFLECTANCE ACCESSORY"
                ],
                "type": [
-                    "COMET"
+                    "SPECTROMETER"
                ],
-               "lidvid": "urn:nasa:pds:context:target:comet.d1993_f2-g_shoemaker-levy_9-g::1.0"
+               "lidvid": "urn:nasa:pds:context:instrument:relab.bcf-ftir2::1.0"
           },
           {
                "name": [
-                    "MINI-RF LRO"
-               ],
-               "type": [
-                    "RADIO-RADAR"
-               ],
-               "lidvid": "urn:nasa:pds:context:instrument:mrflro.lro::1.0"
-          },
-          {
-               "name": [
-                    "106P/SCHUSTER"
-               ],
-               "type": [
-                    "COMET"
-               ],
-               "lidvid": "urn:nasa:pds:context:target:comet.106p_schuster::1.0"
-          },
-          {
-               "name": [
-                    "ION PROPULSION SYSTEM DIAGNOSTIC SUBSYSTEM"
-               ],
-               "type": [
-                    "PLASMA WAVE SPECTROMETER"
-               ],
-               "lidvid": "urn:nasa:pds:context:instrument:ids.ds1::1.0"
-          },
-          {
-               "name": [
-                    "PORTABLE METEROLOGICAL STATION (RALPH LORENZ DESIGN)"
+                    "N/A"
                ],
                "type": [
                     "N/A"
                ],
-               "lidvid": "urn:nasa:pds:context:instrument:no-host.lorenz_met_station::1.0"
+               "lidvid": "urn:nasa:pds:context:telescope:ctio-cerro_tololo.smarts_1m0::1.0"
+          },
+          {
+               "name": [
+                    "N/A"
+               ],
+               "type": [
+                    "N/A"
+               ],
+               "lidvid": "urn:nasa:pds:context:telescope:ctio-cerro_tololo.victorblanco_4m0::1.0"
           },
           {
                "name": [

--- a/src/site/xdoc/index.xml
+++ b/src/site/xdoc/index.xml
@@ -1,7 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document xmlns="http://maven.apache.org/XDOC/2.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 http://maven.apache.org/xsd/xdoc-2.0.xsd">
+<!--
+Copyright © 2019, California Institute of Technology ("Caltech").
+U.S. Government sponsorship acknowledged.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+• Redistributions of source code must retain the above copyright notice,
+  this list of conditions and the following disclaimer.
+• Redistributions must reproduce the above copyright notice, this list of
+  conditions and the following disclaimer in the documentation and/or other
+  materials provided with the distribution.
+• Neither the name of Caltech nor its operating division, the Jet Propulsion
+  Laboratory, nor the names of its contributors may be used to endorse or
+  promote products derived from this software without specific prior written
+  permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+-->
+
+<document>
   <properties>
     <title>About Validate Tool</title>
   </properties>
@@ -12,13 +42,15 @@
       </p>
      
       <ul>
-        <li><a href="#tool-overview">Tool Overview</a></li>
-        <li><a href="#support">Support</a></li>
+        <li><a href="#Tool_Overview">Tool Overview</a></li>
+        <li><a href="#Support">Support</a></li>
       </ul>
      
     </section>
+    
+    <hr />
 
-    <section name="Tool Overview" id="tool-overview">
+    <section name="Tool Overview">
       <p>The Validate Tool currently supports the following features:
       </p>
       
@@ -76,12 +108,14 @@
       </ul>
     </section>
     
-    <section name="Support" id="support">
+    <hr />
+    
+    <section name="Support">
       <p><b><i>Found a bug?</i></b> Or <b><i>want a new feature?</i></b> We would love your feedback and contributions. Here are some links to our public Github repository for source code and submitting issues:</p>
       
       <ul>
-        <li>Submit for a New Feature: <a href="https://github.com/NASA-PDS/validate/issues/new?template=feature_request.yml">https://github.com/NASA-PDS/validate/issues/new?template=feature_request.yml</a></li>
-        <li>Submit a Bug: <a href="https://github.com/NASA-PDS/validate/issues/new?template=bug_report.yml">https://github.com/NASA-PDS/validate/issues/new?template=bug_report.yml</a></li>
+        <li>Submit for a New Feature: <a href="https://github.com/NASA-PDS/validate/issues/new?template=feature_request.md">https://github.com/NASA-PDS/validate/issues/new?template=feature_request.md</a></li>
+        <li>Submit a Bug: <a href="https://github.com/NASA-PDS/validate/issues/new?template=bug_report.md">https://github.com/NASA-PDS/validate/issues/new?template=bug_report.md</a></li>
         <li>Source Code: <a href="https://github.com/NASA-PDS/validate/">https://github.com/NASA-PDS/validate</a></li>
       </ul>
       

--- a/src/site/xdoc/install/index.xml.vm
+++ b/src/site/xdoc/install/index.xml.vm
@@ -1,7 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document xmlns="http://maven.apache.org/XDOC/2.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 http://maven.apache.org/xsd/xdoc-2.0.xsd">
+
+<!--
+Copyright © 2019, California Institute of Technology ("Caltech").
+U.S. Government sponsorship acknowledged.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+• Redistributions of source code must retain the above copyright notice,
+  this list of conditions and the following disclaimer.
+• Redistributions must reproduce the above copyright notice, this list of
+  conditions and the following disclaimer in the documentation and/or other
+  materials provided with the distribution.
+• Neither the name of Caltech nor its operating division, the Jet Propulsion
+  Laboratory, nor the names of its contributors may be used to endorse or
+  promote products derived from this software without specific prior written
+  permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+-->
+
+<document>
   <properties>
     <title>Installation</title>
   </properties>
@@ -10,17 +41,17 @@
     <section name="Installation">
       <p>This document describes how to install the Validate Tool software contained in the <i>${project.artifactId}</i> package. The following topics can be found in this document:
       </p>
-      
-      <ul>
-        <li><a href="#quick-start">Quick Start</a></li>
-        <li><a href="#system-requirements">System Requirements</a></li>
-        <li><a href="#unpacking-the-package">Unpacking the Package</a></li>
-        <li><a href="#configuring-the-environment">Configuring the Environment</a></li>
-      </ul>
 
+      <ul>
+        <li><a href="#Getting_Started">Getting Started</a></li>
+        <li><a href="#Unpacking_the_Package">Unpacking the Package</a></li>
+        <li><a href="#System_Requirements">System Requirements</a></li>
+        <li><a href="#Configuring_the_Environment">Configuring the Environment</a></li>
+        <li><a href="../index.html#Support">Tool Support</a></li>
+      </ul>
     </section>
     
-    <section name="Quick Start" id="quick-start">
+    <section name="Quick Start">
       <p>Initially, Validate Tool works out of the box without needing to perform any additional function:</p>
       
       <ul>
@@ -35,7 +66,7 @@
       </ul>
     </section>
     
-    <section name="Unpacking the Package" id="unpacking-the-package">
+    <section name="Unpacking the Package">
       <p>Download the <i>${project.artifactId}</i> package from <a href="https://github.com/NASA-PDS/${project.artifactId}/releases/v${project.version}" target="_blank">Github</a>. The binary distribution is available in identical zip or tar/gzip packages. The installation directory may vary from environment to environment but in UNIX-based environments it is typical to install software packages in the <i>/usr/local</i> directory and in Windows-based environments it is typical to install software packages in the <i>C:\Program Files</i> directory. Unpack the selected binary distribution file with one of the following commands:
       </p>
       
@@ -79,7 +110,7 @@ or
       </ul>
     </section>
 
-    <section name="System Requirements" id="system-requirements">
+    <section name="System Requirements">
       <p>If you run into issues attempting to run Validate out of the box, this section details the system requirements for installing and operating the Validate Tool.
       </p>
 
@@ -97,16 +128,14 @@ OpenJDK Runtime Environment (build 15.0.1+9)
 OpenJDK 64-Bit Server VM (build 15.0.1+9, mixed mode, sharing)
         </source>
 
-        <p><i>NOTE: Validate requires 64-bit Java in order to enable Java Virtual Machine memory requirements. In version output above, note the line <b>Java HotSpot(TM) 64-Bit Server VM</b></i>.</p>
-        
-        <p><i><b>For Windows Users:</b> The 32-bit JRE is the default on Windows, and even the the online installer for Windows on the <a href="https://www.java.com/en/download/manual.jsp">Java Download All Operating Systems page</a> only installs the 32-bit JRE. If you see an error like that described under <a href="/validate/operate/errors.html#invalid-heap">this common error</a>, you have the wrong JRE installed.</i></p>
+        <p><i>NOTE: Validate requires 64-bit Java in order to enable Java Virtual Machine memory requirements. In version output above, note the line <b>Java HotSpot(TM) 64-Bit Server VM</b></i></p>
 
         <p>If the either of these commands fail, it indicates Java is not installed or the version is not at least 1.9. Consult the local system administrator for installation of this software. For the do-it-yourself crowd, the Java software can be downloaded from the <a href="https://openjdk.java.net/install/" target="_blank">Java Download</a> page.
         </p>
       </subsection>
     </section>
 
-    <section name="Configuring the Environment" id="configuring-the-environment">
+    <section name="Configuring the Environment">
       <p>If you want to run Validate from anywhere on your system, you will need to configure your PATH to know where Validate is located. This section describes how to setup the user environment on UNIX-based and Windows machines.
       </p>
 
@@ -150,17 +179,14 @@ OpenJDK 64-Bit Server VM (build 15.0.1+9, mixed mode, sharing)
         </p>
 
         <source>
-C:\&gt; set Path=%Path%;C:\Program Files\\${project.artifactId}-${project.version}\bin
+C:\&gt; set PATH = %PATH%;C:\Program Files\\${project.artifactId}-${project.version}\bin
         </source>
 
         <p>In addition, the batch scripts require that the <i>JAVA_HOME</i> environment variable be set to the appropriate location of the Java installation on the local machine. This may have already been set when Java was installed. However, if it hasn't, then run the following command to set the <i>JAVA_HOME</i> environment variable:
         </p>
 
         <source>
-C:\&gt; set JAVA_HOME=C:\path\to\java\home
-
-# For example
-C:\&gt; set JAVA_HOME=C:\Program Files\Java\some-jre-version
+C:\&gt; set JAVA_HOME = C:\path\to\java\home
         </source>
 
         <p>The system administrator for the local machine may need to be consulted for this location. The path specified should have a <i>bin</i> sub-directory that contains the <i>java</i> executable. This variable may also be defined within the scripts. Edit the scripts (files with the .bat extension) and change the line in the example above to represent the local Java installation. Additional methods for setting Windows environment variables can be found in the <a href="index-win.html">Windows System Properties</a> document.

--- a/src/site/xdoc/operate/errors.xml.vm
+++ b/src/site/xdoc/operate/errors.xml.vm
@@ -1,9 +1,41 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document xmlns="http://maven.apache.org/XDOC/2.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 http://maven.apache.org/xsd/xdoc-2.0.xsd">
+
+<!--
+Copyright © 2019, California Institute of Technology ("Caltech").
+U.S. Government sponsorship acknowledged.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+• Redistributions of source code must retain the above copyright notice,
+  this list of conditions and the following disclaimer.
+• Redistributions must reproduce the above copyright notice, this list of
+  conditions and the following disclaimer in the documentation and/or other
+  materials provided with the distribution.
+• Neither the name of Caltech nor its operating division, the Jet Propulsion
+  Laboratory, nor the names of its contributors may be used to endorse or
+  promote products derived from this software without specific prior written
+  permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+-->
+
+<document>
   <properties>
     <title>Common Errors</title>
+    <author email="jordan.h.padams@jpl.nasa.gov">Jordan Padams</author>
   </properties>
 
   <body>
@@ -16,19 +48,17 @@
         If you would like to contribute to this page, please create a pull request or issue on our <a href="https://github.com/NASA-PDS/validate/">GitHub</a> 
         repository or email the <a href="mailto:pds_operator@jpl.nasa.gov">PDS Operator</a> with input. Thanks in advance for helping your fellow users.
       </p>
-      
+
       <ul>
-        <li><a href="#whitespace">White spaces are required error</a></li>
-        <li><a href="#outofmemory">java.lang.OutOfMemoryError</a></li>
-        <li><a href="#nochecksum">No checksum found in the manifest errors</a></li>
-        <li><a href="#fields-mismatch">error.table.fields_mismatch</a></li>
-        <li><a href="#context-ref-mismatch">error.label.context_ref_mismatch</a></li>
-        <li><a href="#invalid-heap">Invalid maximum heap size</a></li>
-        <li><a href="#pdfa-issues">PDF/A Issues</a></li>
+        <li><a href="#White_spaces_are_required_error">White spaces are required error</a></li>
+        <li><a href="#java.lang.OutOfMemoryError">java.lang.OutOfMemoryError</a></li>
+        <li><a href="#No_checksum_found_in_the_manifest_errors">No checksum found in the manifest errors</a></li>
+        <li><a href="#error.table.fields_mismatch">error.table.fields_mismatch</a></li>
+        <li><a href="#error.label.context_ref_mismatch">error.label.context_ref_mismatch</a></li>
       </ul>
     </section>
 
-    <section name="White spaces are required error" id="whitespace">
+    <section name="White spaces are required error">
       
       <p>Execution of the Validate Tool may result in the following message appearing in the log:
       </p>
@@ -42,7 +72,7 @@ FAIL: file:/Users/.../hi0173794441_9080000_001_r.xml
       </p>
     </section>
       
-    <section name="java.lang.OutOfMemoryError" id="outofmemory">
+    <section name="java.lang.OutOfMemoryError">
       <p><b><i>Exception in thread "main" java.lang.OutOfMemoryError: GC overhead limit exceeded</i></b></p>
       
       <p>Running the tool against a large bundle may result in an OutOfMemoryError exception appearing in the standard error similar to the following:
@@ -83,7 +113,7 @@ Exception in thread "main" java.lang.OutOfMemoryError: GC overhead limit exceede
 
     </section>
       
-    <section name="No checksum found in the manifest errors" id="nochecksum">
+    <section name="No checksum found in the manifest errors">
       
       <p>When performing Checksum Manifest file validation, having the wrong base path setting will result in multiple errors like the following:
       </p>
@@ -98,7 +128,7 @@ FAIL: file:/home/pds4/dph_example_archive_VG2PLS/browse/Collection_browse.xml
       
     </section>
     
-    <section name="error.table.fields_mismatch" id="fields-mismatch">
+    <section name="error.table.fields_mismatch">
       <p><b>Debugging</b></p>
       <p>The error indicates the fields do not match the table defined in the label. Here are some things you can check to find out where it is failing:</p>
       <ul>
@@ -108,7 +138,7 @@ FAIL: file:/home/pds4/dph_example_archive_VG2PLS/browse/Collection_browse.xml
       </ul>
     </section>
     
-    <section name="error.label.context_ref_mismatch" id="context-ref-mismatch">
+    <section name="error.label.context_ref_mismatch">
       <p><b>Description</b></p>
       <p>
         New to Validate 1.16.0, this feature does a performs a check of the <i>name</i> and <i>type</i> values associated with
@@ -125,7 +155,7 @@ FAIL: file:/home/pds4/dph_example_archive_VG2PLS/browse/Collection_browse.xml
       </ul>
     </section>
     
-    <section name="Invalid maximum heap size" id="invalid-heap">
+    <section name="Invalid maximum heap size">
       <p><b>Description</b></p>
       <p>
         When attempting to run validate, you get the following error:
@@ -148,7 +178,7 @@ OpenJDK 64-Bit Server VM (build 15.0.1+9, mixed mode, sharing)
       </source>
     </section>
     
-    <section name="PDF/A Issues" id="pdfa-issues">
+    <section name="PDF/A Issues">
       <p><b>Description</b></p>
       <p>
         When attempting to validate a Document product as PDF/A, you get an error like:

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.21.0"
+      version = "~> 4.0.0"
     }
   }
 }


### PR DESCRIPTION
## 🗒️ Summary
The new SAXON libraries are more pedantic about processing XML files. It now generates warning and errors that cannot be squashed - well I could not find the wire to cut to the blinking red light. Instead, changed validate so that it would not ask SAXON to parse files that do not have the XML extension given by the user or defined by default.

## ⚙️ Test Data and/or Report
All automated unit tests should pass

## ♻️ Related Issues
Closes #707
Closes #726 