### PR TITLE
Add docker container deployment steps

### DIFF
--- a/.github/workflows/stable-cicd.yaml
+++ b/.github/workflows/stable-cicd.yaml
@@ -80,10 +80,9 @@ jobs:
                     ADMIN_GITHUB_TOKEN: ${{secrets.ADMIN_GITHUB_TOKEN}}
 
             -
-                name: 🫙 Jar and Tag Determination
-                id: jartag
-                run: |
-                    echo "jar_file=$(find ./service/target/ -maxdepth 1 -regextype posix-extended -regex '.*/validate-[0-9]+\.[0-9]+\.[0-9]+(-SNAPSHOT)?\.jar')" >> $GITHUB_OUTPUT
+                name: 🫙 Tar and Tag Determination
+                id: gettartag
+                run: echo "tar_file=$(tar_file=$(find ./target/ -maxdepth 1 -regextype posix-extended -regex '.*/*-[0-9]+\.[0-9]+\.[0-9]+(-SNAPSHOT)?\.tar.gz')" >> $GITHUB_OUTPUT
                     echo "image_tag=$(echo ${{github.ref}} | awk -F/ '{print $NF}')" >> $GITHUB_OUTPUT
             -
                 name: 💳 Docker Hub Identification
@@ -103,10 +102,10 @@ jobs:
                 with:
                     context: ./
                     file: ./docker/Dockerfile
-                    build-args: validate_jar=${{steps.jartag.outputs.jar_file}}
+                    build-args: tar_file=${{steps.gettartag.outputs.tar_file}}
                     platforms: linux/amd64,linux/arm64
                     push: true
-                    tags: ${{secrets.DOCKERHUB_USERNAME}}/validate:${{steps.jartag.outputs.image_tag}}
+                    tags: ${{secrets.DOCKERHUB_USERNAME}}/validate:${{steps.gettartag.outputs.image_tag}}
 
 ...
 

--- a/.github/workflows/stable-cicd.yaml
+++ b/.github/workflows/stable-cicd.yaml
@@ -82,7 +82,7 @@ jobs:
             -
                 name: 🫙 Tar and Tag Determination
                 id: gettartag
-                run: echo "tar_file=$(find ./target/ -maxdepth 1 -regextype posix-extended -regex '.*/*-[0-9]+\.[0-9]+\.[0-9]+(-SNAPSHOT)?\.tar.gz')" >> $GITHUB_OUTPUT
+                run: echo "tar_file=$(find ./target/ -maxdepth 1 -regextype posix-extended -regex '.*/.*-[0-9]+\.[0-9]+\.[0-9]+(-SNAPSHOT)?\.tar.gz')" >> $GITHUB_OUTPUT
                     echo "image_tag=$(echo ${{github.ref}} | awk -F/ '{print $NF}')" >> $GITHUB_OUTPUT
             -
                 name: 💳 Docker Hub Identification

--- a/.github/workflows/stable-cicd.yaml
+++ b/.github/workflows/stable-cicd.yaml
@@ -82,7 +82,7 @@ jobs:
             -
                 name: 🫙 Tar and Tag Determination
                 id: gettartag
-                run: echo "tar_file=$(find ./target/ -maxdepth 1 -regextype posix-extended -regex '.*/.*-[0-9]+\.[0-9]+\.[0-9]+(-SNAPSHOT)?-bin\.tar.gz')" >> $GITHUB_OUTPUT
+                run: echo "tar_file=$(find ./target/ -maxdepth 1 -regextype posix-extended -regex '.*/.*-[0-9]+\.[0-9]+\.[0-9]+(-SNAPSHOT)?-bin\.tar\.gz')" >> $GITHUB_OUTPUT
                     echo "image_tag=$(echo ${{github.ref}} | awk -F/ '{print $NF}')" >> $GITHUB_OUTPUT
             -
                 name: 💳 Docker Hub Identification

