### PR TITLE
Downgrade maven-site-plugin per bug with markdown

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
-        <version>4.0.0-M15</version>
+        <version>4.0.0-M13</version>
         <configuration>
           <skip>false</skip>  <!-- This is `true` in parent pom -->
           <skipDeploy>false</skipDeploy>  <!-- This is `true` in parent pom -->


### PR DESCRIPTION
Maven-site-plugin appears to have a bug where it is not generating the site for markdown files for versions 4.0.0-M14+.

Resolves #933

<img width="1176" alt="Screenshot 2024-06-11 at 11 50 14 AM" src="https://github.com/NASA-PDS/validate/assets/33492486/4f39e571-414d-43b2-9b8d-c95441f13215">

