### PR TITLE
Fix plurality in JSON report header to make it consistent with other styles

### DIFF
--- a/src/main/java/gov/nasa/pds/validate/report/JSONReport.java
+++ b/src/main/java/gov/nasa/pds/validate/report/JSONReport.java
@@ -243,7 +243,7 @@ public class JSONReport extends Report {
           this.msgs.clear();
           break;
         case HEADER:
-          this.append ("configurations", this.configs);
+          this.append ("configuration", this.configs);
           this.append ("parameters", this.params);
           this.configs.clear();
           this.params.clear();


### PR DESCRIPTION
## 🗒️ Summary
Removes the `s` from `"configurations"` so that the JSON report header keys match the tags in the XML style (see [line 150 of XmlReport.java](https://github.com/NASA-PDS/validate/blob/main/src/main/java/gov/nasa/pds/validate/report/XmlReport.java#L150)) and the section titles in the "full" report (see [line 168 of FullReport.java](https://github.com/NASA-PDS/validate/blob/main/src/main/java/gov/nasa/pds/validate/report/FullReport.java#L168)).

## ⚙️ Test Data and/or Report
Given the extremely simple nature of this PR (see [Files changed](./835/files)), I did not bother setting up a local testing environment. Hopefully that is okay in this case, but let me know if it's needed.

## ♻️ Related Issues

https://github.com/NASA-PDS/validate/issues/827#issuecomment-1949434226