--- a/.github/workflows/stable-cicd.yaml
+++ b/.github/workflows/stable-cicd.yaml
@@ -79,6 +79,35 @@ jobs:
                     CODE_SIGNING_KEY: ${{secrets.CODE_SIGNING_KEY}}
                     ADMIN_GITHUB_TOKEN: ${{secrets.ADMIN_GITHUB_TOKEN}}
 
+            -
+                name: 🫙 Jar and Tag Determination
+                id: jartag
+                run: |
+                    echo "jar_file=$(find ./service/target/ -maxdepth 1 -regextype posix-extended -regex '.*/validate-[0-9]+\.[0-9]+\.[0-9]+(-SNAPSHOT)?\.jar')" >> $GITHUB_OUTPUT
+                    echo "image_tag=$(echo ${{github.ref}} | awk -F/ '{print $NF}')" >> $GITHUB_OUTPUT
+            -
+                name: 💳 Docker Hub Identification
+                uses: docker/login-action@v2
+                with:
+                    username: ${{secrets.DOCKERHUB_USERNAME}}
+                    password: ${{secrets.DOCKERHUB_TOKEN}}
+            -
+                name: 🎰 QEMU Multiple Machine Emulation
+                uses: docker/setup-qemu-action@v2
+            -
+                name: 🚢 Docker Buildx
+                uses: docker/setup-buildx-action@v2
+            -
+                name: 🧱 Image Construction and Publication
+                uses: docker/build-push-action@v3
+                with:
+                    context: ./
+                    file: ./docker/Dockerfile
+                    build-args: validate_jar=${{steps.jartag.outputs.jar_file}}
+                    platforms: linux/amd64,linux/arm64
+                    push: true
+                    tags: ${{secrets.DOCKERHUB_USERNAME}}/validate:${{steps.jartag.outputs.image_tag}}
+
 ...
 
 # -*- mode: yaml; indent: 4; fill-column: 120; coding: utf-8 -*-

--- a/.github/workflows/stable-cicd.yaml
+++ b/.github/workflows/stable-cicd.yaml
@@ -82,7 +82,7 @@ jobs:
             -
                 name: 🫙 Tar and Tag Determination
                 id: gettartag
-                run: echo "tar_file=$(find ./target/ -maxdepth 1 -regextype posix-extended -regex '.*/.*-[0-9]+\.[0-9]+\.[0-9]+(-SNAPSHOT)?\.tar.gz')" >> $GITHUB_OUTPUT
+                run: echo "tar_file=$(find ./target/ -maxdepth 1 -regextype posix-extended -regex '.*/.*-[0-9]+\.[0-9]+\.[0-9]+(-SNAPSHOT)?-bin\.tar.gz')" >> $GITHUB_OUTPUT
                     echo "image_tag=$(echo ${{github.ref}} | awk -F/ '{print $NF}')" >> $GITHUB_OUTPUT
             -
                 name: 💳 Docker Hub Identification

--- a/.github/workflows/stable-cicd.yaml
+++ b/.github/workflows/stable-cicd.yaml
@@ -82,7 +82,7 @@ jobs:
             -
                 name: 🫙 Tar and Tag Determination
                 id: gettartag
-                run: echo "tar_file=$(tar_file=$(find ./target/ -maxdepth 1 -regextype posix-extended -regex '.*/*-[0-9]+\.[0-9]+\.[0-9]+(-SNAPSHOT)?\.tar.gz')" >> $GITHUB_OUTPUT
+                run: echo "tar_file=$(find ./target/ -maxdepth 1 -regextype posix-extended -regex '.*/*-[0-9]+\.[0-9]+\.[0-9]+(-SNAPSHOT)?\.tar.gz')" >> $GITHUB_OUTPUT
                     echo "image_tag=$(echo ${{github.ref}} | awk -F/ '{print $NF}')" >> $GITHUB_OUTPUT
             -
                 name: 💳 Docker Hub Identification

