### PR TITLE
Performance improvements for referential integrity checking

### DIFF
--- a/src/main/java/gov/nasa/pds/tools/util/ReferentialIntegrityUtil.java
+++ b/src/main/java/gov/nasa/pds/tools/util/ReferentialIntegrityUtil.java
@@ -949,7 +949,7 @@ public class ReferentialIntegrityUtil {
    */
   protected static void reportError(ProblemDefinition defn, URL targetUrl, int lineNumber,
       int columnNumber) {
-    ValidationProblem problem = new ValidationProblem(defn, new ValidationTarget(targetUrl),
+    ValidationProblem problem = new ValidationProblem(defn, ValidationTarget.build(targetUrl),
         lineNumber, columnNumber, defn.getMessage());
     problemListener.addProblem(problem);
   }
@@ -965,7 +965,7 @@ public class ReferentialIntegrityUtil {
    */
   protected static void reportError(ProblemDefinition defn, URL target, int lineNumber,
       int columnNumber, String message) {
-    ValidationProblem problem = new ValidationProblem(defn, new ValidationTarget(target),
+    ValidationProblem problem = new ValidationProblem(defn, ValidationTarget.build(target),
         lineNumber, columnNumber, message);
     problemListener.addProblem(problem);
   }

--- a/src/main/java/gov/nasa/pds/tools/util/ReferentialIntegrityUtil.java
+++ b/src/main/java/gov/nasa/pds/tools/util/ReferentialIntegrityUtil.java
@@ -49,9 +49,10 @@ public class ReferentialIntegrityUtil {
   private static ArrayList<URL> urlsParsedCumulative = new ArrayList<>(0);
   private static ArrayList<String> logicalIdentifiersCumulative = new ArrayList<>(0);
   private static ArrayList<String> lidOrLidVidReferencesCumulative = new ArrayList<>(0);
+  private static HashSet<String> lidAndFilenameCombo = new HashSet<String>();
   private static HashMap<String, HashSetReferenceInfo> contextReferencesCumulative =
       new HashMap<>(0); // Collect all references defined in "Context_Area" tag from all labels.
-  private static HashMap<String, HashSet> bundleOrCollectionReferenceMap = new HashMap<String, HashSet>(); // Collect
+  private static HashMap<String, HashSet<String>> bundleOrCollectionReferenceMap = new HashMap<String, HashSet<String>>(); // Collect
                                                                                             // all
                                                                                             // references
                                                                                             // defined
@@ -170,6 +171,7 @@ public class ReferentialIntegrityUtil {
     // and it will be difficult to figure out why. The code may work when validate
     // runs from the command line
     // but not in regression test.
+    ReferentialIntegrityUtil.lidAndFilenameCombo.clear();
     ReferentialIntegrityUtil.logicalIdentifiersCumulative.clear();
     ReferentialIntegrityUtil.lidOrLidVidReferencesCumulative.clear();
     ReferentialIntegrityUtil.contextReferencesCumulative.clear();
@@ -466,35 +468,6 @@ public class ReferentialIntegrityUtil {
     }
   }
 
-  private static boolean hasReferenceIDAndFilenameComboAdded(String singleLidorLidVidReference,
-      URL filename) {
-    boolean referenceIDAndFilenameComboAddedFlag = false;
-    // Build the combo of reference and filename together from input parameters.
-    // Remove the use of the slash '/' to avoid confusion. We are merely looking at
-    // the combination of the lid_reference (or lidvid_reference) plus filename as
-    // strings for comparison.
-    String referenceIDAndFilenameComboValue = singleLidorLidVidReference + filename.toString();
-    for (int ii = 0; ii < ReferentialIntegrityUtil.lidOrLidVidReferencesCumulative.size(); ii++) {
-      // Build the combo of reference and filename together from each value in
-      // ReferentialIntegrityUtil.lidOrLidVidReferencesCumulative.get and
-      // ReferentialIntegrityUtil.lidOrLidVidReferencesCumulativeFileNames.get.
-      // Remove the use of the slash '/' to avoid confusion. We are merely looking at
-      // the combination of the lid_reference (or lidvid_reference) plus filename as
-      // strings for comparison.
-      String singleComboValue = ReferentialIntegrityUtil.lidOrLidVidReferencesCumulative.get(ii)
-          + ReferentialIntegrityUtil.lidOrLidVidReferencesCumulativeFileNames.get(ii);
-      LOG.debug(
-          "hasReferenceIDAndFilenameComboAdded:referenceIDAndFilenameComboValue,singleComboValue {},{}",
-          referenceIDAndFilenameComboValue, singleComboValue);
-      if (referenceIDAndFilenameComboValue.equals(singleComboValue)) {
-        // If there is a compare, we have found our answer and will break out of loop.
-        referenceIDAndFilenameComboAddedFlag = true;
-        break;
-      }
-    }
-    return (referenceIDAndFilenameComboAddedFlag);
-  }
-
   private static boolean isIdentiferMatchingBundleBaseID(String singleLogicalIdentifier) {
     // Given a logical identifier, check if it contains the bundle base identifier.
     // If the bundle base identifier is urn:nasa:pds:kaguya_grs_spectra
@@ -757,10 +730,10 @@ public class ReferentialIntegrityUtil {
 
     boolean labelIsCollectionFlag = false;
     boolean labelIsBundleFlag = false;
+    List<Target> children = new ArrayList<>();
     String parentId = null;
 
     try {
-      List<Target> children = new ArrayList<>();
       if (getContext().getCrawler() != null) {
         children = getContext().getCrawler().crawl(crawlTarget, true, getContext().getFileFilters()); // Get also the directories.
       } else {
@@ -790,15 +763,15 @@ public class ReferentialIntegrityUtil {
         // local_identifier and lid_reference or lidvid_reference tags.
         url = child.getUrl();
 
-        if (url.toString().endsWith("." + getContext().getLabelExtension()) && TargetExaminer.isTargetALabel(url)) {
+        // Check this URL has been parsed before. If yes, skip this file.
+        if (ReferentialIntegrityUtil.urlsParsedCumulative.contains(url)) {
+          LOG.info("SKIPPING_URL_TRUE:referenceType,url {},{}",
+              ReferentialIntegrityUtil.getReferenceType(), url);
+          continue;
+        }
 
-          // Check this URL has been parsed before. If yes, skip this file.
-          if (ReferentialIntegrityUtil.urlsParsedCumulative.contains(url)) {
-            LOG.info("SKIPPING_URL_TRUE:referenceType,url {},{}",
-                ReferentialIntegrityUtil.getReferenceType(), url);
-            continue;
-          }
-          LOG.info("SKIPPING_URL_FALSE:referenceType,url {},{}",
+        if (url.toString().endsWith("." + getContext().getLabelExtension()) && TargetExaminer.isTargetALabel(url)) {
+         LOG.info("SKIPPING_URL_FALSE:referenceType,url {},{}",
               ReferentialIntegrityUtil.getReferenceType(), url);
           labelIsCollectionFlag = false;
           labelIsBundleFlag = false;
@@ -813,10 +786,8 @@ public class ReferentialIntegrityUtil {
           if (TargetExaminer.isTargetCollectionType (child.getUrl())) {
             labelIsCollectionFlag = true;
           }
-
           xml = db.parse(url.openStream());
           domSource = new DOMSource(xml);
-
           // Note that the function getLidVidReferences() collects all references in the
           // Reference_List group in Internal_Reference tags.
           // so the lidOrLidVidReferencesCumulative will be a cumulative collection of all
@@ -824,7 +795,6 @@ public class ReferentialIntegrityUtil {
 
           ArrayList<String> lidOrLidVidReferences = LabelUtil.getLidVidReferences(domSource, url);
           ArrayList<String> logicalIdentifiers = LabelUtil.getLogicalIdentifiers(domSource, url);
-
           LOG.debug("additionalReferentialIntegrityChecks:url,lidOrLidVidReferences {},{}", url,
               lidOrLidVidReferences.size());
           LOG.debug("additionalReferentialIntegrityChecks:url,logicalIdentifiers {},{}", url,
@@ -848,6 +818,7 @@ public class ReferentialIntegrityUtil {
           }
 
           if ((lidOrLidVidReferences != null) && !lidOrLidVidReferences.isEmpty()) {
+            String urlstr = url.toString();
             for (int ii = 0; ii < lidOrLidVidReferences.size(); ii++) {
               LOG.debug(
                   "additionalReferentialIntegrityChecks:ii,url,lidOrLidVidReferences.get(ii) {},{},[{}]",
@@ -859,7 +830,7 @@ public class ReferentialIntegrityUtil {
               // Note that because the reference id can be the same, the combination of the id
               // plus the file name will make it unique.
               if (!ReferentialIntegrityUtil
-                  .hasReferenceIDAndFilenameComboAdded(lidOrLidVidReferences.get(ii), url)) {
+                  .lidAndFilenameCombo.contains(lidOrLidVidReferences.get(ii) + urlstr)) {
 
                 ReferentialIntegrityUtil.lidOrLidVidReferencesCumulative
                     .add(lidOrLidVidReferences.get(ii));
@@ -874,7 +845,7 @@ public class ReferentialIntegrityUtil {
                                                                                             // be
                                                                                             // referred
                                                                                             // to.
-
+                ReferentialIntegrityUtil.lidAndFilenameCombo.add(lidOrLidVidReferences.get(ii) + urlstr);
                 LOG.debug("additionalReferentialIntegrityChecks:ADDING_REFERENCE {}",
                     lidOrLidVidReferences.get(ii), lidOrLidVidReferencesCumulative.size());
               }
@@ -938,7 +909,7 @@ public class ReferentialIntegrityUtil {
         ReferentialIntegrityUtil.referenceType, crawlTarget, bundleOrCollectionReferenceMap,
         bundleOrCollectionReferenceMap.size());
   }
-
+ 
   /**
    * Reports an error to the validation listener.
    *

--- a/src/main/java/gov/nasa/pds/tools/util/Utility.java
+++ b/src/main/java/gov/nasa/pds/tools/util/Utility.java
@@ -23,11 +23,9 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLSocketFactory;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.slf4j.Logger;
@@ -35,7 +33,6 @@ import org.slf4j.LoggerFactory;
 import org.xml.sax.InputSource;
 import gov.nasa.pds.tools.validate.TargetExaminer;
 import gov.nasa.pds.tools.validate.TargetType;
-import gov.nasa.pds.tools.validate.ValidationTarget;
 
 /**
  * Utility class.
@@ -45,15 +42,6 @@ import gov.nasa.pds.tools.validate.ValidationTarget;
  */
 public class Utility {
   private static final Logger LOG = LoggerFactory.getLogger(Utility.class);
-
-  // A static cache of the ValidationTargets.
-  // There is no need to re-evaluate and/or create these
-  // as validation proceeds, as they are static things like
-  // a file or a URL.
-  public static HashMap<String, ValidationTarget> cachedTargets;
-  static {
-    cachedTargets = new HashMap<>();
-  }
 
   // Implementation is needed since pds.nasa.gov currently uses SNI
   // which is not supported in Java 6, but is supported in Java 7.
@@ -68,40 +56,6 @@ public class Utility {
             return false;
           }
         });
-  }
-
-  /**
-   * Returns a ValidationTarget for the specified target URL.
-   *
-   * If a cached target already exists in the cache, then that is returned, otherwise a new
-   * ValidationTarget is returned.
-   *
-   */
-  public static ValidationTarget getValidationTarget(URL target) {
-    if (target == null) {
-      // for backwards-compatability with previous code, supporting the null case.
-      // This seems to be null in the additional context products case.
-      return new ValidationTarget(null);
-    }
-    ValidationTarget valTarget = cachedTargets.get(target.toString());
-    if (valTarget == null) {
-      valTarget = new ValidationTarget(target);
-      cachedTargets.put(target.toString(), valTarget);
-    }
-    return valTarget;
-  }
-  public static ValidationTarget getValidationTarget(URL source, URL label) {
-    if (source == null) {
-      // for backwards-compatability with previous code, supporting the null case.
-      // This seems to be null in the additional context products case.
-      return new ValidationTarget(null);
-    }
-    ValidationTarget valTarget = cachedTargets.get(source.toString());
-    if (valTarget == null) {
-      valTarget = new ValidationTarget(source, label);
-      cachedTargets.put(source.toString(), valTarget);
-    }
-    return valTarget;
   }
 
   /**
@@ -126,8 +80,8 @@ public class Utility {
           SSLContext context = SSLContext.getInstance("TLSv1.2");
           context.init(null, null, new java.security.SecureRandom());
           HttpsURLConnection test = (HttpsURLConnection) conn;
-          SSLSocketFactory sf = test.getSSLSocketFactory();
-          SSLSocketFactory d = HttpsURLConnection.getDefaultSSLSocketFactory();
+          test.getSSLSocketFactory();
+          HttpsURLConnection.getDefaultSSLSocketFactory();
           ((HttpsURLConnection) conn).setSSLSocketFactory(context.getSocketFactory());
         } catch (Exception e) {
           throw new IOException(e.getMessage());

--- a/src/main/java/gov/nasa/pds/tools/validate/Identifier.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/Identifier.java
@@ -22,26 +22,26 @@ package gov.nasa.pds.tools.validate;
 public class Identifier {
 
   /** The logical identifier. */
-  private String lid;
+  final private String lid;
 
   /** The version. */
-  private String version;
+  final private String version;
 
   /** Flag to indicate if a version exists. */
-  private boolean hasVersion;
+  final private boolean hasVersion;
 
+  final private String representation;
+  
   public Identifier(String id) {
     this(id, null);
   }
 
   public Identifier(String lid, String version) {
+    if (lid == null) throw new IllegalArgumentException("cannot be an identifier if the lid is null");
+    this.hasVersion = version != null;
     this.lid = lid;
+    this.representation = lid + "::" + (version == null ? "-1.-1" : version);
     this.version = version;
-    if (this.version == null) {
-      hasVersion = false;
-    } else {
-      hasVersion = true;
-    }
   }
 
   public String getLid() {
@@ -66,36 +66,24 @@ public class Identifier {
   }
 
   /**
-   * Determines where 2 LIDVIDs are equal.
+   * Determines where 2 LIDVIDs are near neighbors (equal in some cases).
    *
    */
-  @Override
-  public boolean equals(Object o) {
-    boolean isEqual = false;
-    if (o instanceof Identifier) {
-      Identifier identifier = (Identifier) o;
-      if (this.lid.equals(identifier.getLid())) {
-        if (this.hasVersion) {
-          if (identifier.hasVersion() && this.version.equals(identifier.getVersion())) {
-            isEqual = true;
-          }
-        } else {
-          isEqual = true;
-        }
-      }
-    }
-    return isEqual;
+  public boolean nearNeighbor(Identifier identifier) {
+    return this.lid.equals(identifier.lid) && 
+        (this.version == null || identifier.version == null || this.version.equals(identifier.version));
   }
 
   @Override
+  public boolean equals(Object o) {
+    if (o instanceof Identifier) {
+      Identifier i = (Identifier)o;
+      return this.representation.equals(i.representation);
+    }
+    return false;
+  }
+  @Override
   public int hashCode() {
-    final int prime = 31;
-    int result = 17;
-    // result = prime * result
-    // + (hasVersion ? 0 : 1);
-    result = prime * result + ((lid == null) ? 0 : lid.hashCode());
-    // result = prime * result
-    // + ((version == null) ? 0 : version.hashCode());
-    return result;
+    return this.representation.hashCode();
   }
 }

--- a/src/main/java/gov/nasa/pds/tools/validate/InMemoryRegistrar.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/InMemoryRegistrar.java
@@ -49,7 +49,7 @@ public class InMemoryRegistrar implements TargetRegistrar {
   public synchronized void addTarget(String parentLocation, TargetType type, String location) {
     ValidationTarget target;
     try {
-      target = new ValidationTarget(location, type);
+      target = ValidationTarget.build(location, type);
       if (parentLocation == null) {
         this.rootTarget = target;
       }

--- a/src/main/java/gov/nasa/pds/tools/validate/TargetRegistrar.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/TargetRegistrar.java
@@ -123,7 +123,7 @@ public interface TargetRegistrar {
    * @param identifier the identifier
    * @return true, if the identifier was referenced
    */
-  boolean isIdentifierReferenced(Identifier identifier);
+  boolean isIdentifierReferenced(Identifier identifier, boolean orNearNeighbor);
 
   /**
    * Gets the location where an identifier was defined.
@@ -131,7 +131,7 @@ public interface TargetRegistrar {
    * @param identifier the identifier
    * @return the location where it was defined, or null if not defined
    */
-  String getTargetForIdentifier(Identifier identifier);
+  String getTargetForIdentifier(Identifier identifier, boolean orNearNeighbor);
 
   /**
    * Gets a mapping of identifiers to their locations.
@@ -175,7 +175,7 @@ public interface TargetRegistrar {
    *
    * @return The location where the given identifier is referenced.
    */
-  String getIdentifierReferenceLocation(Identifier id);
+  String getIdentifierReferenceLocation(Identifier id, boolean orNearNeighbor);
 
   public Map<String, ValidationTarget> getCollections();
 

--- a/src/main/java/gov/nasa/pds/tools/validate/ValidationProblem.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/ValidationProblem.java
@@ -15,7 +15,6 @@ package gov.nasa.pds.tools.validate;
 
 import java.net.URL;
 import java.util.Collection;
-import gov.nasa.pds.tools.util.Utility;
 import gov.nasa.pds.tools.validate.rule.GenericProblems;
 
 public class ValidationProblem {
@@ -30,7 +29,7 @@ public class ValidationProblem {
 
   public ValidationProblem(ProblemDefinition defn, URL target, int lineNumber, int columnNumber,
       String message) {
-    this(defn, Utility.getValidationTarget(target), lineNumber, columnNumber, message);
+    this(defn, ValidationTarget.build(target), lineNumber, columnNumber, message);
   }
 
   public ValidationProblem(ProblemDefinition defn, ValidationTarget target, int lineNumber,
@@ -49,7 +48,7 @@ public class ValidationProblem {
   }
 
   public ValidationProblem(ProblemDefinition defn, URL target, int lineNumber, int columnNumber) {
-    this(defn, Utility.getValidationTarget(target), lineNumber, columnNumber);
+    this(defn, ValidationTarget.build(target), lineNumber, columnNumber);
   }
 
   public ValidationProblem(ProblemDefinition defn, ValidationTarget target, int lineNumber,
@@ -58,7 +57,7 @@ public class ValidationProblem {
   }
 
   public ValidationProblem(ProblemDefinition defn, URL target, String message) {
-    this(defn, Utility.getValidationTarget(target), message);
+    this(defn, ValidationTarget.build(target), message);
   }
 
   public ValidationProblem(ProblemDefinition defn, ValidationTarget target, String message) {
@@ -66,10 +65,10 @@ public class ValidationProblem {
   }
 
   public ValidationProblem(ProblemDefinition defn, URL target) {
-    this(defn, Utility.getValidationTarget(target));
+    this(defn, ValidationTarget.build(target));
   }
   public ValidationProblem(ProblemDefinition defn, URL source, URL label) {
-    this(defn, Utility.getValidationTarget(source, label));
+    this(defn, ValidationTarget.build(source, label));
   }
 
   public ValidationProblem(ProblemDefinition defn, ValidationTarget target) {

--- a/src/main/java/gov/nasa/pds/tools/validate/content/table/InventoryTableValidator.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/content/table/InventoryTableValidator.java
@@ -29,7 +29,7 @@ public class InventoryTableValidator {
       InventoryTableValidator.checkAllUnique(ids, listener, aggregate);
     } catch (XPathException | XPathExpressionException e) {
       listener.addProblem(new ValidationProblem(GenericProblems.UNCAUGHT_EXCEPTION,
-          new ValidationTarget(aggregate),-1, -1, e.getMessage()));
+          ValidationTarget.build(aggregate),-1, -1, e.getMessage()));
     }
   }
   public static void uniqueCollectionRefs (ProblemListener listener, URL aggregate) {
@@ -46,7 +46,7 @@ public class InventoryTableValidator {
       InventoryTableValidator.checkAllUnique(ids, listener, aggregate);
     } catch (InventoryReaderException e) {
       listener.addProblem(new ValidationProblem(GenericProblems.UNCAUGHT_EXCEPTION,
-          new ValidationTarget(aggregate),-1, -1, e.getMessage()));
+          ValidationTarget.build(aggregate),-1, -1, e.getMessage()));
     }
   }
   private static void checkAllUnique(List<String> ids, ProblemListener listener, URL aggregate) {

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/AbstractValidationRule.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/AbstractValidationRule.java
@@ -168,7 +168,7 @@ public abstract class AbstractValidationRule implements ValidationRule {
    */
   protected void reportError(ProblemDefinition defn, URL targetUrl, int lineNumber,
       int columnNumber) {
-    ValidationProblem problem = new ValidationProblem(defn, new ValidationTarget(targetUrl),
+    ValidationProblem problem = new ValidationProblem(defn, ValidationTarget.build(targetUrl),
         lineNumber, columnNumber, defn.getMessage());
     listener.addProblem(problem);
   }
@@ -184,7 +184,7 @@ public abstract class AbstractValidationRule implements ValidationRule {
    */
   protected void reportError(ProblemDefinition defn, URL target, int lineNumber, int columnNumber,
       String message) {
-    ValidationProblem problem = new ValidationProblem(defn, new ValidationTarget(target),
+    ValidationProblem problem = new ValidationProblem(defn, ValidationTarget.build(target),
         lineNumber, columnNumber, message);
     listener.addProblem(problem);
   }

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/BundleReferentialIntegrityRule.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/BundleReferentialIntegrityRule.java
@@ -161,7 +161,7 @@ public class BundleReferentialIntegrityRule extends AbstractValidationRule {
             .entrySet()) {
           LOG.debug("getBundleMembers:reference,memberStatus,id,idEntry.getKey()) {},{},{},{}",
               reference, memberStatus, id, idEntry.getKey());
-          if (id.equals(idEntry.getKey())) {
+          if (id.nearNeighbor(idEntry.getKey())) {
             matchingMembers.add(idEntry);
             LOG.debug(
                 "getBundleMembers:ADDING_IDENTRY:reference,memberStatus,id,idEntry.getKey()) {},{},{},{}",

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/CollectionReferentialIntegrityRule.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/CollectionReferentialIntegrityRule.java
@@ -152,7 +152,7 @@ public class CollectionReferentialIntegrityRule extends AbstractValidationRule {
             List<Map.Entry<Identifier, String>> matchingMembers = new ArrayList<>();
             for (Map.Entry<Identifier, String> idEntry : getRegistrar().getIdentifierDefinitions()
                 .entrySet()) {
-              if (id.equals(idEntry.getKey())) {
+              if (id.nearNeighbor(idEntry.getKey())) {
                 matchingMembers.add(idEntry);
               }
             }

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/ContextProductReferenceValidationRule.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/ContextProductReferenceValidationRule.java
@@ -176,7 +176,7 @@ public class ContextProductReferenceValidationRule extends AbstractValidationRul
       } catch (URISyntaxException e) {
         // Should never happen
       }
-      ValidationTarget target = new ValidationTarget(getTarget());
+      ValidationTarget target = ValidationTarget.build(getTarget());
       Document label = getContext().getContextValue(PDS4Context.LABEL_DOCUMENT, Document.class);
       DOMSource source = new DOMSource(label);
       source.setSystemId(uri.toString());

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/FileAndDirectoryNamingChecker.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/FileAndDirectoryNamingChecker.java
@@ -40,7 +40,7 @@ public class FileAndDirectoryNamingChecker extends FileAndDirectoryNamingRule {
 
   private ValidationProblem constructError(ProblemDefinition defn, URL targetUrl, int lineNumber,
       int columnNumber) {
-    ValidationProblem problem = new ValidationProblem(defn, new ValidationTarget(targetUrl),
+    ValidationProblem problem = new ValidationProblem(defn, ValidationTarget.build(targetUrl),
         lineNumber, columnNumber, defn.getMessage());
     return (problem);
   }

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/FileReferenceValidationRule.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/FileReferenceValidationRule.java
@@ -124,10 +124,10 @@ public class FileReferenceValidationRule extends AbstractValidationRule {
       ProblemDefinition pd =
           new ProblemDefinition(ExceptionType.ERROR, ProblemType.INTERNAL_ERROR, te.getMessage());
       if (te.getLocator() != null) {
-        getListener().addProblem(new ValidationProblem(pd, new ValidationTarget(getTarget()),
+        getListener().addProblem(new ValidationProblem(pd, ValidationTarget.build(getTarget()),
             te.getLocator().getLineNumber(), te.getLocator().getColumnNumber(), te.getMessage()));
       } else {
-        getListener().addProblem(new ValidationProblem(pd, new ValidationTarget(getTarget())));
+        getListener().addProblem(new ValidationProblem(pd, ValidationTarget.build(getTarget())));
       }
     }
     LOG.debug("validateFileReferences:leaving:uri {}", uri);
@@ -160,7 +160,7 @@ public class FileReferenceValidationRule extends AbstractValidationRule {
   }
 
   private boolean validate(NodeInfo xml) {
-    this.target = new ValidationTarget(getTarget());
+    this.target = ValidationTarget.build(getTarget());
 
     try {
       // Perform checksum validation on the label itself

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/FindUnreferencedIdentifiers.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/FindUnreferencedIdentifiers.java
@@ -59,7 +59,7 @@ public class FindUnreferencedIdentifiers extends AbstractValidationRule {
           getRegistrar().getIdentifierDefinitions().keySet().size());
       long startTime = System.currentTimeMillis();
       for (Identifier id : getRegistrar().getIdentifierDefinitions().keySet()) {
-        String location = getRegistrar().getTargetForIdentifier(id);
+        String location = getRegistrar().getTargetForIdentifier(id, false);
         URL locationUrl = null;
         try {
           locationUrl = new URL(location);
@@ -68,22 +68,17 @@ public class FindUnreferencedIdentifiers extends AbstractValidationRule {
         }
         this.filesProcessed += 1;
         getListener().addLocation(location);
-        boolean found = false;
-        for (Identifier ri : getRegistrar().getReferencedIdentifiers()) {
-          if (ri.equals(id)) {
-            found = true;
-            getListener()
-                .addProblem(new ValidationProblem(
-                    new ProblemDefinition(ExceptionType.INFO, ProblemType.REFERENCED_MEMBER,
-                        "Identifier '" + id.toString() + "' is a member of '"
-                            + getRegistrar().getIdentifierReferenceLocation(id) + "'"),
-                    locationUrl));
-            break;
-          }
-        }
+        boolean found = this.getRegistrar().isIdentifierReferenced(id, true);
         LOG.debug("findUnreferencedIdentifiers:id,location,found,filesProcessed: {},{},{},{}", id,
             location, found, this.filesProcessed);
-        if (!found) {
+        if (found) {
+          getListener()
+          .addProblem(new ValidationProblem(
+              new ProblemDefinition(ExceptionType.INFO, ProblemType.REFERENCED_MEMBER,
+                  "Identifier '" + id.toString() + "' is a member of '"
+                      + getRegistrar().getIdentifierReferenceLocation(id, true) + "'"),
+              locationUrl));
+        } else {
           String memberType = "collection";
           if (TargetExaminer.isTargetCollectionType (locationUrl)) {
             memberType = "bundle";

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/LocalIdentifierReferencesRule.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/LocalIdentifierReferencesRule.java
@@ -68,7 +68,7 @@ public class LocalIdentifierReferencesRule extends AbstractValidationRule {
   @ValidationTest
   public void validateLocalIdentifiers() {
     List<ValidationProblem> problems = new ArrayList<>();
-    ValidationTarget target = new ValidationTarget(getTarget());
+    ValidationTarget target = ValidationTarget.build(getTarget());
     Document label = getContext().getContextValue(PDS4Context.LABEL_DOCUMENT, Document.class);
     DOMSource source = new DOMSource(label);
 
@@ -80,7 +80,7 @@ public class LocalIdentifierReferencesRule extends AbstractValidationRule {
       ProblemDefinition pd = new ProblemDefinition(ExceptionType.ERROR, ProblemType.INTERNAL_ERROR,
           "Error while finding local_identifier_reference attributes using XPath '"
               + LOCAL_IDENTIFIER_REF_PATH + "': " + xe.getMessage());
-      getListener().addProblem(new ValidationProblem(pd, new ValidationTarget(getTarget())));
+      getListener().addProblem(new ValidationProblem(pd, ValidationTarget.build(getTarget())));
       return;
     }
     NodeList localIds = null;
@@ -91,7 +91,7 @@ public class LocalIdentifierReferencesRule extends AbstractValidationRule {
       ProblemDefinition pd = new ProblemDefinition(ExceptionType.ERROR, ProblemType.INTERNAL_ERROR,
           "Error while finding local_identifier attributes using XPath '" + LOCAL_IDENTIFIER_PATH
               + "': " + xe.getMessage());
-      getListener().addProblem(new ValidationProblem(pd, new ValidationTarget(getTarget())));
+      getListener().addProblem(new ValidationProblem(pd, ValidationTarget.build(getTarget())));
       return;
     }
 

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/RegisterLabelIdentifiers.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/RegisterLabelIdentifiers.java
@@ -102,11 +102,11 @@ public class RegisterLabelIdentifiers extends AbstractValidationRule {
     }
     LOG.debug("RegisterLabelIdentifiers:registerIdentifier:getTarget(),identifier {},{}",
         getTarget(), identifier);
-    if (registrar.getTargetForIdentifier(identifier) == null) {
+    if (registrar.getTargetForIdentifier(identifier, false) == null) {
       registrar.setTargetIdentifier(target.normalize().toString(), identifier);
     } else {
       String message = String.format("Identifier %s already defined (old location: %s)",
-          identifier.toString(), registrar.getTargetForIdentifier(identifier));
+          identifier.toString(), registrar.getTargetForIdentifier(identifier, false));
       reportError(PDS4Problems.DUPLICATE_LOGICAL_IDENTIFIER, getTarget(), -1, -1, message);
     }
   }


### PR DESCRIPTION
## 🗒️ Summary
Multi step process of cleaning up validate to improve performance:
1. Fixed ValidateTarget to be compliant with Java: hashCode() returned different values when equals() returned true.
2. Fixed ValidateTarget.cachedTargets was implemented in a Utility class so very few creators of ValidateTarget used it. Moved cache to ValidateTarget, privatized constructors, used factory methods (build) for consistent use of cache.
3. Fixing Identifier to be compliant with Java: hashCode() returned different values when equals() returned true.
4. Fix all of the loops to use contains() instead. Those loops are a consequence of (3).

## ⚙️ Test Data and/or Report
Automated unit/regression tests below should pass.

## ♻️ Related Issues
Closes #969 
