### PR TITLE
Fix code scanning alert no. 468: Resolving XML external entity in user-controlled data

### DIFF
--- a/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/SchemaValidator.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/SchemaValidator.java
@@ -69,7 +69,13 @@ public class SchemaValidator {
   public SchemaValidator() {
     // Support for XSD 1.1
     schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
-
+    try {
+      schemaFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+      schemaFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+      schemaFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+    } catch (SAXNotRecognizedException | SAXNotSupportedException e) {
+      LOG.error("Error setting SchemaFactory features to prevent XXE", e);
+    }
     schemaFactory.setResourceResolver(new XMLCatalogResolver());
   }
 


### PR DESCRIPTION
Fixes [https://github.com/NASA-PDS/validate/security/code-scanning/468](https://github.com/NASA-PDS/validate/security/code-scanning/468)

To fix the problem, we need to configure the `SchemaFactory` to disable DTDs and external entities. This can be done by setting specific features on the `SchemaFactory` instance. The best way to fix this without changing existing functionality is to add these configurations in the constructor of the `SchemaValidator` class.

1. Set the feature `http://apache.org/xml/features/disallow-doctype-decl` to `true` to disallow DTDs.
2. Set the feature `http://xml.org/sax/features/external-general-entities` to `false` to disallow external general entities.
3. Set the feature `http://xml.org/sax/features/external-parameter-entities` to `false` to disallow external parameter entities.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
