### PR TITLE
Add WARNING messages for context product metadata mismatch with labels and new flag `--disable-context-mismatch-warnings` to disable the messages

### DIFF
--- a/src/main/java/gov/nasa/pds/tools/label/LocationValidator.java
+++ b/src/main/java/gov/nasa/pds/tools/label/LocationValidator.java
@@ -431,6 +431,9 @@ public class LocationValidator {
   public void setEveryN(int value) {
     ruleContext.setEveryN(value);
   }
+  public void setContextMismatchAsWarn(boolean value) {
+    ruleContext.setContextMismatchAsWarn(value);
+  }
   public void setCompleteDescriptions(boolean b) {
     ruleContext.setCompleteDescriptions(b);
   }

--- a/src/main/java/gov/nasa/pds/tools/validate/ProblemType.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/ProblemType.java
@@ -262,7 +262,8 @@ public enum ProblemType {
 
   CONTEXT_REFERENCE_FOUND("info.label.context_ref_found"),
 
-  CONTEXT_REFERENCE_FOUND_MISMATCH("info.label.context_ref_mismatch"),
+  CONTEXT_REFERENCE_FOUND_MISMATCH_INFO("info.label.context_ref_mismatch"),
+  CONTEXT_REFERENCE_FOUND_MISMATCH_WARN("warning.label.context_ref_mismatch"),
 
   LOCAL_ID_FOUND("info.label.local_identifier_found"),
 

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/RuleContext.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/RuleContext.java
@@ -122,7 +122,7 @@ public class RuleContext extends ContextBase {
    * The key used to indicate how many lines or records to skip during content validation.
    */
   public static final String EVERY_N_KEY = "validate.every-n";
-  
+  public static final String CONTEXT_MISMATCH_AS_WARN_KEY = "validate.context-mismatch-as-warn";
   /**
    * The key used to indicate enable/disable of every bit account for in file area
    */
@@ -408,10 +408,16 @@ public class RuleContext extends ContextBase {
   }
 
   public int getEveryN() {
-	return getContextValue(EVERY_N_KEY, Integer.class) == null ? 1 : getContextValue(EVERY_N_KEY, Integer.class);
+    return getContextValue(EVERY_N_KEY, Integer.class) == null ? 1 : getContextValue(EVERY_N_KEY, Integer.class);
+  }
+  public boolean getContextMismatchAsWarn() {
+    return getContextValue(CONTEXT_MISMATCH_AS_WARN_KEY, Boolean.class) == null ? false : getContextValue(CONTEXT_MISMATCH_AS_WARN_KEY, Boolean.class);
   }
   public void setEveryN(int value) {
 	putContextValue(EVERY_N_KEY, value);
+  }
+  public void setContextMismatchAsWarn (boolean value) {
+    putContextValue(CONTEXT_MISMATCH_AS_WARN_KEY, value);
   }
   public boolean getCompleteDescriptions() {
     return getContextValue(COMPLETE_DESCRIPTIONS, Boolean.class) == null ? false : getContextValue(COMPLETE_DESCRIPTIONS, boolean.class);

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/ContextProductReferenceValidationRule.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/ContextProductReferenceValidationRule.java
@@ -279,8 +279,8 @@ public class ContextProductReferenceValidationRule extends AbstractValidationRul
                   for (String name : names) {
                     if (!rgpNames.stream().anyMatch(name::equalsIgnoreCase)) {
                       getListener().addProblem(new ValidationProblem(
-                          new ProblemDefinition(ExceptionType.INFO,
-                              ProblemType.CONTEXT_REFERENCE_FOUND_MISMATCH,
+                          new ProblemDefinition(this.getContext().getContextMismatchAsWarn() ? ExceptionType.WARNING : ExceptionType.INFO,
+                              this.getContext().getContextMismatchAsWarn() ? ProblemType.CONTEXT_REFERENCE_FOUND_MISMATCH_WARN : ProblemType.CONTEXT_REFERENCE_FOUND_MISMATCH_INFO,
                               "Context reference name mismatch. Value: '" + name + "'"
                                   + " Expected one of: '" + rgp.getNames() + "'"),
                           target, locator.getLineNumber(), -1));
@@ -292,8 +292,8 @@ public class ContextProductReferenceValidationRule extends AbstractValidationRul
                         !topNode.getLocalName().equals("Observing_System_Component")) {
                       // TODO: For now, we are punting on Observing_System_Component
                       getListener().addProblem(new ValidationProblem(
-                          new ProblemDefinition(ExceptionType.INFO,
-                              ProblemType.CONTEXT_REFERENCE_FOUND_MISMATCH,
+                          new ProblemDefinition(this.getContext().getContextMismatchAsWarn() ? ExceptionType.WARNING : ExceptionType.INFO,
+                              this.getContext().getContextMismatchAsWarn() ? ProblemType.CONTEXT_REFERENCE_FOUND_MISMATCH_WARN : ProblemType.CONTEXT_REFERENCE_FOUND_MISMATCH_INFO,
                               "Context reference type mismatch. Value: '" + type + "'"
                                   + " Expected one of: '" + rgp.getTypes() + "'"),
                           target, locator.getLineNumber(), -1));

--- a/src/main/java/gov/nasa/pds/validate/ValidateLauncher.java
+++ b/src/main/java/gov/nasa/pds/validate/ValidateLauncher.java
@@ -222,6 +222,8 @@ public class ValidateLauncher {
 
   private int everyN;
 
+  private boolean contextMismatchAsWarn = false;
+  
   private String pdfErrorDir;
 
   private int spotCheckData;
@@ -276,6 +278,7 @@ public class ValidateLauncher {
     maxErrors = MAX_ERRORS;
     completeDescriptions = false;
     everyN = 1;
+    contextMismatchAsWarn = false;
     spotCheckData = -1;
     allowUnlabeledFiles = false;
     registeredAndNonRegistedProducts = new HashMap<>();
@@ -426,6 +429,8 @@ public class ValidateLauncher {
         setContextReferenceCheck(false);
       } else if (Flag.CHECK_INBETWEEN_FIELDS.getLongName().equals(o.getLongOpt())) {
         setCheckInbetweenFields(true);
+      } else if (Flag.CONTEXT_MISMATCH_AS_WARNING.getLongName().equals(o.getLongOpt())) {
+        setContextMismatchAsWarn(true);
       } else if (Flag.ENABLE_STACK_PRINTING.getLongName().equals(o.getLongOpt())) {
         FlagsUtil.setStackPrintingFlag(true);
         // Also call setSeverity to 0.
@@ -768,6 +773,10 @@ public class ValidateLauncher {
       if (config.containsKey(ConfigKey.EVERY_N)) {
         setEveryN(config.getInt(ConfigKey.EVERY_N));
       }
+      if (config.containsKey(ConfigKey.CONTEXT_MISMATCH_AS_WARNING)) {
+        contextMismatchAsWarn = true;
+        setContextMismatchAsWarn(true);
+      }
       if (config.containsKey(ConfigKey.COMPLETE_DESCRIPTIONS)) {
         setCompleteDescriptions(true);
       }
@@ -1064,6 +1073,10 @@ public class ValidateLauncher {
 
   public void setEveryN(int value) {
     this.everyN = value;
+  }
+
+  public void setContextMismatchAsWarn(boolean value) {
+    this.contextMismatchAsWarn = value;
   }
 
   public void setCompleteDescriptions(boolean b) {
@@ -1383,6 +1396,7 @@ public class ValidateLauncher {
         validator.setCheckData(contentValidationFlag);
         validator.setSpotCheckData(spotCheckData);
         validator.setEveryN(everyN);
+        validator.setContextMismatchAsWarn(contextMismatchAsWarn);
         validator.setCompleteDescriptions(this.completeDescriptions);
         validator.setPDFErrorDir(pdfErrorDir);
         validator.setAllowUnlabeledFiles(allowUnlabeledFiles);

--- a/src/main/java/gov/nasa/pds/validate/ValidateLauncher.java
+++ b/src/main/java/gov/nasa/pds/validate/ValidateLauncher.java
@@ -222,7 +222,7 @@ public class ValidateLauncher {
 
   private int everyN;
 
-  private boolean contextMismatchAsWarn = false;
+  private boolean contextMismatchAsWarn = true;
   
   private String pdfErrorDir;
 
@@ -278,7 +278,7 @@ public class ValidateLauncher {
     maxErrors = MAX_ERRORS;
     completeDescriptions = false;
     everyN = 1;
-    contextMismatchAsWarn = false;
+    contextMismatchAsWarn = true;
     spotCheckData = -1;
     allowUnlabeledFiles = false;
     registeredAndNonRegistedProducts = new HashMap<>();
@@ -429,8 +429,8 @@ public class ValidateLauncher {
         setContextReferenceCheck(false);
       } else if (Flag.CHECK_INBETWEEN_FIELDS.getLongName().equals(o.getLongOpt())) {
         setCheckInbetweenFields(true);
-      } else if (Flag.CONTEXT_MISMATCH_AS_WARNING.getLongName().equals(o.getLongOpt())) {
-        setContextMismatchAsWarn(true);
+      } else if (Flag.DISABLE_CONTEXT_MISMATCH_WARNINGS.getLongName().equals(o.getLongOpt())) {
+        setContextMismatchAsWarn(false);
       } else if (Flag.ENABLE_STACK_PRINTING.getLongName().equals(o.getLongOpt())) {
         FlagsUtil.setStackPrintingFlag(true);
         // Also call setSeverity to 0.
@@ -773,9 +773,9 @@ public class ValidateLauncher {
       if (config.containsKey(ConfigKey.EVERY_N)) {
         setEveryN(config.getInt(ConfigKey.EVERY_N));
       }
-      if (config.containsKey(ConfigKey.CONTEXT_MISMATCH_AS_WARNING)) {
-        contextMismatchAsWarn = true;
-        setContextMismatchAsWarn(true);
+      if (config.containsKey(ConfigKey.DISABLE_CONTEXT_MISMATCH_WARNINGS)) {
+        contextMismatchAsWarn = false;
+        setContextMismatchAsWarn(false);
       }
       if (config.containsKey(ConfigKey.COMPLETE_DESCRIPTIONS)) {
         setCompleteDescriptions(true);

--- a/src/main/java/gov/nasa/pds/validate/commandline/options/ConfigKey.java
+++ b/src/main/java/gov/nasa/pds/validate/commandline/options/ConfigKey.java
@@ -117,6 +117,11 @@ public class ConfigKey {
   public static final String EVERY_N = "validate.everyN";
 
   /**
+   * Property to if context ref mismatches should be INFO or WARNING.
+   */
+  public static final String CONTEXT_MISMATCH_AS_WARNING = "validate.contextMismatchAsWarning";
+
+  /**
    * Property to enable/disable (true/false) full bit checking of tables and arrays
    */
   public static final String COMPLETE_DESCRIPTIONS = "validate.completeDescriptions";

--- a/src/main/java/gov/nasa/pds/validate/commandline/options/ConfigKey.java
+++ b/src/main/java/gov/nasa/pds/validate/commandline/options/ConfigKey.java
@@ -119,7 +119,7 @@ public class ConfigKey {
   /**
    * Property to if context ref mismatches should be INFO or WARNING.
    */
-  public static final String CONTEXT_MISMATCH_AS_WARNING = "validate.contextMismatchAsWarning";
+  public static final String DISABLE_CONTEXT_MISMATCH_WARNINGS = "validate.disableContextMismatchWarnings";
 
   /**
    * Property to enable/disable (true/false) full bit checking of tables and arrays

--- a/src/main/java/gov/nasa/pds/validate/commandline/options/Flag.java
+++ b/src/main/java/gov/nasa/pds/validate/commandline/options/Flag.java
@@ -69,7 +69,7 @@ public enum Flag {
       "Specify file extension for the labels files. Default: xml. NOTE: Support for intermingled bundles where collections have differing label file extensions is not yet supported."),
 
   EVERY_N(null, "everyN", "value", int.class, "Process every N files with the default being every file."),
-  CONTEXT_MISMATCH_AS_WARNING(null, "context-mismatch-as-warning", "When true, context mismatches will reported as warnings otherwise as info"),
+  DISABLE_CONTEXT_MISMATCH_WARNINGS(null, "disable-context-mismatch-warnings", "When present, context mismatches will reported as info otherwise as warnings"),
   /**
    * DEPRECATED: Flag to force the tool to perform validation against the schema and schematron
    * specified in a given label.

--- a/src/main/java/gov/nasa/pds/validate/commandline/options/Flag.java
+++ b/src/main/java/gov/nasa/pds/validate/commandline/options/Flag.java
@@ -69,6 +69,7 @@ public enum Flag {
       "Specify file extension for the labels files. Default: xml. NOTE: Support for intermingled bundles where collections have differing label file extensions is not yet supported."),
 
   EVERY_N(null, "everyN", "value", int.class, "Process every N files with the default being every file."),
+  CONTEXT_MISMATCH_AS_WARNING(null, "context-mismatch-as-warning", "When true, context mismatches will reported as warnings otherwise as info"),
   /**
    * DEPRECATED: Flag to force the tool to perform validation against the schema and schematron
    * specified in a given label.

--- a/src/main/java/gov/nasa/pds/validate/commandline/options/FlagOptions.java
+++ b/src/main/java/gov/nasa/pds/validate/commandline/options/FlagOptions.java
@@ -51,6 +51,7 @@ public class FlagOptions {
     options.addOption(new ToolsOption(Flag.CHECKSUM_MANIFEST));
     options.addOption(new ToolsOption(Flag.COMPLETE_DESCRIPTIONS));
     options.addOption(new ToolsOption(Flag.CONFIG));
+    options.addOption(new ToolsOption(Flag.CONTEXT_MISMATCH_AS_WARNING));
     options.addOption(new ToolsOption(Flag.MAX_ERRORS));
     options.addOption(new ToolsOption(Flag.EXTENSION));
     options.addOption(new ToolsOption(Flag.EVERY_N));

--- a/src/main/java/gov/nasa/pds/validate/commandline/options/FlagOptions.java
+++ b/src/main/java/gov/nasa/pds/validate/commandline/options/FlagOptions.java
@@ -51,7 +51,7 @@ public class FlagOptions {
     options.addOption(new ToolsOption(Flag.CHECKSUM_MANIFEST));
     options.addOption(new ToolsOption(Flag.COMPLETE_DESCRIPTIONS));
     options.addOption(new ToolsOption(Flag.CONFIG));
-    options.addOption(new ToolsOption(Flag.CONTEXT_MISMATCH_AS_WARNING));
+    options.addOption(new ToolsOption(Flag.DISABLE_CONTEXT_MISMATCH_WARNINGS));
     options.addOption(new ToolsOption(Flag.MAX_ERRORS));
     options.addOption(new ToolsOption(Flag.EXTENSION));
     options.addOption(new ToolsOption(Flag.EVERY_N));

--- a/src/test/java/gov/nasa/pds/validate/ValidationIntegrationTests.java
+++ b/src/test/java/gov/nasa/pds/validate/ValidationIntegrationTests.java
@@ -219,7 +219,7 @@ class ValidationIntegrationTests {
 
       count = this.getMessageCount(reportJson, ProblemType.CONTEXT_REFERENCE_NOT_FOUND.getKey());
       count +=
-          this.getMessageCount(reportJson, ProblemType.CONTEXT_REFERENCE_FOUND_MISMATCH.getKey());
+          this.getMessageCount(reportJson, ProblemType.CONTEXT_REFERENCE_FOUND_MISMATCH_INFO.getKey());
       assertEquals(count, 3,
           "Three errors expected for invalid context reference (Lid, name, value) test.");
 
@@ -255,7 +255,7 @@ class ValidationIntegrationTests {
       int count =
           this.getMessageCount(reportJson, ProblemType.CONTEXT_REFERENCE_NOT_FOUND.getKey());
       count +=
-          this.getMessageCount(reportJson, ProblemType.CONTEXT_REFERENCE_FOUND_MISMATCH.getKey());
+          this.getMessageCount(reportJson, ProblemType.CONTEXT_REFERENCE_FOUND_MISMATCH_INFO.getKey());
       assertEquals(count, 0, "No errors expected. Context validation disabled.");
 
       // test without option: "--no-context-valid"
@@ -274,7 +274,7 @@ class ValidationIntegrationTests {
 
       count = this.getMessageCount(reportJson, ProblemType.CONTEXT_REFERENCE_NOT_FOUND.getKey());
       count +=
-          this.getMessageCount(reportJson, ProblemType.CONTEXT_REFERENCE_FOUND_MISMATCH.getKey());
+          this.getMessageCount(reportJson, ProblemType.CONTEXT_REFERENCE_FOUND_MISMATCH_INFO.getKey());
       assertEquals(count, 3, "Three errors expected. Context validation enabled.");
 
     } catch (ExitException e) {

--- a/src/test/resources/features/developer.feature
+++ b/src/test/resources/features/developer.feature
@@ -76,7 +76,7 @@ Scenario Outline: Execute validate command for tests below.
 |"NASA-PDS/validate#631 Success context case matching" | "github631" | 0 | "0 errors expected" | "totalErrors" | "src/test/resources" | "target/test" | "-r {reportDir}/report_github631.json -s json -v 1 -t {resourceDir}/github631/hyb2_tir_20180629_075501_l1.xml" | "report_github631.json" |
 
 # Validate#628
-|"NASA-PDS/validate#628 Warning Version Mismatch" | "github628" | 1 | "1 warnings expected" | "totalWarnings" | "src/test/resources" | "target/test" | "-r {reportDir}/report_github628.json -s json --skip-content-validation -t {resourceDir}/github628/mp2_flat_20061109.xml" | "report_github628.json" |
+|"NASA-PDS/validate#628 Warning Version Mismatch" | "github628" | 1 | "1 warnings expected" | "totalWarnings" | "src/test/resources" | "target/test" | "-r {reportDir}/report_github628.json -s json --skip-content-validation --disable-context-mismatch-warnings -t {resourceDir}/github628/mp2_flat_20061109.xml" | "report_github628.json" |
 
 # Validate#617
 |"NASA-PDS/validate#617 Warning File Extension Mismatch" | "github617" | 1 | "1 warnings expected" | "totalWarnings" | "src/test/resources" | "target/test" | "-r {reportDir}/report_github617.json -s json --skip-content-validation -t {resourceDir}/github617/uvis_euv_2005_159_solar_time_series_ingress.xml" | "report_github617.json" |
@@ -210,8 +210,8 @@ Scenario Outline: Execute validate command for tests below.
 
 # https://github.com/NASA-PDS/validate/issues/15 Verify that all name/type attribute values correspond to names denoted context products
 
- |"NASA-PDS/validate#15 1" | "github15" | 0 | "0 valid context references should be found" | "CONTEXT_REFERENCE_NOT_FOUND" | "src/test/resources" | "target/test" | "-v1 -r {reportDir}/report_github15_pass.json -s json -R pds4.label -t {resourceDir}/github15/test_check-pass_context_products.xml" | "report_github15_pass.json" |
- |"NASA-PDS/validate#15 2" | "github15" | 4 | "4 errors expected for invalid context reference (Lid, name, value) test." | "CONTEXT_REFERENCE_NOT_FOUND,CONTEXT_REFERENCE_FOUND_MISMATCH_INFO" | "src/test/resources" | "target/test" | "-v1 -r {reportDir}/report_github15_no-pass.json -s json {resourceDir}/github15/test_check-no-pass_context_products.xml" | "report_github15_no-pass.json" |
+ |"NASA-PDS/validate#15 1" | "github15" | 0 | "0 valid context references should be found" | "CONTEXT_REFERENCE_NOT_FOUND" | "src/test/resources" | "target/test" | "-v1 -r {reportDir}/report_github15_pass.json -s json --disable-context-mismatch-warnings -R pds4.label -t {resourceDir}/github15/test_check-pass_context_products.xml" | "report_github15_pass.json" |
+ |"NASA-PDS/validate#15 2" | "github15" | 4 | "4 errors expected for invalid context reference (Lid, name, value) test." | "CONTEXT_REFERENCE_NOT_FOUND,CONTEXT_REFERENCE_FOUND_MISMATCH_INFO" | "src/test/resources" | "target/test" | "-v1 -r {reportDir}/report_github15_no-pass.json -s json --disable-context-mismatch-warnings {resourceDir}/github15/test_check-no-pass_context_products.xml" | "report_github15_no-pass.json" |
 
 # The below tests are for real.
 
@@ -222,8 +222,8 @@ Scenario Outline: Execute validate command for tests below.
  |"NASA-PDS/validate#137 1" | "github137" | 2 | "FIELD_VALUE_DATA_TYPE_MISMATCH info/error messages not expected." | "FIELD_VALUE_DATA_TYPE_MISMATCH" |  "src/test/resources" | "target/test" | "-r {reportDir}/report_github137_2.json -s json -t {resourceDir}/github137/delimited_table_bad.xml" | "report_github137_2.json" |
 
 ## Note that the reference code re-use the JSON report file for both tests but we won't
- |"NASA-PDS/validate#47 1" | "github47" | 0 | "No errors expected. Context validation disabled" | "CONTEXT_REFERENCE_NOT_FOUND" | "src/test/resources" | "target/test" | "-r {reportDir}/report_github47_disable-valid.json -s json -R pds4.label --skip-content-validation --skip-context-validation {resourceDir}/github47/test_context_products.xml" | "report_github47_disable-valid.json" |
- |"NASA-PDS/validate#47 2" | "github47" | 4 | "4 errors expected. Context validation enabled." | "CONTEXT_REFERENCE_NOT_FOUND,CONTEXT_REFERENCE_FOUND_MISMATCH_INFO" | "src/test/resources" | "target/test" | "-v1 --skip-content-validation -r {reportDir}/report_github47_enable-valid.json -s json -R pds4.label {resourceDir}/github47/test_context_products.xml" | "report_github47_enable-valid.json" |
+ |"NASA-PDS/validate#47 1" | "github47" | 0 | "No errors expected. Context validation disabled" | "CONTEXT_REFERENCE_NOT_FOUND" | "src/test/resources" | "target/test" | "-r {reportDir}/report_github47_disable-valid.json -s json --disable-context-mismatch-warnings -R pds4.label --skip-content-validation --skip-context-validation {resourceDir}/github47/test_context_products.xml" | "report_github47_disable-valid.json" |
+ |"NASA-PDS/validate#47 2" | "github47" | 4 | "4 errors expected. Context validation enabled." | "CONTEXT_REFERENCE_NOT_FOUND,CONTEXT_REFERENCE_FOUND_MISMATCH_INFO" | "src/test/resources" | "target/test" | "-v1 --skip-content-validation -r {reportDir}/report_github47_enable-valid.json -s json --disable-context-mismatch-warnings -R pds4.label {resourceDir}/github47/test_context_products.xml" | "report_github47_enable-valid.json" |
 
  |"NASA-PDS/validate#62 1"   | "github62" | 4 | "4 info.label.context_ref_found info messages expected.\n" | "CONTEXT_REFERENCE_FOUND" | "src/test/resources" | "target/test" | "-v1 -r {reportDir}/report_github62_1.json -s json --no-data-check -t {resourceDir}/github62/ele_mom_tblChar.xml"  | "report_github62_1.json" |
  |"NASA-PDS/validate#62 2" | "github62" | 8 | "8 info/error messages expected.\n" | "CONTEXT_REFERENCE_FOUND,CONTEXT_REFERENCE_NOT_FOUND" |  "src/test/resources" | "target/test" | "-v1 -r {reportDir}/report_github62_2.json -s json --no-data-check -t {resourceDir}/github62/spacecraft.orex_1.1.xml"  | "report_github62_2.json" |
@@ -261,12 +261,12 @@ Scenario Outline: Execute validate command for tests below.
 
 # The 3 tests below are from "github209"
 # There should be no WARN message for VALID test.
- |"NASA-PDS/validate#209 VALID" | "github209" | 0 | "0 WARN message(s) expected. See validation report:" | "totalWarnings" | "src/test/resources" | "target/test" | "-r {reportDir}/report_github209_1.json -s json  -t {resourceDir}/github209/VALID_odf07155_msgr_11.xml" | "report_github209_1.json" |
+ |"NASA-PDS/validate#209 VALID" | "github209" | 0 | "0 WARN message(s) expected. See validation report:" | "totalWarnings" | "src/test/resources" | "target/test" | "-r {reportDir}/report_github209_1.json -s json --disable-context-mismatch-warnings -t {resourceDir}/github209/VALID_odf07155_msgr_11.xml" | "report_github209_1.json" |
 # For some reason, when ran, the actual number is 4 instead of 1.
 # [{"severity":"ERROR","type":"error.table.field_value_overlap","table":12,"record":1,"field":5,"message":"The bit field overlaps the next field. Current stop_bit_location: 23. Next start_bit_location: 20"}]}]}],"summary":{"totalErrors":4,
- |"NASA-PDS/validate#209 FAIL1" | "github209" | 1 | "1 message(s) expected. See validation report:" | "FIELD_VALUE_OVERLAP" | "src/test/resources" | "target/test" | "-r {reportDir}/report_github209_2.json -s json  -t {resourceDir}/github209/FAIL1_overlapping_bit_fields.xml" | "report_github209_2.json" |
+ |"NASA-PDS/validate#209 FAIL1" | "github209" | 1 | "1 message(s) expected. See validation report:" | "FIELD_VALUE_OVERLAP" | "src/test/resources" | "target/test" | "-r {reportDir}/report_github209_2.json -s json --disable-context-mismatch-warnings -t {resourceDir}/github209/FAIL1_overlapping_bit_fields.xml" | "report_github209_2.json" |
 # ,{"severity":"ERROR","type":"error.table.bad_field_read","table":12,"record":1,"field":6,"message":"Error while getting field value: Stop bit past end of packed field (32 > 31)"}]}]}],"summary":{"totalErrors":5,
- |"NASA-PDS/validate#209 FAIL2" | "github209" | 2 | "2 message(s) expected. See validation report:" | "FIELD_VALUE_OVERLAP,BAD_FIELD_READ" | "src/test/resources" | "target/test" | "-r {reportDir}/report_github209_3.json -s json  -t {resourceDir}/github209/FAIL2_bad_stop_bit.xml" | "report_github209_3.json" |
+ |"NASA-PDS/validate#209 FAIL2" | "github209" | 2 | "2 message(s) expected. See validation report:" | "FIELD_VALUE_OVERLAP,BAD_FIELD_READ" | "src/test/resources" | "target/test" | "-r {reportDir}/report_github209_3.json -s json --disable-context-mismatch-warnings -t {resourceDir}/github209/FAIL2_bad_stop_bit.xml" | "report_github209_3.json" |
 #
 #
 # The correct location of file catalog.xml is in {reportDir} and not {resourceDir}
@@ -451,12 +451,12 @@ Scenario Outline: Execute validate command for tests below.
 # https://github.com/NASA-PDS/validate/issues/419 validate 2.2.0-SNAPSHOT warns about a pretty benign bundle + readme.txt 
 
 
- |"NASA-PDS/validate#419 VALID" | "github419" | 0 | "0 warning messages expected" | "totalWarnings" | "src/test/resources" | "target/test" | "-R pds4.label -r {reportDir}/report_github419_label_valid.json -s json -t {resourceDir}/github419/bundle_astromat_chem.xml" | "report_github419_label_valid.json" |
+ |"NASA-PDS/validate#419 VALID" | "github419" | 0 | "0 warning messages expected" | "totalWarnings" | "src/test/resources" | "target/test" | "-R pds4.label -r {reportDir}/report_github419_label_valid.json -s json --disable-context-mismatch-warnings -t {resourceDir}/github419/bundle_astromat_chem.xml" | "report_github419_label_valid.json" |
 
 
 # https://github.com/NASA-PDS/validate/issues/429 validate warns "document standard id ... is not correct" on good labels
 
- |"NASA-PDS/validate#429 VALID" | "github429" | 0 | "0 warning messages expected" | "totalWarnings" | "src/test/resources" | "target/test" | "-R pds4.label -r {reportDir}/report_github429_label_valid.json -s json -t {resourceDir}/github429/EPPS_EDR_SIS.xml" | "report_github429_label_valid.json" |
+ |"NASA-PDS/validate#429 VALID" | "github429" | 0 | "0 warning messages expected" | "totalWarnings" | "src/test/resources" | "target/test" | "-R pds4.label -r {reportDir}/report_github429_label_valid.json -s json --disable-context-mismatch-warnings -t {resourceDir}/github429/EPPS_EDR_SIS.xml" | "report_github429_label_valid.json" |
 
 # Validate#427
 |"NASA-PDS/validate#427 Success with spaces in directory" | "github427" | 0 | "0 errors expected" | "totalErrors" | "src/test/resources" | "target/test" | "-r {reportDir}/report_github427.json -s json --skip-context-validation  -t {resourceDir}/github427/dir%20with%20spaces/rs_20160518_014000_udsc64_l3_e_v10.xml" | "report_github427.json" |

--- a/src/test/resources/features/developer.feature
+++ b/src/test/resources/features/developer.feature
@@ -211,7 +211,7 @@ Scenario Outline: Execute validate command for tests below.
 # https://github.com/NASA-PDS/validate/issues/15 Verify that all name/type attribute values correspond to names denoted context products
 
  |"NASA-PDS/validate#15 1" | "github15" | 0 | "0 valid context references should be found" | "CONTEXT_REFERENCE_NOT_FOUND" | "src/test/resources" | "target/test" | "-v1 -r {reportDir}/report_github15_pass.json -s json -R pds4.label -t {resourceDir}/github15/test_check-pass_context_products.xml" | "report_github15_pass.json" |
- |"NASA-PDS/validate#15 2" | "github15" | 4 | "4 errors expected for invalid context reference (Lid, name, value) test." | "CONTEXT_REFERENCE_NOT_FOUND,CONTEXT_REFERENCE_FOUND_MISMATCH" | "src/test/resources" | "target/test" | "-v1 -r {reportDir}/report_github15_no-pass.json -s json {resourceDir}/github15/test_check-no-pass_context_products.xml" | "report_github15_no-pass.json" |
+ |"NASA-PDS/validate#15 2" | "github15" | 4 | "4 errors expected for invalid context reference (Lid, name, value) test." | "CONTEXT_REFERENCE_NOT_FOUND,CONTEXT_REFERENCE_FOUND_MISMATCH_INFO" | "src/test/resources" | "target/test" | "-v1 -r {reportDir}/report_github15_no-pass.json -s json {resourceDir}/github15/test_check-no-pass_context_products.xml" | "report_github15_no-pass.json" |
 
 # The below tests are for real.
 
@@ -223,7 +223,7 @@ Scenario Outline: Execute validate command for tests below.
 
 ## Note that the reference code re-use the JSON report file for both tests but we won't
  |"NASA-PDS/validate#47 1" | "github47" | 0 | "No errors expected. Context validation disabled" | "CONTEXT_REFERENCE_NOT_FOUND" | "src/test/resources" | "target/test" | "-r {reportDir}/report_github47_disable-valid.json -s json -R pds4.label --skip-content-validation --skip-context-validation {resourceDir}/github47/test_context_products.xml" | "report_github47_disable-valid.json" |
- |"NASA-PDS/validate#47 2" | "github47" | 4 | "4 errors expected. Context validation enabled." | "CONTEXT_REFERENCE_NOT_FOUND,CONTEXT_REFERENCE_FOUND_MISMATCH" | "src/test/resources" | "target/test" | "-v1 --skip-content-validation -r {reportDir}/report_github47_enable-valid.json -s json -R pds4.label {resourceDir}/github47/test_context_products.xml" | "report_github47_enable-valid.json" |
+ |"NASA-PDS/validate#47 2" | "github47" | 4 | "4 errors expected. Context validation enabled." | "CONTEXT_REFERENCE_NOT_FOUND,CONTEXT_REFERENCE_FOUND_MISMATCH_INFO" | "src/test/resources" | "target/test" | "-v1 --skip-content-validation -r {reportDir}/report_github47_enable-valid.json -s json -R pds4.label {resourceDir}/github47/test_context_products.xml" | "report_github47_enable-valid.json" |
 
  |"NASA-PDS/validate#62 1"   | "github62" | 4 | "4 info.label.context_ref_found info messages expected.\n" | "CONTEXT_REFERENCE_FOUND" | "src/test/resources" | "target/test" | "-v1 -r {reportDir}/report_github62_1.json -s json --no-data-check -t {resourceDir}/github62/ele_mom_tblChar.xml"  | "report_github62_1.json" |
  |"NASA-PDS/validate#62 2" | "github62" | 8 | "8 info/error messages expected.\n" | "CONTEXT_REFERENCE_FOUND,CONTEXT_REFERENCE_NOT_FOUND" |  "src/test/resources" | "target/test" | "-v1 -r {reportDir}/report_github62_2.json -s json --no-data-check -t {resourceDir}/github62/spacecraft.orex_1.1.xml"  | "report_github62_2.json" |


### PR DESCRIPTION
## 🗒️ Summary
Allow user to determine if context mismatches are info or warning with info being the default because least change to current behavior.

## ⚙️ Test Data and/or Report
Automated unit/regression tests below

## ♻️ Related Issues
Closes #861
Closes #860 
Closes #857 