### PR TITLE
Fix code scanning alert no. 442: Resolving XML external entity in user-controlled data

### DIFF
--- a/src/main/java/gov/nasa/pds/tools/label/SchematronTransformer.java
+++ b/src/main/java/gov/nasa/pds/tools/label/SchematronTransformer.java
@@ -21,6 +21,7 @@ import java.io.StringWriter;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.XMLConstants;
 import javax.xml.transform.Source;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerConfigurationException;
@@ -61,6 +62,13 @@ public class SchematronTransformer {
 
   private Transformer buildIsoTransformer() throws TransformerConfigurationException {
     TransformerFactory isoFactory = TransformerFactory.newInstance();
+    try {
+      isoFactory.setFeature("http://javax.xml.XMLConstants/feature/secure-processing", true);
+      isoFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+      isoFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+    } catch (TransformerConfigurationException e) {
+      throw new TransformerConfigurationException("Failed to configure TransformerFactory for secure processing", e);
+    }
     // Set the resolver that will look in the jar for imports
     isoFactory.setURIResolver(new XslURIResolver());
     // Load the isoSchematron stylesheet that will be used to transform each


### PR DESCRIPTION
Fixes [https://github.com/NASA-PDS/validate/security/code-scanning/442](https://github.com/NASA-PDS/validate/security/code-scanning/442)

To fix the problem, we need to disable external entity resolution in the `TransformerFactory` used in the `SchematronTransformer` class. This can be done by setting specific features on the `TransformerFactory` instance to disallow DTDs and external entities. This will prevent XXE attacks by ensuring that the XML parser does not process external entities.

The changes should be made in the `buildIsoTransformer` method of the `SchematronTransformer` class. We will set the necessary features on the `TransformerFactory` instance to secure it against XXE attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
