### PR TITLE
Update XXE prevention code

### DIFF
--- a/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/SchemaValidator.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/SchemaValidator.java
@@ -71,8 +71,6 @@ public class SchemaValidator {
     schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
     try {
       schemaFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-      schemaFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
-      schemaFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
     } catch (SAXNotRecognizedException | SAXNotSupportedException e) {
       LOG.error("Error setting SchemaFactory features to prevent XXE", e);
     }


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary
The feature setting is an older method and is no longer working. Per https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html, it looks like only this line is needed.

```
factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
```

## ⚙️ Test Data and/or Report
Verify tests execute successfully.
