### PR TITLE
Fix intermittent bug with reading schematrons per Saxon upgrade

### DIFF
--- a/src/main/java/gov/nasa/pds/tools/label/SchematronTransformer.java
+++ b/src/main/java/gov/nasa/pds/tools/label/SchematronTransformer.java
@@ -154,7 +154,12 @@ public class SchematronTransformer {
         in = Utility.openConnection(conn);
 
         StreamSource source = new StreamSource(in);
-        //source.setSystemId(schematron.toString());
+        /* This fixes the problem but is it a good fix. The message now indicates that it is finding
+         * the same URI (systemId) for two files. The one it is reading and the source that we have?
+         * Maybe in saxon 12.3 it fills in the systemId correctly? Cannot find anything that makes
+         * this fix definitive good or bad but that is a search skill problem not lack of information
+         * 
+         * source.setSystemId(schematron.toString()); */
         isoTransformer.transform(source, new StreamResult(schematronStyleSheet));
         transformer = transformerFactory
             .newTransformer(new StreamSource(new StringReader(schematronStyleSheet.toString())));

--- a/src/main/java/gov/nasa/pds/tools/label/SchematronTransformer.java
+++ b/src/main/java/gov/nasa/pds/tools/label/SchematronTransformer.java
@@ -154,7 +154,7 @@ public class SchematronTransformer {
         in = Utility.openConnection(conn);
 
         StreamSource source = new StreamSource(in);
-        source.setSystemId(schematron.toString());
+        //source.setSystemId(schematron.toString());
         isoTransformer.transform(source, new StreamResult(schematronStyleSheet));
         transformer = transformerFactory
             .newTransformer(new StreamSource(new StringReader(schematronStyleSheet.toString())));

--- a/src/main/java/gov/nasa/pds/tools/label/TransformerErrorListener.java
+++ b/src/main/java/gov/nasa/pds/tools/label/TransformerErrorListener.java
@@ -88,6 +88,9 @@ public class TransformerErrorListener implements ErrorListener {
   @Override
   public void warning(TransformerException exception) throws TransformerException {
     SourceLocator locator = exception.getLocator();
+    if (locator == null) {
+      locator = this.nullLocator;
+    }
     addProblem(ExceptionType.WARNING, ProblemType.SCHEMATRON_WARNING, exception.getMessage(),
         locator.getSystemId(), locator.getLineNumber(), locator.getColumnNumber());
   }

--- a/src/main/java/gov/nasa/pds/tools/label/TransformerErrorListener.java
+++ b/src/main/java/gov/nasa/pds/tools/label/TransformerErrorListener.java
@@ -33,7 +33,29 @@ import gov.nasa.pds.tools.validate.ValidationProblem;
  */
 public class TransformerErrorListener implements ErrorListener {
   private ProblemHandler handler;
+  private class DefaultSourceLocator implements SourceLocator{
 
+    @Override
+    public String getPublicId() {
+      return "null";
+    }
+
+    @Override
+    public String getSystemId() {
+      return "null";
+    }
+
+    @Override
+    public int getLineNumber() {
+      return -1;
+    }
+
+    @Override
+    public int getColumnNumber() {
+      return -1;
+    }
+  }
+  final private SourceLocator nullLocator = new DefaultSourceLocator();
   /**
    * Constructor.
    *
@@ -46,6 +68,9 @@ public class TransformerErrorListener implements ErrorListener {
   @Override
   public void error(TransformerException exception) throws TransformerException {
     SourceLocator locator = exception.getLocator();
+    if (locator == null) {
+      locator = this.nullLocator;
+    }
     addProblem(ExceptionType.ERROR, ProblemType.SCHEMATRON_ERROR, exception.getMessage(),
         locator.getSystemId(), locator.getLineNumber(), locator.getColumnNumber());
   }
@@ -53,6 +78,9 @@ public class TransformerErrorListener implements ErrorListener {
   @Override
   public void fatalError(TransformerException exception) throws TransformerException {
     SourceLocator locator = exception.getLocator();
+    if (locator == null) {
+      locator = this.nullLocator;
+    }
     addProblem(ExceptionType.FATAL, ProblemType.SCHEMATRON_ERROR, exception.getMessage(),
         locator.getSystemId(), locator.getLineNumber(), locator.getColumnNumber());
   }


### PR DESCRIPTION
## 🗒️ Summary
Fixed a bad use of null and replaced it with a NullObject that behaves like an object returning obviously null information but preventing null pointer exceptions while handling exceptions.

## ⚙️ Test Data and/or Report
All unit tests pass

## ♻️ Related Issues
Closes #739 
Refs #707