### PR TITLE
Update EncodingMimeMapping.java with additional file suffix for `jp2`

### DIFF
--- a/src/main/java/gov/nasa/pds/tools/util/EncodingMimeMapping.java
+++ b/src/main/java/gov/nasa/pds/tools/util/EncodingMimeMapping.java
@@ -7,7 +7,7 @@ import java.util.List;
 public enum EncodingMimeMapping {
   DAT(Arrays.asList("dat","DAT")),
   GIF(Arrays.asList("gif")),
-  J2C(Arrays.asList("j2c", "mj2", "mjp2")),
+  J2C(Arrays.asList("j2c", ""jp2", mj2", "mjp2")),
   JPEG(Arrays.asList("jpg", "jpeg")),
   MP4(Arrays.asList("mp4")),
   PDF(Arrays.asList("pdf")),

--- a/src/main/java/gov/nasa/pds/tools/util/EncodingMimeMapping.java
+++ b/src/main/java/gov/nasa/pds/tools/util/EncodingMimeMapping.java
@@ -7,7 +7,7 @@ import java.util.List;
 public enum EncodingMimeMapping {
   DAT(Arrays.asList("dat","DAT")),
   GIF(Arrays.asList("gif")),
-  J2C(Arrays.asList("j2c", ""jp2", mj2", "mjp2")),
+  J2C(Arrays.asList("j2c", "jp2", mj2", "mjp2")),
   JPEG(Arrays.asList("jpg", "jpeg")),
   MP4(Arrays.asList("mp4")),
   PDF(Arrays.asList("pdf")),

--- a/src/main/java/gov/nasa/pds/tools/util/EncodingMimeMapping.java
+++ b/src/main/java/gov/nasa/pds/tools/util/EncodingMimeMapping.java
@@ -7,7 +7,7 @@ import java.util.List;
 public enum EncodingMimeMapping {
   DAT(Arrays.asList("dat","DAT")),
   GIF(Arrays.asList("gif")),
-  J2C(Arrays.asList("j2c", "jp2", mj2", "mjp2")),
+  J2C(Arrays.asList("j2c", "jp2", "mj2", "mjp2")),
   JPEG(Arrays.asList("jpg", "jpeg")),
   MP4(Arrays.asList("mp4")),
   PDF(Arrays.asList("pdf")),


### PR DESCRIPTION
## 🗒️ Summary
Suggestion was exactly right and added 'jp2' to the J2C known extensions.

## ⚙️ Test Data and/or Report
All unit tests pass below.

## ♻️ Related Issues
Closes #1104


