### PR TITLE
Fix bug introduced by #308 when converting URLs to local paths on Windows

### DIFF
--- a/src/main/java/gov/nasa/pds/tools/validate/CrossLabelFileAreaReferenceChecker.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/CrossLabelFileAreaReferenceChecker.java
@@ -1,6 +1,7 @@
 package gov.nasa.pds.tools.validate;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -14,9 +15,9 @@ import gov.nasa.pds.tools.util.LabelUtil;
 
 public class CrossLabelFileAreaReferenceChecker {
   final private static HashMap<String,List<String>> knownRefs = new HashMap<String,List<String>>();
-  private static String resolve (String name, ValidationTarget target) {
+  private static String resolve (String name, ValidationTarget target) throws URISyntaxException {
     if (!name.startsWith ("/")) {
-      name = Path.of(target.getUrl().getPath()).getParent().resolve(name).toString();
+      name = Path.of(target.getUrl().toURI()).getParent().resolve(name).toString();
     }
     return name;
   }
@@ -30,8 +31,9 @@ public class CrossLabelFileAreaReferenceChecker {
    * @throws IOException
    * @throws ParserConfigurationException
    * @throws SAXException
+   * @throws URISyntaxException
    */
-  public static boolean add (String name, ValidationTarget target) throws IOException, ParserConfigurationException, SAXException {
+  public static boolean add (String name, ValidationTarget target) throws IOException, ParserConfigurationException, SAXException, URISyntaxException {
     boolean success = false;
     DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
     Document xml = dbf.newDocumentBuilder().parse(target.getUrl().openStream());
@@ -49,10 +51,10 @@ public class CrossLabelFileAreaReferenceChecker {
     }
     return success;
   }
-  public static String getOtherId (String name, ValidationTarget target) {
+  public static String getOtherId (String name, ValidationTarget target) throws URISyntaxException {
     return knownRefs.get(resolve(name, target)).get(0);
   }
-  public static String getOtherFilename (String name, ValidationTarget target) {
+  public static String getOtherFilename (String name, ValidationTarget target) throws URISyntaxException {
     return knownRefs.get(resolve(name, target)).get(1);
   }
   public static void reset() {


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary
When using Path.of() we need to pass a URI on a Windows machine, not the Path.

Resolves #809

## ⚙️ Test Data and/or Report
See regression tests to verify this doesn't break other tests.

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->
Resolves #809
