### PR TITLE
Add JP2 as an alias encoding to J2C

### DIFF
--- a/src/main/java/gov/nasa/pds/tools/util/EncodingMimeMapping.java
+++ b/src/main/java/gov/nasa/pds/tools/util/EncodingMimeMapping.java
@@ -30,6 +30,7 @@ public enum EncodingMimeMapping {
     if (encoding != null) {
       if (encoding.equalsIgnoreCase("GIF")) return GIF;
       if (encoding.equalsIgnoreCase("J2C")) return J2C;
+      if (encoding.equalsIgnoreCase("JP2")) return J2C;
       if (encoding.equalsIgnoreCase("JPEG")) return JPEG;
       if (encoding.equalsIgnoreCase("MMM ODR Stream")) return DAT;
       if (encoding.equalsIgnoreCase("MP4/H.264")) return MP4;


### PR DESCRIPTION
## 🗒️ Summary
Added JP2 encoding as an alias to J2C.

## ⚙️ Test Data and/or Report
All automated unit tests below should pass.

## ♻️ Related Issues
Closes #1210 


