### PR TITLE
Update validate-bundle to be case insensitive

### DIFF
--- a/src/main/resources/bin/validate-bundle
+++ b/src/main/resources/bin/validate-bundle
@@ -164,7 +164,7 @@ else
   echo "  Splitting up into groups, based on --num-groups (${NUM_GROUPS}) specified on command-line..."
 fi
 
-find  ${PRODUCT_DIR} -name "*.xml" > validate_all_files.txt
+find  ${PRODUCT_DIR} -iname "*.xml" > validate_all_files.txt
 
 TOTAL_PRODUCTS=`wc -l < validate_all_files.txt`
 
@@ -186,7 +186,7 @@ echo "  |       Group        |   # in Group   |"
 echo "  +--------------------+----------------+"
 
 PRODUCT_IDX=0
-find $PRODUCT_DIR -name "*.xml" -type f -print0 | while IFS= read -r -d '' LABEL_FILEPATH; do
+find $PRODUCT_DIR -iname "*.xml" -type f -print0 | while IFS= read -r -d '' LABEL_FILEPATH; do
   echo $LABEL_FILEPATH >> ./validate_set_$((PRODUCT_IDX % NUM_GROUPS))
   ((PRODUCT_IDX++))
 done


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary
Brief summary of changes if not sufficiently described by commit messages.

## ⚙️ Test Data and/or Report