--- a/.github/workflows/unstable-cicd.yaml
+++ b/.github/workflows/unstable-cicd.yaml
@@ -85,9 +85,9 @@ jobs:
                     ADMIN_GITHUB_TOKEN: ${{secrets.ADMIN_GITHUB_TOKEN}}
 
             -
-                name: 🫙 Jar File Determination
-                id: jarrer
-                run: echo "jar_file=$(find ./target/ -maxdepth 1 -regextype posix-extended -regex '.*/validate-[0-9]+\.[0-9]+\.[0-9]+(-SNAPSHOT)?\.jar')" >> $GITHUB_OUTPUT
+                name: 🫙 Version Determination
+                id: version
+                run: echo "version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_OUTPUT
             -
                 name: 💳 Docker Hub Identification
                 uses: docker/login-action@v2
@@ -106,7 +106,7 @@ jobs:
                 with:
                     context: ./
                     file: ./docker/Dockerfile
-                    build-args: validate_jar=${{steps.jarrer.outputs.jar_file}}
+                    build-args: version=${{steps.jarrer.outputs.version}}
                     platforms: linux/amd64,linux/arm64
                     push: true
                     tags: ${{secrets.DOCKERHUB_USERNAME}}/validate:latest

--- a/.github/workflows/unstable-cicd.yaml
+++ b/.github/workflows/unstable-cicd.yaml
@@ -86,7 +86,7 @@ jobs:
 
             -
                 name: 🫙 Version Determination
-                id: version
+                id: getversion
                 run: echo "version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_OUTPUT
             -
                 name: 💳 Docker Hub Identification
@@ -106,7 +106,7 @@ jobs:
                 with:
                     context: ./
                     file: ./docker/Dockerfile
-                    build-args: version=${{steps.jarrer.outputs.version}}
+                    build-args: version=${{steps.getversion.outputs.version}}
                     platforms: linux/amd64,linux/arm64
                     push: true
                     tags: ${{secrets.DOCKERHUB_USERNAME}}/validate:latest

--- a/.github/workflows/unstable-cicd.yaml
+++ b/.github/workflows/unstable-cicd.yaml
@@ -87,7 +87,7 @@ jobs:
             -
                 name: 🫙 Tar Determination
                 id: gettar
-                run: echo "tar_file=$(find ./target/ -maxdepth 1 -regextype posix-extended -regex '.*/.*-[0-9]+\.[0-9]+\.[0-9]+(-SNAPSHOT)?-bin\.tar.gz')" >> $GITHUB_OUTPUT
+                run: echo "tar_file=$(find ./target/ -maxdepth 1 -regextype posix-extended -regex '.*/.*-[0-9]+\.[0-9]+\.[0-9]+(-SNAPSHOT)?-bin\.tar\.gz')" >> $GITHUB_OUTPUT
             -
                 name: 💳 Docker Hub Identification
                 uses: docker/login-action@v2

--- a/.github/workflows/unstable-cicd.yaml
+++ b/.github/workflows/unstable-cicd.yaml
@@ -87,7 +87,7 @@ jobs:
             -
                 name: 🫙 Tar Determination
                 id: gettar
-                run: echo "tar_file=$(tar_file=$(find ./target/ -maxdepth 1 -regextype posix-extended -regex '.*/*-[0-9]+\.[0-9]+\.[0-9]+(-SNAPSHOT)?\.tar.gz')" >> $GITHUB_OUTPUT
+                run: echo "tar_file=$(find ./target/ -maxdepth 1 -regextype posix-extended -regex '.*/*-[0-9]+\.[0-9]+\.[0-9]+(-SNAPSHOT)?\.tar.gz')" >> $GITHUB_OUTPUT
             -
                 name: 💳 Docker Hub Identification
                 uses: docker/login-action@v2

--- a/.github/workflows/unstable-cicd.yaml
+++ b/.github/workflows/unstable-cicd.yaml
@@ -84,6 +84,33 @@ jobs:
                     CODE_SIGNING_KEY: ${{secrets.CODE_SIGNING_KEY}}
                     ADMIN_GITHUB_TOKEN: ${{secrets.ADMIN_GITHUB_TOKEN}}
 
