### PR TITLE
Update PDF-A checker to fix mismatched filenames in error messages

### DIFF
--- a/src/main/java/gov/nasa/pds/tools/util/PDFUtil.java
+++ b/src/main/java/gov/nasa/pds/tools/util/PDFUtil.java
@@ -23,13 +23,11 @@ import org.verapdf.pdfa.results.ValidationResult;
  */
 public class PDFUtil {
   private static final Logger LOG = LoggerFactory.getLogger(PDFUtil.class);
-  private URL target = null;
   private String externalErrorFilename = null;
   private String parserFlavor = null;
   private String errorMessage = null;
 
-  public PDFUtil(URL target) {
-    this.target = target;
+  public PDFUtil() {
     VeraGreenfieldFoundryProvider.initialise(); // Should only do this once.
   }
 
@@ -39,14 +37,6 @@ public class PDFUtil {
    */
   public synchronized String getExternalErrorFilename() {
     return (this.externalErrorFilename);
-  }
-
-  /**
-   * Returns the URL of the target.
-   *
-   */
-  public URL getTarget() {
-    return (this.target);
   }
 
   private synchronized void writeErrorToFile(String baseDir, String pdfFullName, ValidationResult result, String flavor) {
@@ -149,7 +139,7 @@ public class PDFUtil {
    * @return true if the PDF is PDF/A compliant, and false otherwise
    *
    */
-  public synchronized boolean validateFileStandardConformity(String baseDir, String pdfBase, URL parentURL)
+  public synchronized boolean validateFileStandardConformity(String baseDir, String pdfBase, URL parentURL, URL target)
       throws Exception {
     // Do the validation of the PDF document.
     // https://verapdf.org/category/software/
@@ -160,15 +150,15 @@ public class PDFUtil {
     // Get the location of the PDF file.
     URI uri = null;
     try {
-      uri = getTarget().toURI();
+      uri = target.toURI();
     } catch (URISyntaxException e) {
       // Should never happen
       // but if it does, print an error message and returns false for pdfValidateFlag.
       // Observed in DEV that if the file name contains spaces, the getURI() results
       // in the URISyntaxException exception.
-      LOG.error("validateFileStandardConformity:Cannot build URI for target {}", getTarget());
+      LOG.error("validateFileStandardConformity:Cannot build URI for target {}", target);
       throw new Exception(
-          "validateFileStandardConformity:Cannot build URI for target [" + getTarget() + "]");
+          "validateFileStandardConformity:Cannot build URI for target [" + target + "]");
     }
 
     // Get the parent from parentURL instead of using "new

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/FileReferenceValidationRule.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/FileReferenceValidationRule.java
@@ -755,14 +755,14 @@ public class FileReferenceValidationRule extends AbstractValidationRule {
 
     if (this.pdfUtil == null) {
       // Save pdfUtil so it can be reused.
-      this.pdfUtil = new PDFUtil(fileRef);
+      this.pdfUtil = new PDFUtil();
     }
 
     // First, let's check the filename even makes sense
     DocumentsChecker check = new DocumentsChecker();
     if (check.isMimeTypeCorrect(fileRef.toString(), "PDF/A")) {
       // The parent is also needed for validateFileStandardConformity function.
-      pdfValidateFlag = this.pdfUtil.validateFileStandardConformity(this.getContext().getPDFErrorDir(), pdfName, new URL(parent, directory));
+      pdfValidateFlag = this.pdfUtil.validateFileStandardConformity(this.getContext().getPDFErrorDir(), pdfName, new URL(parent, directory), fileRef);
 
       // Report an error if the PDF file is not PDF/A compliant.
       if (!pdfValidateFlag && TargetExaminer.isTargetDocumentType(target.getUrl())) {

--- a/src/test/resources/github693/test1_invalid_pdfa_2b.xml
+++ b/src/test/resources/github693/test1_invalid_pdfa_2b.xml
@@ -7,7 +7,7 @@
     xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1 
          https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1B00.xsd">
     <Identification_Area>
-        <logical_identifier>urn:nasa:pds:cocirs_c2h4abund:document:cocirs_c2h4abund_document2</logical_identifier>
+        <logical_identifier>urn:nasa:pds:cocirs_c2h4abund:document:cocirs_c2h4abund_document2_t1</logical_identifier>
         <version_id>1.0</version_id>
         <title>Ethylene Emission in the Aftermath of Saturn's 2010 Northern Storm</title>
         <information_model_version>1.11.0.0</information_model_version>

--- a/src/test/resources/github693/test2_invalid_pdf.xml
+++ b/src/test/resources/github693/test2_invalid_pdf.xml
@@ -7,7 +7,7 @@
     xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1 
          https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1B00.xsd">
     <Identification_Area>
-        <logical_identifier>urn:nasa:pds:cocirs_c2h4abund:document:cocirs_c2h4abund_document2</logical_identifier>
+        <logical_identifier>urn:nasa:pds:cocirs_c2h4abund:document:cocirs_c2h4abund_document2_t2</logical_identifier>
         <version_id>1.0</version_id>
         <title>Ethylene Emission in the Aftermath of Saturn's 2010 Northern Storm</title>
         <information_model_version>1.11.0.0</information_model_version>

--- a/src/test/resources/github693/test3_invalid_pdfa_3a.xml
+++ b/src/test/resources/github693/test3_invalid_pdfa_3a.xml
@@ -7,7 +7,7 @@
     xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1 
          https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1B00.xsd">
     <Identification_Area>
-        <logical_identifier>urn:nasa:pds:cocirs_c2h4abund:document:cocirs_c2h4abund_document2</logical_identifier>
+        <logical_identifier>urn:nasa:pds:cocirs_c2h4abund:document:cocirs_c2h4abund_document2_t3</logical_identifier>
         <version_id>1.0</version_id>
         <title>Ethylene Emission in the Aftermath of Saturn's 2010 Northern Storm</title>
         <information_model_version>1.11.0.0</information_model_version>

--- a/src/test/resources/github693/test4_invalid_pdfa.xml
+++ b/src/test/resources/github693/test4_invalid_pdfa.xml
@@ -7,7 +7,7 @@
     xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1 
          https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1B00.xsd">
     <Identification_Area>
-        <logical_identifier>urn:nasa:pds:cocirs_c2h4abund:document:cocirs_c2h4abund_document2</logical_identifier>
+        <logical_identifier>urn:nasa:pds:cocirs_c2h4abund:document:cocirs_c2h4abund_document2_t4</logical_identifier>
         <version_id>1.0</version_id>
         <title>Ethylene Emission in the Aftermath of Saturn's 2010 Northern Storm</title>
         <information_model_version>1.11.0.0</information_model_version>


### PR DESCRIPTION
## 🗒️ Summary
Changed PDFUtils to not record target as unchanging value.

## ⚙️ Test Data and/or Report
Beyond reach of regression tests. Was this:
```
  FAIL: test3_invalid_pdfa_3a.xml
      ERROR  [error.pdf.file.not_pdfa_compliant]   Invalid PDF/A version detected for test3_invalid_pdfa_3a.pdf. Expected: 1a or 1b. Actual: 3a
        1 product validation(s) completed
  FAIL: test1_invalid_pdfa_2b.xml
      ERROR  [error.pdf.file.not_pdfa_compliant]   Invalid PDF/A version detected for test3_invalid_pdfa_3a.pdf. Expected: 1a or 1b. Actual: 2b
```

Notice that on the second test it still shows the first PDF file as the problem. This matches the reported issue. Updating to not use target in constructor:
```
  FAIL: test3_invalid_pdfa_3a.xml
      ERROR  [error.pdf.file.not_pdfa_compliant]   Invalid PDF/A version detected for test3_invalid_pdfa_3a.pdf. Expected: 1a or 1b. Actual: 3a
        1 product validation(s) completed
  FAIL: test1_invalid_pdfa_2b.xml
      ERROR  [error.pdf.file.not_pdfa_compliant]   Invalid PDF/A version detected for test1_invalid_pdfa_2b.pdf. Expected: 1a or 1b. Actual: 2b
        2 product validation(s) completed
```

Notice that the PDF names reflect the test label names better.

## ♻️ Related Issues
Closes #936 

