### PR TITLE
check for duplicate lids pointing at same file

### DIFF
--- a/src/main/java/gov/nasa/pds/validate/ri/CommandLineInterface.java
+++ b/src/main/java/gov/nasa/pds/validate/ri/CommandLineInterface.java
@@ -24,12 +24,10 @@ public class CommandLineInterface {
   public CommandLineInterface() {
     super();
     this.opts = new Options();
-    
-    // Disabling this argument for the time being since the Search API does not yet support authorized access
+    /* registry is not ready. Deactivating this option until it becomes ready
     this.opts.addOption(Option.builder("A").argName("auth-file").desc(
         "file with the URL and credential content to have full (all product states) read-only access to the Registry Search API")
-        .hasArg(true).longOpt("auth-api").numberOfArgs(1).optionalArg(true).build());
-
+        .hasArg(true).longOpt("auth-api").numberOfArgs(1).optionalArg(true).build()); */
     this.opts.addOption(Option.builder("a").argName("auth-file").desc(
         "file with the URL and credential content to have full, direct read-only access to the Registry OpenSearch DB")
         .hasArg(true).longOpt("auth-opensearch").numberOfArgs(1).optionalArg(true).build());
@@ -74,32 +72,33 @@ public class CommandLineInterface {
 
     LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
     Configuration config = ctx.getConfiguration();
-    Logger logger = LogManager.getRootLogger();
     LoggerConfig loggerConfig = config.getLoggerConfig(LogManager.ROOT_LOGGER_NAME);
-
     loggerConfig.addAppender(counter, null, null);
     ctx.updateLoggers();
-
     CommandLine cl = new DefaultParser().parse(this.opts, args);
+
     if (cl.hasOption('h')) {
       this.help();
       return 0;
     }
+
     if (cl.hasOption("verbose"))
       loggerConfig.setLevel(Level.INFO);
     ctx.updateLoggers();
 
-    // Disabling this argument for the time being since the Search API does not yet support authorized access
-    this.opts.addOption(Option.builder("A").argName("auth-file").desc(
-        "file with the URL and credential content to have full (all product states) read-only access to the Registry Search API")
-        .hasArg(true).longOpt("auth-api").numberOfArgs(1).optionalArg(true).build());
-    if (!cl.hasOption("a"))
+    if (!cl.hasOption("a")) {
       throw new ParseException("Not yet implemented. Must provide OpenSearch Registry authorization information.");
+    } else if (!cl.hasOption("A")) {
+      log.warn("Using Registry OpenSearch Database to check references.");
+    } else {
+      /* not true statement until registry handles authentication
+       * throw new ParseException("Must supply authorization file for access to either OpenSearch Database (auth-opensearch) or OpenSearch Registry (auth-api).");
+       */
+      throw new ParseException("Must define authorization file for access to OpenSearch Database (auth-opensearch).");
+    }
 
     if (cl.getArgList().size() < 1)
       throw new ParseException("Must provide at least one LIDVID, Label file path, or manifest file path as a starting point.");
-    if (!cl.hasOption("A"))
-      log.warn("Using Registry OpenSearch Database to check references.");
 
     if (cl.hasOption("t")) {
       try {
@@ -113,12 +112,18 @@ public class CommandLineInterface {
     } else
       this.log.info("lidvids will be sequentially processed.");
 
-    this.log.info("Starting the reference integrity checks.");
     try {
+      DuplicateFileAreaFilenames scanner = new DuplicateFileAreaFilenames(
+          AuthInformation.buildFrom(cl.getOptionValue("auth-api", "")),
+          AuthInformation.buildFrom(cl.getOptionValue("auth-opensearch", "")));
       Engine engine = new Engine(cylinders, UserInput.toLidvids (cl.getArgList()),
           AuthInformation.buildFrom(cl.getOptionValue("auth-api", "")),
-          AuthInformation.buildFrom(cl.getOptionValue("auth-opensearch")));
-      engine.processQueueUntilEmpty();
+          AuthInformation.buildFrom(cl.getOptionValue("auth-opensearch", "")));
+      this.log.info("Starting the duplicate filename in FileArea checks.");
+      scanner.findDuplicatesInBackground();
+      this.log.info("Starting the reference integrity checks.");
+     //engine.processQueueUntilEmpty();
+      scanner.waitTillDone();
       broken = engine.getBroken();
       total = engine.getTotal();
     } catch (IOException e) {
@@ -136,7 +141,7 @@ public class CommandLineInterface {
       this.log.info("   " + this.total + " products processed");
       this.log.info("   " + this.broken + " missing references");
       this.log.info("   " + counter.getNumberOfFatals() + " fatals");
-      this.log.info("   " + (counter.getNumberOfErrors() - broken)
+      this.log.info("   " + Math.max(0, counter.getNumberOfErrors() - this.broken)
           + " errors not including missing references");
       this.log.info("   " + counter.getNumberOfWarnings() + " warnings");
     }

--- a/src/main/java/gov/nasa/pds/validate/ri/Cylinder.java
+++ b/src/main/java/gov/nasa/pds/validate/ri/Cylinder.java
@@ -1,7 +1,6 @@
 package gov.nasa.pds.validate.ri;
 
 import java.util.ArrayList;
-import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -38,8 +37,8 @@ public class Cylinder implements Runnable {
   public void run() {
     try {
       ArrayList<String> referenced_valid_lidvids = new ArrayList<String>();
-      DocumentInfo registry = new RegistryDocument(this.registry);
-      DocumentInfo search = new OpensearchDocument(this.search);
+      DocumentInfo search = AuthInformation.NO_AUTH.equals (this.registry) ? new OpensearchDocument(this.search) : new RegistryDocument(this.registry);;
+      String magicWord = AuthInformation.NO_AUTH.equals (this.registry) ? "database." : "registry.";
 
       if (search.exists(this.lidvid)) {
         this.log.info(
@@ -50,32 +49,11 @@ public class Cylinder implements Runnable {
           else {
             this.broken++;
             this.reporter.error("In the search the lidvid '" + this.lidvid + "' references '"
-                + reference + "' that is missing in the database.");
+                + reference + "' that is missing in the " + magicWord);
           }
         }
       } else
-        this.reporter.error("The given lidvid '" + this.lidvid + "' is missing from the database.");
-
-      if (!AuthInformation.NO_AUTH.equals(this.registry)) {
-        if (registry.exists(this.lidvid)) {
-          this.log.info("In the registry-api the lidvid '" + this.lidvid + "' is of type: "
-              + registry.getProductTypeOf(this.lidvid));
-          List<String> members = registry.getReferencesOf(this.lidvid);
-          for (String member : members) {
-            if (!referenced_valid_lidvids.contains(member))
-              this.reporter.error("For the lidvid '" + this.lidvid
-                  + "' the registry-api erroneously references the lidvid '" + member + "'.");
-          }
-          for (String reference : referenced_valid_lidvids) {
-            if (!members.contains(reference))
-              this.reporter.error("For the lidvid '" + this.lidvid
-                  + "' the registry-api erroneously failed to reference the lidvid '" + reference
-                  + "'.");
-          }
-        } else
-          this.reporter
-              .error("The given lidvid '" + this.lidvid + "' is missing from the registry");
-      }
+        this.reporter.error("The given lidvid '" + this.lidvid + "' is missing from the " + magicWord);
 
       if (this.has_children(search))
         this.cam.addAll(referenced_valid_lidvids);

--- a/src/main/java/gov/nasa/pds/validate/ri/DuplicateFileAreaFilenames.java
+++ b/src/main/java/gov/nasa/pds/validate/ri/DuplicateFileAreaFilenames.java
@@ -91,6 +91,8 @@ class DuplicateFileAreaFilenames extends OpensearchDocument implements Runnable,
           RestClient.builder(new HttpHost(url.getHost(), url.getPort(), url.getProtocol()))
               .setHttpClientConfigCallback(this).setRequestConfigCallback(this));
       response = this.search(client, request);
+      if (response.getAggregations() == null || response.getAggregations().get("duplicates") == null)
+        return;
       for (Terms.Bucket bucket : ((Terms)response.getAggregations().get("duplicates")).getBuckets()) {
         SearchRequest findIDs = new SearchRequest()
             .indices("registry")

--- a/src/main/java/gov/nasa/pds/validate/ri/DuplicateFileAreaFilenames.java
+++ b/src/main/java/gov/nasa/pds/validate/ri/DuplicateFileAreaFilenames.java
@@ -67,7 +67,7 @@ class DuplicateFileAreaFilenames extends OpensearchDocument implements Runnable,
      *   "aggregations": {
      *     "duplicates": {
      *       "terms": {
-     *         "field": "ops:Data_File_Info/ops:file_name",
+     *         "field": "ops:Data_File_Info/ops:file_ref",
      *         "size": 100,
      *         "min_doc_count": 2
      *       }
@@ -79,7 +79,7 @@ class DuplicateFileAreaFilenames extends OpensearchDocument implements Runnable,
         .indices("registry")
         .source(new SearchSourceBuilder()
             .aggregation(new TermsAggregationBuilder("duplicates")
-                .field("ops:Data_File_Info/ops:file_name")
+                .field("ops:Data_File_Info/ops:file_ref")
                 .minDocCount(2)
                 .size(this.PAGE_SIZE)
                 )
@@ -101,7 +101,7 @@ class DuplicateFileAreaFilenames extends OpensearchDocument implements Runnable,
                 .query(
                     QueryBuilders.boolQuery()
                         .must(QueryBuilders
-                            .termQuery("ops:Data_File_Info/ops:file_name", bucket.getKeyAsString())))
+                            .termQuery("ops:Data_File_Info/ops:file_ref", bucket.getKeyAsString())))
                 .size(this.PAGE_SIZE));
         SearchResponse duplicators = this.search(client, findIDs);
         HashSet<String> lids = new HashSet<String>();

--- a/src/main/java/gov/nasa/pds/validate/ri/DuplicateFileAreaFilenames.java
+++ b/src/main/java/gov/nasa/pds/validate/ri/DuplicateFileAreaFilenames.java
@@ -3,9 +3,12 @@ package gov.nasa.pds.validate.ri;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import org.apache.http.HttpHost;
-import org.apache.http.client.config.RequestConfig.Builder;
-import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.action.search.SearchRequest;
@@ -13,29 +16,23 @@ import org.opensearch.action.search.SearchResponse;
 import org.opensearch.client.RestClient;
 import org.opensearch.client.RestClientBuilder;
 import org.opensearch.client.RestHighLevelClient;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.aggregations.bucket.terms.Terms;
 import org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 import org.opensearch.search.builder.SearchSourceBuilder;
 
 class DuplicateFileAreaFilenames extends OpensearchDocument implements Runnable, RestClientBuilder.HttpClientConfigCallback, RestClientBuilder.RequestConfigCallback {
   final private AuthInformation registry;
   final private AuthInformation search;
+  final private HashMap<String, List<String>> duplicates = new HashMap<String, List<String>>();
   final private Logger log = LogManager.getLogger(CommandLineInterface.class);
-  private boolean done = false;
+  private boolean done = true;
 
   public DuplicateFileAreaFilenames(AuthInformation registry, AuthInformation search) {
     super(search);
     this.registry = registry;
     this.search = search;    
-  }
-  @Override
-  public Builder customizeRequestConfig(Builder requestConfigBuilder) {
-    // TODO Auto-generated method stub
-    return null;
-  }
-  @Override
-  public HttpAsyncClientBuilder customizeHttpClient(HttpAsyncClientBuilder httpClientBuilder) {
-    // TODO Auto-generated method stub
-    return null;
   }
   public void findDuplicates() {
     if (AuthInformation.NO_AUTH.equals(this.registry)) {
@@ -45,13 +42,18 @@ class DuplicateFileAreaFilenames extends OpensearchDocument implements Runnable,
     }
   }
   public void findDuplicatesInBackground() {
+    this.done = false;
     Thread t = new Thread(this);
+    t.setDaemon(true);
     t.start();
+  }
+  public Map<String, List<String>> getResults() {
+    return this.duplicates;
   }
   @Override
   public void run() {
     findDuplicates();
-    done = true;
+    this.done = true;
     synchronized(this) {
       this.notifyAll();
     }
@@ -79,7 +81,7 @@ class DuplicateFileAreaFilenames extends OpensearchDocument implements Runnable,
             .aggregation(new TermsAggregationBuilder("duplicates")
                 .field("ops:Data_File_Info/ops:file_name")
                 .minDocCount(2)
-                .size(10000)
+                .size(this.PAGE_SIZE)
                 )
             .size(0));
     SearchResponse response;
@@ -89,7 +91,25 @@ class DuplicateFileAreaFilenames extends OpensearchDocument implements Runnable,
           RestClient.builder(new HttpHost(url.getHost(), url.getPort(), url.getProtocol()))
               .setHttpClientConfigCallback(this).setRequestConfigCallback(this));
       response = this.search(client, request);
-      System.out.println (response);
+      for (Terms.Bucket bucket : ((Terms)response.getAggregations().get("duplicates")).getBuckets()) {
+        SearchRequest findIDs = new SearchRequest()
+            .indices("registry")
+            .source(new SearchSourceBuilder()
+                .fetchSource ("lid", null)
+                .query(
+                    QueryBuilders.boolQuery()
+                        .must(QueryBuilders
+                            .termQuery("ops:Data_File_Info/ops:file_name", bucket.getKeyAsString())))
+                .size(this.PAGE_SIZE));
+        SearchResponse duplicators = this.search(client, findIDs);
+        HashSet<String> lids = new HashSet<String>();
+        for (SearchHit hit : duplicators.getHits()) {
+          lids.add(hit.getSourceAsMap().get("lid").toString());
+        }
+        if (1 < lids.size()) {
+          this.duplicates.put (bucket.getKeyAsString(), new ArrayList<String>(lids));
+        }
+      }
     } catch (MalformedURLException e) {
       this.log.error ("Could not form a valid URL from " + this.search.getUrl(), e);
     } catch (IOException e) {

--- a/src/main/java/gov/nasa/pds/validate/ri/DuplicateFileAreaFilenames.java
+++ b/src/main/java/gov/nasa/pds/validate/ri/DuplicateFileAreaFilenames.java
@@ -107,6 +107,7 @@ class DuplicateFileAreaFilenames extends OpensearchDocument implements Runnable,
           lids.add(hit.getSourceAsMap().get("lid").toString());
         }
         if (1 < lids.size()) {
+          this.log.error("Found duplicate file: " + bucket.getKeyAsString());
           this.duplicates.put (bucket.getKeyAsString(), new ArrayList<String>(lids));
         }
       }

--- a/src/main/java/gov/nasa/pds/validate/ri/DuplicateFileAreaFilenames.java
+++ b/src/main/java/gov/nasa/pds/validate/ri/DuplicateFileAreaFilenames.java
@@ -1,0 +1,111 @@
+package gov.nasa.pds.validate.ri;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import org.apache.http.HttpHost;
+import org.apache.http.client.config.RequestConfig.Builder;
+import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.client.RestClient;
+import org.opensearch.client.RestClientBuilder;
+import org.opensearch.client.RestHighLevelClient;
+import org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
+import org.opensearch.search.builder.SearchSourceBuilder;
+
+class DuplicateFileAreaFilenames extends OpensearchDocument implements Runnable, RestClientBuilder.HttpClientConfigCallback, RestClientBuilder.RequestConfigCallback {
+  final private AuthInformation registry;
+  final private AuthInformation search;
+  final private Logger log = LogManager.getLogger(CommandLineInterface.class);
+  private boolean done = false;
+
+  public DuplicateFileAreaFilenames(AuthInformation registry, AuthInformation search) {
+    super(search);
+    this.registry = registry;
+    this.search = search;    
+  }
+  @Override
+  public Builder customizeRequestConfig(Builder requestConfigBuilder) {
+    // TODO Auto-generated method stub
+    return null;
+  }
+  @Override
+  public HttpAsyncClientBuilder customizeHttpClient(HttpAsyncClientBuilder httpClientBuilder) {
+    // TODO Auto-generated method stub
+    return null;
+  }
+  public void findDuplicates() {
+    if (AuthInformation.NO_AUTH.equals(this.registry)) {
+      viaOpenSearch();
+    } else {
+      viaRegistry();
+    }
+  }
+  public void findDuplicatesInBackground() {
+    Thread t = new Thread(this);
+    t.start();
+  }
+  @Override
+  public void run() {
+    findDuplicates();
+    done = true;
+    synchronized(this) {
+      this.notifyAll();
+    }
+  }
+  private void viaOpenSearch() {
+    RestHighLevelClient client = null;
+    /* 
+     * GET registry/_search
+     * {
+     *   "size": 0,
+     *   "aggregations": {
+     *     "duplicates": {
+     *       "terms": {
+     *         "field": "ops:Data_File_Info/ops:file_name",
+     *         "size": 100,
+     *         "min_doc_count": 2
+     *       }
+     *     }
+     *   }
+     * }
+    */
+    SearchRequest request = new SearchRequest()
+        .indices("registry")
+        .source(new SearchSourceBuilder()
+            .aggregation(new TermsAggregationBuilder("duplicates")
+                .field("ops:Data_File_Info/ops:file_name")
+                .minDocCount(2)
+                .size(10000)
+                )
+            .size(0));
+    SearchResponse response;
+    try {
+      URL url = new URL(this.search.getUrl());
+      client = new RestHighLevelClient(
+          RestClient.builder(new HttpHost(url.getHost(), url.getPort(), url.getProtocol()))
+              .setHttpClientConfigCallback(this).setRequestConfigCallback(this));
+      response = this.search(client, request);
+      System.out.println (response);
+    } catch (MalformedURLException e) {
+      this.log.error ("Could not form a valid URL from " + this.search.getUrl(), e);
+    } catch (IOException e) {
+      this.log.error ("Something went wrong talking to opensearch.", e);
+    }
+  }
+  private void viaRegistry() {
+    this.log.fatal("finding duplicate file area filenames is not implemented.");
+  }
+  public synchronized void waitTillDone() {
+    while (!this.done) {
+      try {
+        this.wait();
+      } catch (InterruptedException e) {
+        // ignore
+      }
+    }
+  }
+}

--- a/src/main/java/gov/nasa/pds/validate/ri/OpensearchDocument.java
+++ b/src/main/java/gov/nasa/pds/validate/ri/OpensearchDocument.java
@@ -37,7 +37,7 @@ import org.opensearch.search.builder.SearchSourceBuilder;
 public class OpensearchDocument implements DocumentInfo, RestClientBuilder.HttpClientConfigCallback,
     RestClientBuilder.RequestConfigCallback {
   protected static OpensearchDocument sourceOverride = null;
-  final private int PAGE_SIZE = 5000;
+  protected final int PAGE_SIZE = 5000;
   final private AuthInformation context;
   final private HashMap<String, Map<String, Object>> documents =
       new HashMap<String, Map<String, Object>>();


### PR DESCRIPTION
## 🗒️ Summary
Use opensearch to find all lids that reference same file.

## ⚙️ Test Data and/or Report
Had to use data from NASA-PDS/harvest#143. Created a single duplicate rqd. There are lots of missing secondary references and surprise duplicates:
```
15:45:14.943 [main] INFO  gov.nasa.pds.validate.ri.CommandLineInterface - Reference Summary:
15:45:14.943 [main] INFO  gov.nasa.pds.validate.ri.CommandLineInterface -    22275 products processed
15:45:14.943 [main] INFO  gov.nasa.pds.validate.ri.CommandLineInterface -    115290 missing references
15:45:14.943 [main] INFO  gov.nasa.pds.validate.ri.CommandLineInterface -    0 fatals
15:45:14.943 [main] INFO  gov.nasa.pds.validate.ri.CommandLineInterface -    0 errors not including missing references
15:45:14.943 [main] INFO  gov.nasa.pds.validate.ri.CommandLineInterface -    0 warnings
15:45:14.943 [main] INFO  gov.nasa.pds.validate.ri.CommandLineInterface - Duplicate Summary:
15:45:14.943 [main] INFO  gov.nasa.pds.validate.ri.CommandLineInterface -    Number of duplicates found: 2
15:45:14.943 [main] INFO  gov.nasa.pds.validate.ri.CommandLineInterface -    File: ps__0125_0678032243_000rqa__00417120483005510000___j01.csv
15:45:14.943 [main] INFO  gov.nasa.pds.validate.ri.CommandLineInterface -       referer: urn:nasa:pds:mars2020_pixl:data_oxides_pmc:ps__0125_0678032243_000rqa__00417120483005510000___j01
15:45:14.943 [main] INFO  gov.nasa.pds.validate.ri.CommandLineInterface -       referer: urn:nasa:pds:mars2020_pixl:data_oxides_pmc:ps__0125_0678032243_000rqd__00417120483005510000___j01
15:45:14.943 [main] INFO  gov.nasa.pds.validate.ri.CommandLineInterface -    File: readme.txt
15:45:14.943 [main] INFO  gov.nasa.pds.validate.ri.CommandLineInterface -       referer: urn:nasa:pds:mars2020.spice
15:45:14.943 [main] INFO  gov.nasa.pds.validate.ri.CommandLineInterface -       referer: urn:nasa:pds:insight_rad
15:45:14.943 [main] INFO  gov.nasa.pds.validate.ri.CommandLineInterface -       referer: urn:nasa:pds:mars2020_pixl
```

## ♻️ Related Issues
Closes #773 