+            -
+                name: 🫙 Jar File Determination
+                id: jarrer
+                run: echo "jar_file=$(find ./target/ -maxdepth 1 -regextype posix-extended -regex '.*/validate-[0-9]+\.[0-9]+\.[0-9]+(-SNAPSHOT)?\.jar')" >> $GITHUB_OUTPUT
+            -
+                name: 💳 Docker Hub Identification
+                uses: docker/login-action@v2
+                with:
+                    username: ${{secrets.DOCKERHUB_USERNAME}}
+                    password: ${{secrets.DOCKERHUB_TOKEN}}
+            -
+                name: 🎰 QEMU Multiple Machine Emulation
+                uses: docker/setup-qemu-action@v2
+            -
+                name: 🚢 Docker Buildx
+                uses: docker/setup-buildx-action@v2
+            -
+                name: 🧱 Image Construction and Publication
+                uses: docker/build-push-action@v3
+                with:
+                    context: ./
+                    file: ./docker/Dockerfile
+                    build-args: api_jar=${{steps.jarrer.outputs.jar_file}}
+                    platforms: linux/amd64,linux/arm64
+                    push: true
+                    tags: ${{secrets.DOCKERHUB_USERNAME}}/validate:latest
+
 ...
 
 # -*- mode: yaml; indent: 4; fill-column: 120; coding: utf-8 -*-

--- a/.github/workflows/unstable-cicd.yaml
+++ b/.github/workflows/unstable-cicd.yaml
@@ -85,9 +85,9 @@ jobs:
                     ADMIN_GITHUB_TOKEN: ${{secrets.ADMIN_GITHUB_TOKEN}}
 
             -
-                name: 🫙 Version Determination
-                id: getversion
-                run: echo "version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_OUTPUT
+                name: 🫙 Tar Determination
+                id: gettar
+                run: echo "tar_file=$(tar_file=$(find ./target/ -maxdepth 1 -regextype posix-extended -regex '.*/*-[0-9]+\.[0-9]+\.[0-9]+(-SNAPSHOT)?\.tar.gz')" >> $GITHUB_OUTPUT
             -
                 name: 💳 Docker Hub Identification
                 uses: docker/login-action@v2
@@ -106,7 +106,7 @@ jobs:
                 with:
                     context: ./
                     file: ./docker/Dockerfile
-                    build-args: version=${{steps.getversion.outputs.version}}
+                    build-args: tar_file=${{steps.gettar.outputs.tar_file}}
                     platforms: linux/amd64,linux/arm64
                     push: true
                     tags: ${{secrets.DOCKERHUB_USERNAME}}/validate:latest

--- a/.github/workflows/unstable-cicd.yaml
+++ b/.github/workflows/unstable-cicd.yaml
@@ -87,7 +87,7 @@ jobs:
             -
                 name: 🫙 Tar Determination
                 id: gettar
-                run: echo "tar_file=$(find ./target/ -maxdepth 1 -regextype posix-extended -regex '.*/*-[0-9]+\.[0-9]+\.[0-9]+(-SNAPSHOT)?\.tar.gz')" >> $GITHUB_OUTPUT
+                run: echo "tar_file=$(find ./target/ -maxdepth 1 -regextype posix-extended -regex '.*/.*-[0-9]+\.[0-9]+\.[0-9]+(-SNAPSHOT)?\.tar.gz')" >> $GITHUB_OUTPUT
             -
                 name: 💳 Docker Hub Identification
                 uses: docker/login-action@v2

--- a/.github/workflows/unstable-cicd.yaml
+++ b/.github/workflows/unstable-cicd.yaml
@@ -87,7 +87,7 @@ jobs:
             -
                 name: 🫙 Tar Determination
                 id: gettar
