### PR TITLE
Fix for disabling context ref mismatch for `pds4.collection` and `pds4.bundle` rules

### DIFF
--- a/src/main/java/gov/nasa/pds/tools/validate/rule/AbstractValidationRule.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/AbstractValidationRule.java
@@ -113,7 +113,8 @@ public abstract class AbstractValidationRule implements ValidationRule {
     newContext.setLabelExtension(context.getLabelExtension());
     newContext.setLabelPattern(context.getLabelPattern());
     newContext.setLastDirectoryFlag(context.isLastDirectory());
-
+    newContext.setEveryN(this.context.getEveryN());
+    newContext.setContextMismatchAsWarn(this.context.getContextMismatchAsWarn());
     return newContext;
   }
 

--- a/src/test/resources/features/developer.feature
+++ b/src/test/resources/features/developer.feature
@@ -15,6 +15,9 @@ Scenario Outline: Execute validate command for tests below.
 # Validate#915
 |"NASA-PDS/validate#915 Failure context ref mismatch" | "github915" | 4 | "4 warnings expected" | "CONTEXT_REFERENCE_FOUND_MISMATCH_WARN" | "src/test/resources"   | "target/test" | "-r {reportDir}/report_github915.json -s json --skip-content-validation -R pds4.collection -t {resourceDir}/github915/collection.xml" | "report_github915.json" |
 
+# Validate#950
+|"NASA-PDS/validate#950 Disable context ref mismatch collection" | "github915" | 0 | "0 warnings expected" | "CONTEXT_REFERENCE_FOUND_MISMATCH_WARN" | "src/test/resources"   | "target/test" | "-r {reportDir}/report_github950.json -s json --skip-content-validation -R pds4.collection -t {resourceDir}/github915/collection.xml" | "report_github950.json" |
+
 # Validate#905
 |"NASA-PDS/validate#905 Success no duplicates in non-observational;" | "github905" | 0 | "0 errors expected" | "totalErrors" | "src/test/resources"   | "target/test" | "-r {reportDir}/report_github905.json -s json --skip-context-validation -t {resourceDir}/github905/dsn_0159-science.2008-02-29.xml {resourceDir}/github905/dsn_0159-science.2009-05-18.xml" | "report_github905.json" |
 

--- a/src/test/resources/features/developer.feature
+++ b/src/test/resources/features/developer.feature
@@ -9,14 +9,14 @@ Scenario Outline: Execute validate command for tests below.
   Examples:
  | testName                                             | testDir     | messageCount | messageText         | problemEnum     | resourceDir          | reportDir     | commandArgs                                                                | refOutputValue | 
 
+# Validate#950
+|"NASA-PDS/validate#950 Disable context ref mismatch collection" | "github915" | 0 | "0 warnings expected" | "CONTEXT_REFERENCE_FOUND_MISMATCH_WARN" | "src/test/resources"   | "target/test" | "-r {reportDir}/report_github950.json -s json --skip-content-validation --disable-context-mismatch-warnings -R pds4.collection -t {resourceDir}/github915/collection.xml" | "report_github950.json" |
+
 # Validate#919
 |"NASA-PDS/validate#919 Success with 61 bit value" | "github919" | 0 | "0 errors expected" | "totalErrors" | "src/test/resources"   | "target/test" | "-r {reportDir}/report_github919.json -s json --skip-context-validation -t {resourceDir}/github919/uh0003b_draft.xml" | "report_github919.json" |
 
 # Validate#915
 |"NASA-PDS/validate#915 Failure context ref mismatch" | "github915" | 4 | "4 warnings expected" | "CONTEXT_REFERENCE_FOUND_MISMATCH_WARN" | "src/test/resources"   | "target/test" | "-r {reportDir}/report_github915.json -s json --skip-content-validation -R pds4.collection -t {resourceDir}/github915/collection.xml" | "report_github915.json" |
-
-# Validate#950
-|"NASA-PDS/validate#950 Disable context ref mismatch collection" | "github915" | 0 | "0 warnings expected" | "CONTEXT_REFERENCE_FOUND_MISMATCH_WARN" | "src/test/resources"   | "target/test" | "-r {reportDir}/report_github950.json -s json --skip-content-validation -R pds4.collection -t {resourceDir}/github915/collection.xml" | "report_github950.json" |
 
 # Validate#905
 |"NASA-PDS/validate#905 Success no duplicates in non-observational;" | "github905" | 0 | "0 errors expected" | "totalErrors" | "src/test/resources"   | "target/test" | "-r {reportDir}/report_github905.json -s json --skip-context-validation -t {resourceDir}/github905/dsn_0159-science.2008-02-29.xml {resourceDir}/github905/dsn_0159-science.2009-05-18.xml" | "report_github905.json" |


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary
Fix for disabling context ref mismatch for `pds4.collection` and `pds4.bundle` rules

## ⚙️ Test Data and/or Report
See new test case added

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->
Resolves #950 

