### PR TITLE
Create new `error.connection.registry` to avoid internal errors being thrown for registry connection issues

### DIFF
--- a/src/main/java/gov/nasa/pds/tools/validate/ProblemType.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/ProblemType.java
@@ -44,6 +44,8 @@ public enum ProblemType {
 
   CONTEXT_REFERENCE_NOT_FOUND("error.label.context_ref_not_found"),
 
+  CONNECTION_ERROR("error.connection.registry"),
+  
   OUT_OF_MEMORY("error.validation.out_of_memory", ProblemCategory.EXECUTION),
 
   INTERNAL_ERROR("error.validation.internal_error"),

--- a/src/main/java/gov/nasa/pds/validate/ValidateLauncher.java
+++ b/src/main/java/gov/nasa/pds/validate/ValidateLauncher.java
@@ -561,7 +561,7 @@ public class ValidateLauncher {
     } catch (IOException ex) {
       try {
         ValidationProblem p = new ValidationProblem(new ProblemDefinition(ExceptionType.ERROR,
-            ProblemType.INTERNAL_ERROR,
+            ProblemType.CONNECTION_ERROR,
             "Error connecting to Registry to update registered context products config file. Verify internet connection and try again."),
             registeredProductsFile.toURI().toURL());
         report.record(registeredProductsFile.toURI(), p);

--- a/src/main/java/gov/nasa/pds/validate/ValidateLauncher.java
+++ b/src/main/java/gov/nasa/pds/validate/ValidateLauncher.java
@@ -120,7 +120,6 @@ import gov.nasa.pds.validate.report.Report;
 import gov.nasa.pds.validate.report.XmlReport;
 import gov.nasa.pds.validate.util.ToolInfo;
 import gov.nasa.pds.validate.util.Utility;
-import jdk.internal.org.jline.utils.Log;
 
 /**
  * Wrapper class for the Validate Tool. Class handles command-line parsing and querying, in addition


### PR DESCRIPTION
## 🗒️ Summary
Added new ProblemType.CONNECTION_ERROR and changed internal error to this.

## ⚙️ Test Data and/or Report
All unit tests below pass and visual inspection of code changes.

## ♻️ Related Issues
Closes #1085