-                run: echo "tar_file=$(find ./target/ -maxdepth 1 -regextype posix-extended -regex '.*/.*-[0-9]+\.[0-9]+\.[0-9]+(-SNAPSHOT)?\.tar.gz')" >> $GITHUB_OUTPUT
+                run: echo "tar_file=$(find ./target/ -maxdepth 1 -regextype posix-extended -regex '.*/.*-[0-9]+\.[0-9]+\.[0-9]+(-SNAPSHOT)?-bin\.tar.gz')" >> $GITHUB_OUTPUT
             -
                 name: 💳 Docker Hub Identification
                 uses: docker/login-action@v2

--- a/.github/workflows/unstable-cicd.yaml
+++ b/.github/workflows/unstable-cicd.yaml
@@ -106,7 +106,7 @@ jobs:
                 with:
                     context: ./
                     file: ./docker/Dockerfile
-                    build-args: api_jar=${{steps.jarrer.outputs.jar_file}}
+                    build-args: validate_jar=${{steps.jarrer.outputs.jar_file}}
                     platforms: linux/amd64,linux/arm64
                     push: true
                     tags: ${{secrets.DOCKERHUB_USERNAME}}/validate:latest

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,17 +30,10 @@
 
 FROM openjdk:15-slim
 
-# Set following argument with the required validate tool version
-ARG version=3.0.3
-
-# Install curl (to download the validate binary)
-RUN apt-get update -y \
-    && apt-get install -y curl
-
-ENV VALIDATE_IMAGE_PATH=https://github.com/NASA-PDS/validate/releases/download/v${version}/validate-${version}-bin.tar.gz
+ARG tar_file
 
 # Install Validate tool
-ADD $VALIDATE_IMAGE_PATH /tmp/validate-bin.tar.gz
+ADD $tar_file /tmp/validate-bin.tar.gz
 RUN  mkdir /opt/validate  \
      && tar xzf /tmp/validate-bin.tar.gz  -C /opt/validate --strip-components 1 \
      && rm -f /tmp/validate-bin.tar.gz \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,13 +31,13 @@
 FROM openjdk:15-slim
 
 # Set following argument with the required validate tool version
-ARG validate_version=3.0.3
+ARG version=3.0.3
 
 # Install curl (to download the validate binary)
 RUN apt-get update -y \
     && apt-get install -y curl
 
-ENV VALIDATE_IMAGE_PATH=https://github.com/NASA-PDS/validate/releases/download/v${validate_version}/validate-${validate_version}-bin.tar.gz
+ENV VALIDATE_IMAGE_PATH=https://github.com/NASA-PDS/validate/releases/download/v${version}/validate-${version}-bin.tar.gz
 
 # Install Validate tool
 ADD $VALIDATE_IMAGE_PATH /tmp/validate-bin.tar.gz

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,7 +33,8 @@ FROM openjdk:15-slim
 ARG tar_file
 
 # Install Validate tool
-ADD $tar_file /tmp/validate-bin.tar.gz
+COPY $tar_file /tmp/validate-bin.tar.gz
+
 RUN  mkdir /opt/validate  \
      && tar xzf /tmp/validate-bin.tar.gz  -C /opt/validate --strip-components 1 \
      && rm -f /tmp/validate-bin.tar.gz \

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,44 +1,30 @@
-# 🪐 Docker Image and Container for Validate Tool
+# 🚢 Dockerfile
 
-The docker image of Validate Tool provides an easy way to deploy the Validate Tool, without having to 
-worry about the Java/JDK versions installed and operating systems supported. Also, this helps to 
-easily use the Validate Tool in other execution environments such as docker compose and Amazon ECS.
+There's one Dockerfile here that can be used to make images for development and production.
 
-The only prerequisite to use the dockerized Validate Tool is the availability of docker software in the host computer.
-At the time of writing this, the Validate Tool was tested with Docker version 20.10.12.
+To build an image, run:
 
