### PR TITLE
Update handling of Infinity / NaN values as special constants when they are not represented as the data type of the parent object.

### DIFF
--- a/src/main/java/gov/nasa/pds/tools/validate/SpecialConstantChecker.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/SpecialConstantChecker.java
@@ -2,11 +2,21 @@ package gov.nasa.pds.tools.validate;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.List;
 import gov.nasa.arc.pds.xml.generated.SpecialConstants;
 import gov.nasa.pds.tools.validate.content.ProblemReporter;
 import gov.nasa.pds.tools.validate.content.SpecialConstantBitPatternTransforms;
 
 public class SpecialConstantChecker {
+  final private static List<String> INF_NAN_VALUES = Arrays.asList("INF", "-INF", "+INF", "INFINITY",
+      "-INFINITY", "+INFINITY", "NAN", "-NAN", "+NAN");
+  public static boolean isInf (String value) {
+    return INF_NAN_VALUES.subList(0, 6).contains(value.toUpperCase());
+  }
+  public static boolean isInfOrNan (String value) {
+    return INF_NAN_VALUES.contains (value.toUpperCase());
+  }
   /**
    * Use this when the special constant may not conform to the type constraints
    * meaning only string comparisons can be done.
@@ -150,6 +160,23 @@ public class SpecialConstantChecker {
     if (constant_repr == null) return false;
     if (number.toString().equals(constant_repr)) {
       return true;
+    }
+    if (isInfOrNan(constant_repr)) {
+      if (number instanceof BigDecimal || number instanceof Double) {
+        Double d = number instanceof Double ? (Double)number : ((BigDecimal)number).doubleValue();
+        if (isInf(constant_repr)) {
+          return d.isInfinite();
+        } else {
+          return d.isNaN();
+        }
+      }
+      if (number instanceof Float) {
+        if (isInf(constant_repr)) {
+          return ((Float)number).isInfinite();
+        } else {
+          return ((Float)number).isNaN();
+        }
+      }
     }
     if (number instanceof BigDecimal) number = ((BigDecimal)number).doubleValue();
     if (number instanceof Byte) number = BigInteger.valueOf(number.byteValue());

--- a/src/main/java/gov/nasa/pds/tools/validate/content/table/FieldValueValidator.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/content/table/FieldValueValidator.java
@@ -53,8 +53,6 @@ import gov.nasa.pds.tools.validate.rule.pds4.DateTimeValidator;
 public class FieldValueValidator {
   private static final Logger LOG = LoggerFactory.getLogger(FieldValueValidator.class);
   /** List of invalid values. */
-  private final List<String> INF_NAN_VALUES = Arrays.asList("INF", "-INF", "+INF", "INFINITY",
-      "-INFINITY", "+INFINITY", "NAN", "-NAN", "+NAN");
 
   /** List of valid datetime formats. */
   private static final Map<String, String> DATE_TIME_VALID_FORMATS = new HashMap<>();
@@ -578,7 +576,7 @@ public class FieldValueValidator {
 
     LOG.debug("checkType:value,type:after [{}],[{}]", value, type);
 
-    if (INF_NAN_VALUES.contains(value.toUpperCase()) && !realTypes.contains(type)) {
+    if (SpecialConstantChecker.isInfOrNan(value) && !realTypes.contains(type)) {
       throw new InvalidTableException(value + " is not allowed");
     }
     if (FieldType.ASCII_INTEGER.getXMLType().equals(type.getXMLType())) {


### PR DESCRIPTION
## 🗒️ Summary
Add the ability to use inf/nan for special constants. Does not in include #893 nor was any test data given.

## ⚙️ Test Data and/or Report
Automated unit/regression test below

Given test data size, here is validate after patch:
```
PDS Validate Tool Report

Configuration:
   Version     3.5.0-SNAPSHOT
   Date        2024-05-13T16:53:16Z

Parameters:
   Targets                      [file:/home/niessner/Projects/PDS/validate/src/test/resources/github844/MDIS_RTM_N01_010599_7521824_1.xml]
   Severity Level               WARNING
   Recurse Directories          true
   File Filters Used            [*.xml, *.XML]
   Data Content Validation      on
   Product Level Validation     on
   Max Errors                   100000
   Registered Contexts File     /home/niessner/Projects/PDS/validate/target/classes/util/registered_context_products.json

Product Level Validation Results

  PASS: file:/home/niessner/Projects/PDS/validate/src/test/resources/github844/MDIS_RTM_N01_010599_7521824_1.xml
        1 product validation(s) completed

Summary:

  1 product(s)
  0 error(s)
  0 warning(s)

  Product Validation Summary:
    1          product(s) passed
    0          product(s) failed
    0          product(s) skipped
    1          product(s) total

  Referential Integrity Check Summary:
    0          check(s) passed
    0          check(s) failed
    0          check(s) skipped
    0          check(s) total


End of Report
Completed execution in 18477 ms
```

## ♻️ Related Issues
Closes #844 