### PR TITLE
Specify specific maven project.version in the validate execution scripts

### DIFF
--- a/src/main/assembly/tar-assembly.xml
+++ b/src/main/assembly/tar-assembly.xml
@@ -56,7 +56,7 @@ POSSIBILITY OF SUCH DAMAGE.
       </excludes>
     </fileSet>
     <fileSet>
-      <directory>src/main/resources/bin</directory>
+      <directory>target/classes/bin</directory>
       <outputDirectory>bin</outputDirectory>
       <includes>
         <include>validate</include>
@@ -69,7 +69,7 @@ POSSIBILITY OF SUCH DAMAGE.
       <lineEnding>keep</lineEnding>
     </fileSet>
     <fileSet>
-      <directory>src/main/resources/bin</directory>
+      <directory>target/classes/bin</directory>
       <outputDirectory>bin</outputDirectory>
       <includes>
         <include>logging.properties</include>

--- a/src/main/assembly/zip-assembly.xml
+++ b/src/main/assembly/zip-assembly.xml
@@ -56,7 +56,7 @@ POSSIBILITY OF SUCH DAMAGE.
       </excludes>
     </fileSet>
     <fileSet>
-      <directory>src/main/resources/bin</directory>
+      <directory>target/classes/bin</directory>
       <outputDirectory>bin</outputDirectory>
       <includes>
         <include>validate</include>
@@ -69,7 +69,7 @@ POSSIBILITY OF SUCH DAMAGE.
       <lineEnding>keep</lineEnding>
     </fileSet>
     <fileSet>
-      <directory>src/main/resources/bin</directory>
+      <directory>target/classes/bin</directory>
       <outputDirectory>bin</outputDirectory>
       <includes>
         <include>logging.properties</include>

--- a/src/main/resources/bin/validate
+++ b/src/main/resources/bin/validate
@@ -59,7 +59,7 @@ if [ ! -f ${LIB_DIR}/validate-*.jar ]; then
 fi
 
 # Finds the jar file in LIB_DIR and sets it to VALIDATE_JAR.
-VALIDATE_JAR=`ls ${LIB_DIR}/validate-@project.version@.jar`
+VALIDATE_JAR=${LIB_DIR}/validate-@project.version@.jar
 
 # Executes Validate Tool via the executable jar file
 # Arguments are passed in to the tool via '$@'

--- a/src/main/resources/bin/validate
+++ b/src/main/resources/bin/validate
@@ -59,7 +59,7 @@ if [ ! -f ${LIB_DIR}/validate-*.jar ]; then
 fi
 
 # Finds the jar file in LIB_DIR and sets it to VALIDATE_JAR.
-VALIDATE_JAR=`ls ${LIB_DIR}/validate-*.jar`
+VALIDATE_JAR=`ls ${LIB_DIR}/validate-@project.version@.jar`
 
 # Executes Validate Tool via the executable jar file
 # Arguments are passed in to the tool via '$@'

--- a/src/main/resources/bin/validate-refs
+++ b/src/main/resources/bin/validate-refs
@@ -59,7 +59,7 @@ if [ ! -f ${LIB_DIR}/validate-*.jar ]; then
 fi
 
 # Finds the jar file in LIB_DIR and sets it to VALIDATE_JAR.
-VALIDATE_JAR=`ls ${LIB_DIR}/validate-@project.version@.jar`
+VALIDATE_JAR=${LIB_DIR}/validate-@project.version@.jar
 
 # Executes Validate Tool via the executable jar file
 # Arguments are passed in to the tool via '$@'

--- a/src/main/resources/bin/validate-refs
+++ b/src/main/resources/bin/validate-refs
@@ -59,7 +59,7 @@ if [ ! -f ${LIB_DIR}/validate-*.jar ]; then
 fi
 
 # Finds the jar file in LIB_DIR and sets it to VALIDATE_JAR.
-VALIDATE_JAR=`ls ${LIB_DIR}/validate-*.jar`
+VALIDATE_JAR=`ls ${LIB_DIR}/validate-@project.version@.jar`
 
 # Executes Validate Tool via the executable jar file
 # Arguments are passed in to the tool via '$@'

--- a/src/main/resources/bin/validate-refs.bat
+++ b/src/main/resources/bin/validate-refs.bat
@@ -48,15 +48,12 @@ set PARENT_DIR=%SCRIPT_DIR%..
 set LIB_DIR=%PARENT_DIR%\lib
 
 :: Check for dependencies.
-if exist "%LIB_DIR%\validate-*.jar" (
-set VALIDATE_JAR=%LIB_DIR%\validate-*.jar
+if exist "%LIB_DIR%\validate-@project.version@.jar" (
+set VALIDATE_JAR=%LIB_DIR%\validate-@project.version@.jar
 ) else (
-echo Cannot find VTool jar file in %LIB_DIR%
+echo Cannot find VTool jar file (validate-@project.version@.jar) in %LIB_DIR%
 goto END
 )
-
-:: Finds the jar file in LIB_DIR and sets it to VALIDATE_JAR
-for %%i in ("%LIB_DIR%"\validate-*.jar) do set VALIDATE_JAR=%%i
 
 :: Executes the Validate Tool via the executable jar file
 :: The special variable '%*' allows the arguments

--- a/src/main/resources/bin/validate.bat
+++ b/src/main/resources/bin/validate.bat
@@ -48,15 +48,12 @@ set PARENT_DIR=%SCRIPT_DIR%..
 set LIB_DIR=%PARENT_DIR%\lib
 
 :: Check for dependencies.
-if exist "%LIB_DIR%\validate-*.jar" (
-set VALIDATE_JAR=%LIB_DIR%\validate-*.jar
+if exist "%LIB_DIR%\validate-@project.validate@.jar" (
+set VALIDATE_JAR=%LIB_DIR%\validate-@project.version@.jar
 ) else (
-echo Cannot find VTool jar file in %LIB_DIR%
+echo Cannot find VTool jar file (validate-@project.validate@.jar) in %LIB_DIR%
 goto END
 )
-
-:: Finds the jar file in LIB_DIR and sets it to VALIDATE_JAR
-for %%i in ("%LIB_DIR%"\validate-*.jar) do set VALIDATE_JAR=%%i
 
 :: Executes the Validate Tool via the executable jar file
 :: The special variable '%*' allows the arguments


### PR DESCRIPTION
## 🗒️ Summary
Updated scripts so that maven filtering will do substitutions during maven build

## ⚙️ Test Data and/or Report
Outside of java and regression tests.

validate now looks like this after mvn build:
```
VALIDATE_JAR=${LIB_DIR}/validate-3.6.0-SNAPSHOT.jar
```

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->


