### PR TITLE
Image vulnerability scanning in support of safer devops

### DIFF
--- a/.github/workflows/stable-cicd.yaml
+++ b/.github/workflows/stable-cicd.yaml
@@ -14,7 +14,7 @@
 #     A *private* key with which we can sign artifacts.
 # ``OSSRH_USERNAME``
 #     Username for the Central Repository.
-# ``OSSRH_USERNAME``
+# ``OSSRH_PASSWORD``
 #     Password for the Central Repository.
 #
 
@@ -102,8 +102,25 @@ jobs:
                 name: 🚢 Docker Buildx
                 uses: docker/setup-buildx-action@v3
             -
-                name: 🧱 Image Construction and Publication
+                name: 🧱 Image Construction and Local Publication
                 uses: docker/build-push-action@v6
+                with:
+                    context: ./
+                    file: ./docker/Dockerfile
+                    build-args: tar_file=${{steps.gettartag.outputs.tar_file}}
+                    platforms: linux/amd64,linux/arm64
+                    push: false
+                    load: true
+                    tags: ${{secrets.DOCKERHUB_USERNAME}}/validate:${{steps.gettartag.outputs.image_tag}}
+            -
+                name: 🕵️‍♂️ Image Vulnerability Scanning
+                uses: anchore/scan-action@v4
+                with:
+                    fail-build: true
+                    severity-cutoff: critical
+                    image: ${{secrets.DOCKERHUB_USERNAME}}/validate:${{steps.gettartag.outputs.image_tag}}
+            -
+                name: 🧱 Image Construction and Remote Publication
                 with:
                     context: ./
                     file: ./docker/Dockerfile

--- a/.github/workflows/unstable-cicd.yaml
+++ b/.github/workflows/unstable-cicd.yaml
@@ -14,7 +14,7 @@
 #     A *private* key with which we can sign artifacts.
 # ``OSSRH_USERNAME``
 #     Username for the Central Repository.
-# ``OSSRH_USERNAME``
+# ``OSSRH_PASSWORD``
 #     Password for the Central Repository.
 
 
@@ -109,8 +109,25 @@ jobs:
                     file: ./docker/Dockerfile
                     build-args: tar_file=${{steps.gettar.outputs.tar_file}}
                     platforms: linux/amd64,linux/arm64
-                    push: true
+                    push: false
+                    load: true
                     tags: ${{secrets.DOCKERHUB_USERNAME}}/validate:latest
+            -
+                name: 🕵️‍♂️ Image Vulnerability Scanning
+                uses: anchore/scan-action@v4
+                with:
+                    fail-build: true
+                    severity-cutoff: critical
+                    image: ${{secrets.DOCKERHUB_USERNAME}}/validate:${{steps.gettartag.outputs.image_tag}}
+            -
+                name: 🧱 Image Construction and Remote Publication
+                with:
+                    context: ./
+                    file: ./docker/Dockerfile
+                    build-args: tar_file=${{steps.gettartag.outputs.tar_file}}
+                    platforms: linux/amd64,linux/arm64
+                    push: true
+                    tags: ${{secrets.DOCKERHUB_USERNAME}}/validate:${{steps.gettartag.outputs.image_tag}}
 
 ...
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,3 +17,11 @@ repos:
         - --exclude-files '\.git.*'
         - --exclude-files '\.pre-commit-config\.yaml'
         - --exclude-files 'target'
+- repo: local
+  hooks:
+    - id: grype-cve-scan
+      name: Grype Vulnerability Scan
+      description: Scans for dependency vulnerabilities. Fails if CRITICAL vulnerabilities detected.
+      entry: python3 -c "import os; import subprocess; import sys; os.environ['GRYPE_DB_AUTO_UPDATE'] = 'false'; result=subprocess.run(['grype', 'dir:.', '--fail-on', 'critical'], capture_output=True); print(result.stdout.decode()); print('CRITICAL level vulnerabilities found. To address issues, run scan via `grype dir:.`, then `git add` followed by `git commit` your fix or ignore via `git commit --no-verify`') if result.returncode != 0 else print('No CRITICAL level vulnerabilities found.'); sys.exit(result.returncode)"
+      language: system
+      verbose: true


### PR DESCRIPTION
## 🗒️ Summary

Merge this to add [Grype-based](https://github.com/anchore/grype) image vulnerability scanning based on the [SLIM guide](https://riverma.github.io/slim/docs/guides/software-lifecycle/security/dependency-vulnerability-scanning/).

Specifically:

- Adds a pre-commit hook to run Grype to abort on critical-level vulnerabilities 
- Adds unstable and stable workflow steps to run Grype and abort publication on critical-level vulnerabilities 


## ⚙️ Test Data and/or Report

Pre-commit:
```
$ git commit -am 'Support of devops#76'
Google Java Formatter................................(no files to check)Skipped
Detect secrets...........................................................Passed
Grype Vulnerability Scan.................................................Passed
- hook id: grype-cve-scan
- duration: 3.67s

NAME               INSTALLED  FIXED-IN  TYPE          VULNERABILITY        SEVERITY 
commons-beanutils  1.8.3      1.9.4     java-archive  GHSA-p66x-2cv9-qq3v  High      
commons-beanutils  1.8.3      1.9.4     java-archive  GHSA-6phf-73q6-gh87  High      
opensearch         2.5.0      2.11.1    java-archive  GHSA-6g3j-p5g6-992f  Medium    
snakeyaml          1.32       2.0       java-archive  GHSA-mjmj-j48q-9wg2  High      
zookeeper          3.9.1      3.9.2     java-archive  GHSA-r978-9m6m-6gm6  Medium

No CRITICAL level vulnerabilities found.
```

(The GitHub Actions workflows require GitHub Actions for testing.)

## ♻️ Related Issues

- [devops#76](https://github.com/NASA-PDS/devops/issues/76)

