### PR TITLE
Fix validate.bat java execution bug

### DIFF
--- a/src/main/resources/bin/validate-refs.bat
+++ b/src/main/resources/bin/validate-refs.bat
@@ -61,6 +61,6 @@ for %%i in ("%LIB_DIR%"\validate-*.jar) do set VALIDATE_JAR=%%i
 :: Executes the Validate Tool via the executable jar file
 :: The special variable '%*' allows the arguments
 :: to be passed into the executable.
-"%JAVA_HOME%"\bin\java -Xms2048m -Xmx4096m -Dresources.home="%PARENT_DIR%"\resources -Dcom.sun.xml.bind.v2.bytecode.ClassTailor.noOptimize=true -Djava.util.logging.config.file=logging.properties -cp "%VALIDATE_JAR%" gov.nasa.pds.validate.ReferenceIntegrityMain %*
+"%JAVA_HOME%\bin\java" -Xms2048m -Xmx4096m -Dresources.home="%PARENT_DIR%"\resources -Dcom.sun.xml.bind.v2.bytecode.ClassTailor.noOptimize=true -Djava.util.logging.config.file=logging.properties -cp "%VALIDATE_JAR%" gov.nasa.pds.validate.ReferenceIntegrityMain %*
 
 :END

--- a/src/main/resources/bin/validate.bat
+++ b/src/main/resources/bin/validate.bat
@@ -61,6 +61,6 @@ for %%i in ("%LIB_DIR%"\validate-*.jar) do set VALIDATE_JAR=%%i
 :: Executes the Validate Tool via the executable jar file
 :: The special variable '%*' allows the arguments
 :: to be passed into the executable.
-"%JAVA_HOME%"\bin\java -Xms2048m -Xmx4096m -Dresources.home="%PARENT_DIR%"\resources -Dcom.sun.xml.bind.v2.bytecode.ClassTailor.noOptimize=true -Djava.util.logging.config.file=logging.properties -jar "%VALIDATE_JAR%" %*
+"%JAVA_HOME%\bin\java" -Xms2048m -Xmx4096m -Dresources.home="%PARENT_DIR%"\resources -Dcom.sun.xml.bind.v2.bytecode.ClassTailor.noOptimize=true -Djava.util.logging.config.file=logging.properties -jar "%VALIDATE_JAR%" %*
 
 :END


### PR DESCRIPTION
## 🗒️ Summary
Fix bug with placement of quotes in validate.bat when trying to run java via command-line. Not sure why this breaks in the environment we have setup, and it has not been noticed by other users, but this should work for others as well.

```
C:\Users\jpadams\Downloads\validate-3.3.1-bin\validate-3.3.1\bin>validate.bat --help
usage: validate <target> <options>
    --add-context-products <dir/files>   Explicitly specify a JSON file (or
                                         directory of files) containing
                                         additional context product information
                                         used for validation. WARNING: This
                                         should only be used for development
                                         purposes. All context products must be
                                         registered for validity of a product in
                                         an archive.
    --allow-unlabeled-files              Tells the tool to not check for
                                         unlabeled files in a bundle or
                                         collection.
    --alternate_file_paths <path>        This flag will allow for additional
                                         paths to be specified when attempting
                                         referential integrity validation
                                         (pds4.bundle or pds4.collection rules).
                                         FOR DEVELOPMENT PURPOSES ONLY
 -B,--base-path <path>                   Specify a path for the tool to use in
...
```