### PR TITLE
Update log parameter names per user request

### DIFF
--- a/src/main/java/gov/nasa/pds/validate/ValidateLauncher.java
+++ b/src/main/java/gov/nasa/pds/validate/ValidateLauncher.java
@@ -1282,10 +1282,10 @@ public class ValidateLauncher {
     if (!schematrons.isEmpty()) {
       report.addParameter("schematrons", "User Specified Schematrons", schematrons.toString());
     }
-    report.addParameter("level", "Severity Level", severity.getName());
-    report.addParameter("recurse", "Recurse Directories", String.valueOf(traverse));
+    report.addParameter("severityLevel", "Severity Level", severity.getName());
+    report.addParameter("recurseDirectories", "Recurse Directories", String.valueOf(traverse));
     if (!regExps.isEmpty()) {
-      report.addParameter("regex", "File Filters Used", regExps.toString());
+      report.addParameter("fileFiltersUsed", "File Filters Used", regExps.toString());
     }
     /*
      * Deprecated issue-23 if (force) { report.addParameter("   Force Mode                    on");
@@ -1295,7 +1295,7 @@ public class ValidateLauncher {
       report.addParameter("manifestCksum", "Checksum Manifest File", checksumManifest.toString());
       report.addParameter("manifestPath", "Manifest File Base Path", manifestBasePath.toString());
     }
-    report.addParameter("contentValidation", "Data Content Validation", contentValidationFlag ? "on" : "off");
+    report.addParameter("dataContentValidation", "Data Content Validation", contentValidationFlag ? "on" : "off");
     report.addParameter("productLevelValidation", "Product Level Validation", skipProductValidation ? "off" : "on");
     if (everyN != 1) {
       report.addParameter("everyN", "Data Every N", String.valueOf(everyN));
@@ -1313,8 +1313,8 @@ public class ValidateLauncher {
         || validationRule.equalsIgnoreCase("pds4.collection"))) {
       report.addParameter("allowUnlabeledFiles", "Allow Unlabeled Files", String.valueOf(allowUnlabeledFiles));
     }
-    report.addParameter("maxErrs", "Max Errors", String.valueOf(maxErrors));
-    report.addParameter("regProds", "Registered Contexts File", registeredProductsFile.toString());
+    report.addParameter("maxErrors", "Max Errors", String.valueOf(maxErrors));
+    report.addParameter("registeredContextsFile", "Registered Contexts File", registeredProductsFile.toString());
     if (nonRegisteredProductsFile != null) {
       report
           .addParameter("nonRegProds", "Non Registered Contexts File  ", nonRegisteredProductsFile.toString());

--- a/src/main/java/gov/nasa/pds/validate/ValidateLauncher.java
+++ b/src/main/java/gov/nasa/pds/validate/ValidateLauncher.java
@@ -1274,13 +1274,13 @@ public class ValidateLauncher {
       report.addParameter("ruleType", "Rule Type", validationRule);
     }
     if (!schemas.isEmpty()) {
-      report.addParameter("schemas", "User Specified Schemas", schemas.toString());
+      report.addParameter("userSpecifiedSchemas", "User Specified Schemas", schemas.toString());
     }
     if (!catalogs.isEmpty()) {
-      report.addParameter("catalogs", "User Specified Catalogs", catalogs.toString());
+      report.addParameter("userSpecifiedCatalogs", "User Specified Catalogs", catalogs.toString());
     }
     if (!schematrons.isEmpty()) {
-      report.addParameter("schematrons", "User Specified Schematrons", schematrons.toString());
+      report.addParameter("userSpecifiedSchematrons", "User Specified Schematrons", schematrons.toString());
     }
     report.addParameter("severityLevel", "Severity Level", severity.getName());
     report.addParameter("recurseDirectories", "Recurse Directories", String.valueOf(traverse));
@@ -1292,22 +1292,22 @@ public class ValidateLauncher {
      * } else { report.addParameter("   Force Mode                    off"); }
      */
     if (checksumManifest != null) {
-      report.addParameter("manifestCksum", "Checksum Manifest File", checksumManifest.toString());
-      report.addParameter("manifestPath", "Manifest File Base Path", manifestBasePath.toString());
+      report.addParameter("checksumManifestFile", "Checksum Manifest File", checksumManifest.toString());
+      report.addParameter("manifestFileBasePath", "Manifest File Base Path", manifestBasePath.toString());
     }
     report.addParameter("dataContentValidation", "Data Content Validation", contentValidationFlag ? "on" : "off");
     report.addParameter("productLevelValidation", "Product Level Validation", skipProductValidation ? "off" : "on");
     if (everyN != 1) {
-      report.addParameter("everyN", "Data Every N", String.valueOf(everyN));
+      report.addParameter("dataEveryN", "Data Every N", String.valueOf(everyN));
     }
     if (this.completeDescriptions) {
-      report.addParameter("descriptions", "Complete Descriptions", "true");
+      report.addParameter("completeDescriptions", "Complete Descriptions", "true");
     }
     if (!pdfErrorDir.isEmpty()) {
-      report.addParameter("pdfErrDir", "PDF Error Directory", pdfErrorDir);
+      report.addParameter("pdfErrorDirectory", "PDF Error Directory", pdfErrorDir);
     }
     if (spotCheckData != -1) {
-      report.addParameter("spotCk", "Data Spot Check", String.valueOf(spotCheckData));
+      report.addParameter("dataSpotCheck", "Data Spot Check", String.valueOf(spotCheckData));
     }
     if (validationRule != null && (validationRule.equalsIgnoreCase("pds4.bundle")
         || validationRule.equalsIgnoreCase("pds4.collection"))) {
@@ -1317,7 +1317,7 @@ public class ValidateLauncher {
     report.addParameter("registeredContextsFile", "Registered Contexts File", registeredProductsFile.toString());
     if (nonRegisteredProductsFile != null) {
       report
-          .addParameter("nonRegProds", "Non Registered Contexts File  ", nonRegisteredProductsFile.toString());
+          .addParameter("nonRegisteredContextsFile", "Non Registered Contexts File  ", nonRegisteredProductsFile.toString());
     }
     report.printHeader();
     report.startBody("Product Level Validation Results");


### PR DESCRIPTION
## 🗒️ Summary
Resolves #827

## ⚙️ Test Data and/or Report
Run validate on any file using `-s` and `-r` flags. Verify reports have the updated parameters.

Was
```
  "parameters": {
    "targets": "[file:/Users/jpadams/proj/pds/pdsen/workspace/validate/src/test/resources/github87/2t126632959btr0200p3002n0a1.xml]",
    "level": "WARNING",
    "recurse": "true",
    "regex": "[*.xml, *.XML]",
    "contentValidation": "on",
    "productLevelValidation": "on",
    "maxErrs": "100000",
    "regProds": "/Users/jpadams/proj/pds/pdsen/workspace/validate/validate-3.5.0-SNAPSHOT/resources/registered_context_products.json"
  },
```

Is:
```
  "parameters": {
    "targets": "[file:/Users/jpadams/proj/pds/pdsen/workspace/validate/src/test/resources/github87/2t126632959btr0200p3002n0a1.xml]",
    "severityLevel": "WARNING",
    "recurseDirectories": "true",
    "fileFiltersUsed": "[*.xml, *.XML]",
    "dataContentValidation": "on",
    "productLevelValidation": "on",
    "maxErrors": "100000",
    "registeredContextsFile": "/Users/jpadams/proj/pds/pdsen/workspace/validate/validate-3.5.0-SNAPSHOT/resources/registered_context_products.json"
  },
```

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->
Resolves #827 