Test procedure:
1. clone validate
```
git clone git@github.com:NASA-PDS/validate.git
```
2. Checkout branch and build the repo
```
cd validate
git checkout i1331
mvn clean package -DskipTests  # skips integration tests for now
```
3. Clone the registry-ref-data repo
```
git clone git@github.com:NASA-PDS/registry-ref-data.git
```
4. Tweak one of the files to have an all caps file suffix
```
mv registry-ref-data/custom-datasets/urn-nasa-pds-insight_rad/data_raw/hp3_rad_raw_00390_20200101_120222.xml registry-ref-data/custom-datasets/urn-nasa-pds-insight_rad/data_raw/hp3_rad_raw_00390_20200101_120222.XML
```
5. Add validate to PATH and execute validate-bundle to verify fix:
```
$ export PATH=${PATH}:$(pwd)/validate-3.8.0-SNAPSHOT/bin/
$ validate-3.8.0-SNAPSHOT/bin/validate-bundle --target-bundle registry-ref-data/custom-datasets/urn-nasa-pds-insight_rad/bundle_insight_rad.xml

  validate binary is available (/Users/jpadams/proj/pds/pdsen/workspace/validate/validate-3.8.0-SNAPSHOT/bin/validate) [OK]
  GNU parallel binary is available (/opt/homebrew/bin/parallel) [OK]
  Directory to process is : /Users/jpadams/proj/pds/pdsen/workspace/validate/../registry-ref-data/custom-datasets/urn-nasa-pds-insight_rad
  Number of effective cores on this system: 12
  Half of effective cores on this system  : 6 (usually better than running all cores)
  Splitting up into groups, based on number of cores this machine has...
  Total number of products found to validate:       25
  Cleaning up files from previous runs...
  Splitting up inputs into 6 groups...
    (5 files per group)
  +--------------------+----------------+
  |       Group        |   # in Group   |
  +--------------------+----------------+
  | ./validate_set_3  |   4
  | ./validate_set_4  |   4
  | ./validate_set_5  |   4
  | ./validate_set_2  |   4
  | ./validate_set_0  |   5
  | ./validate_set_1  |   4
  +--------------------+-----------------

Running all 6 groups in parallel now...


* Performing Syntactic, Semantic, and Content validation...
  NOTE: Each validate command will output to an individual log.
* Execution time:


* Performing Referential Integrity validation...
* Execution time:



>>>>>>>>>>>>>>> ./validate_set_5.log:
Summary:

  4 product(s)
  4 error(s)
  0 warning(s)

  Product Validation Summary:
    0          product(s) passed
    4          product(s) failed
    0          product(s) skipped
    4          product(s) total

  Referential Integrity Check Summary:
    0          check(s) passed
    0          check(s) failed
    0          check(s) skipped
    0          check(s) total

  Message Types:
    4            error.label.table_definition_problem

End of Report

<<<<<<<<<<<<<<<


>>>>>>>>>>>>>>> ./validate_set_4.log:
Summary:

  4 product(s)
  3 error(s)
  0 warning(s)

  Product Validation Summary:
    1          product(s) passed
    3          product(s) failed
    0          product(s) skipped
    4          product(s) total

  Referential Integrity Check Summary:
    0          check(s) passed
    0          check(s) failed
    0          check(s) skipped
    0          check(s) total

  Message Types:
    3            error.label.table_definition_problem

End of Report

<<<<<<<<<<<<<<<


>>>>>>>>>>>>>>> ./validate_set_3.log:
Summary:

  4 product(s)
  3 error(s)
  0 warning(s)

  Product Validation Summary:
    1          product(s) passed
    3          product(s) failed
    0          product(s) skipped
    4          product(s) total

  Referential Integrity Check Summary:
    0          check(s) passed
    0          check(s) failed
    0          check(s) skipped
    0          check(s) total

  Message Types:
    3            error.label.table_definition_problem

End of Report

<<<<<<<<<<<<<<<


>>>>>>>>>>>>>>> ./validate_set_2.log:
Summary:

  4 product(s)
  4 error(s)
  0 warning(s)

  Product Validation Summary:
    0          product(s) passed
    4          product(s) failed
    0          product(s) skipped
    4          product(s) total

  Referential Integrity Check Summary:
    0          check(s) passed
    0          check(s) failed
    0          check(s) skipped
    0          check(s) total

  Message Types:
    4            error.label.table_definition_problem

End of Report

<<<<<<<<<<<<<<<


>>>>>>>>>>>>>>> ./validate_set_0.log:
Summary:

  5 product(s)
  3 error(s)
  1 warning(s)

  Product Validation Summary:
    2          product(s) passed
    3          product(s) failed
    0          product(s) skipped
    5          product(s) total

  Referential Integrity Check Summary:
    0          check(s) passed
    0          check(s) failed
    0          check(s) skipped
    0          check(s) total

  Message Types:
    3            error.label.table_definition_problem
    1            warning.label.schema

End of Report

<<<<<<<<<<<<<<<


>>>>>>>>>>>>>>> ./validate_set_1.log:
Summary:

  4 product(s)
  4 error(s)
  0 warning(s)

  Product Validation Summary:
    0          product(s) passed
    4          product(s) failed
    0          product(s) skipped
    4          product(s) total

  Referential Integrity Check Summary:
    0          check(s) passed
    0          check(s) failed
    0          check(s) skipped
    0          check(s) total

  Message Types:
    4            error.label.table_definition_problem

End of Report

<<<<<<<<<<<<<<<


>>>>>>>>>>>>>>> ./validate_referential.log:
Summary:

  24 product(s)
  0 error(s)
  2 warning(s)

  Product Validation Summary:
    0          product(s) passed
    0          product(s) failed
    25         product(s) skipped
    24         product(s) total

  Referential Integrity Check Summary:
    26         check(s) passed
    0          check(s) failed
    0          check(s) skipped
    26         check(s) total

  Message Types:
    1            warning.integrity.pds4_version_mismatch
    1            warning.label.schema

End of Report

<<<<<<<<<<<<<<<

>>>>>>>>>>>>>>> OVERALL SUMMARY:
Summary:

  21 error(s)
  3 warnings(s)

End of Report

<<<<<<<<<<<<<<<

Validation complete.
* See ./$DEFAULT_UNIQUE_REPORT_DIR_STEM/validate_summary.log for a summary of results.
* See ./$DEFAULT_UNIQUE_REPORT_DIR_STEM for individual Validate Tool execution reports.

```

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->
Resolves #1331