-## 🏃 Steps to build the docker image of the Validate Tool
+    docker image build --build-arg tar_file=URL --tag [OWNER/]registry-api-service:TAG .
 
-1. Clone the GIT Repository containing the validate tool.
-```shell
-git clone https://github.com/NASA-PDS/validate.git
+Replace `URL` with the URL (or relative file path) to a `validate` TAR file and `TAG` with the desired version tag. You can add `OWNER/` to tag the image for a specific owner, such as `nasapds/`.
+
+The GitHub Actions configured in this repository automatically make images after each `stable-cicd.yaml` workflow (with a `:X.Y.Z` tag) and `unstable-cicd.yaml` workflow (with a `:latest` tag) and publishes them to the Docker Hub.
+
+
+## 🧱 Example Builds
+
+Building a local image:
+```console
+$ git clone https://github.com/NASA-PDS/validate.git
+$ cd validate
+$ mvn package
+$ docker image build --build-arg tar_file=target/*-bin.tar.gz --tag validate:latest --file docker/Dockerfile .
 ```
 
-2. Update (if required) the following version in the `Dockerfile` with the required Validate Tool version.
-
-| Variable            | Description |
-| ------------------- | ------------|
-| validate_version     | The version of the Validate Tool release to be included in the docker image |
-
-```    
-# Set following argument with the required validate tool version
-ARG validate_version=3.0.3
+Building an image from a released jar file:
+```console
+$ docker image build --build-arg tar_file=https://github.com/NASA-PDS/validate/releases/download/v1.0.0/validate-1.0.0-bin.tar.gz --tag nasapds/validate:1.0.0 --file docker/Dockerfile .
 ```
-
-3. Open a terminal and change the current working directory to `validate/docker`.
-
-4. Build the docker image as follows (make sure that docker is installed and running in your computer).
-
-```
-    docker image build --tag nasapds/validate .
-```
-
-5. Test the `nasapds/validate` docker image as follows.
-
-```
-    docker container run --rm nasapds/validate --help
-```
-The above command should display the help content of the Validate Tool.
 
 
 ## 🏃 Steps to run a docker container of the Validate Tool

--- a/docker/README.md
+++ b/docker/README.md
@@ -4,9 +4,9 @@ There's one Dockerfile here that can be used to make images for development and 
 
 To build an image, run:
 
-    docker image build --build-arg tar_file=URL.tar.gz --tag [OWNER/]validate:TAG .
+    docker image build --build-arg tar_file=PATH --tag [OWNER/]validate:TAG .
 
-Replace `URL` with the URL (e.g. from https://github.com/NASA-PDS/validate/releases/latest, this would be something like https://github.com/NASA-PDS/validate/releases/download/v3.3.3/validate-3.3.3-bin.tar.gz) or relative file path (e. g. target/validate-3.4.0-SNAPSHOT-bin.tar.gz) to a `validate` TAR file and `TAG` with the desired version tag. You can add `OWNER/` to tag the image for a specific owner, such as `nasapds/`.
+Replace `PATH` with the relative file path (e. g. target/validate-3.4.0-SNAPSHOT-bin.tar.gz) to a `validate` tarball file and `TAG` with the desired version tag. You can add `OWNER/` to tag the image for a specific owner, such as `nasapds/`.
 
 The GitHub Actions configured in this repository automatically make images after each `stable-cicd.yaml` workflow (with a `:X.Y.Z` tag) and `unstable-cicd.yaml` workflow (with a `:latest` tag) and publishes them to the Docker Hub.
 
@@ -19,11 +19,6 @@ $ git clone https://github.com/NASA-PDS/validate.git
 $ cd validate
 $ mvn package
 $ docker image build --build-arg tar_file=target/*-bin.tar.gz --tag validate:latest --file docker/Dockerfile .
-```
-
-Building an image from a released jar file:
-```console
-$ docker image build --build-arg tar_file=https://github.com/NASA-PDS/validate/releases/download/v3.3.3/validate-3.3.3-bin.tar.gz --tag nasapds/validate:3.3.3 --file docker/Dockerfile .
 ```
 
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -4,9 +4,9 @@ There's one Dockerfile here that can be used to make images for development and 
 
 To build an image, run:
 
-    docker image build --build-arg tar_file=URL --tag [OWNER/]registry-api-service:TAG .
+    docker image build --build-arg tar_file=URL.tar.gz --tag [OWNER/]validate:TAG .
 
-Replace `URL` with the URL (or relative file path) to a `validate` TAR file and `TAG` with the desired version tag. You can add `OWNER/` to tag the image for a specific owner, such as `nasapds/`.
+Replace `URL` with the URL (e.g. from https://github.com/NASA-PDS/validate/releases/latest, this would be something like https://github.com/NASA-PDS/validate/releases/download/v3.3.3/validate-3.3.3-bin.tar.gz) or relative file path (e. g. target/validate-3.4.0-SNAPSHOT-bin.tar.gz) to a `validate` TAR file and `TAG` with the desired version tag. You can add `OWNER/` to tag the image for a specific owner, such as `nasapds/`.
 
 The GitHub Actions configured in this repository automatically make images after each `stable-cicd.yaml` workflow (with a `:X.Y.Z` tag) and `unstable-cicd.yaml` workflow (with a `:latest` tag) and publishes them to the Docker Hub.
 
@@ -23,7 +23,7 @@ $ docker image build --build-arg tar_file=target/*-bin.tar.gz --tag validate:lat
 
 Building an image from a released jar file:
 ```console
-$ docker image build --build-arg tar_file=https://github.com/NASA-PDS/validate/releases/download/v1.0.0/validate-1.0.0-bin.tar.gz --tag nasapds/validate:1.0.0 --file docker/Dockerfile .
+$ docker image build --build-arg tar_file=https://github.com/NASA-PDS/validate/releases/download/v3.3.3/validate-3.3.3-bin.tar.gz --tag nasapds/validate:3.3.3 --file docker/Dockerfile .
 ```
 
 


### PR DESCRIPTION
Copied from https://github.com/NASA-PDS/registry-api/blob/main/.github/workflows/unstable-cicd.yaml

Note: Not sure if this is correct or not with the Dockerfile in this repo. Hoping for some help from reviewers.


### Testing
```
]$ docker image build --tag nasapds/validate --build-arg tar_file=target/*-bin.tar.gz --file docker/Dockerfile .
[+] Building 2.0s (8/8) FINISHED                                                                                                                       docker:desktop-linux
 => [internal] load .dockerignore                                                                                                                                      0.0s
 => => transferring context: 2B                                                                                                                                        0.0s
 => [internal] load build definition from Dockerfile                                                                                                                   0.0s
 => => transferring dockerfile: 2.10kB                                                                                                                                 0.0s
 => [internal] load metadata for docker.io/library/openjdk:15-slim                                                                                                     0.9s
 => [internal] load build context                                                                                                                                      0.1s
 => => transferring context: 165B                                                                                                                                      0.1s
 => CACHED [1/3] FROM docker.io/library/openjdk:15-slim@sha256:1e069bf1c5c23adde58b29b82281b862e473d698ce7cc4e164194a0a2a1c044a                                        0.0s
 => [2/3] COPY target/*-bin.tar.gz /tmp/validate-bin.tar.gz                                                                                                            0.1s
 => [3/3] RUN  mkdir /opt/validate       && tar xzf /tmp/validate-bin.tar.gz  -C /opt/validate --strip-components 1      && rm -f /tmp/validate-bin.tar.gz      && ap  0.7s
 => exporting to image                                                                                                                                                 0.1s
 => => exporting layers                                                                                                                                                0.1s
 => => writing image sha256:335c5562256c7af4a01e9fe27fb753c8521cb5b8ce48a0b44a3dfef95fc66118                                                                           0.0s
 => => naming to docker.io/nasapds/validate
```
