### PR TITLE
Upgrade to Java 17 to support required dependency upgrades

### DIFF
--- a/.github/workflows/branch-cicd.yaml
+++ b/.github/workflows/branch-cicd.yaml
@@ -33,7 +33,7 @@ jobs:
 
         strategy:
             matrix:
-                java-version: [11, 17]
+                java-version: [17]
 
         steps:
             -

--- a/.github/workflows/stable-cicd.yaml
+++ b/.github/workflows/stable-cicd.yaml
@@ -72,7 +72,7 @@ jobs:
                 uses: NASA-PDS/roundup-action@stable
                 with:
                     assembly: stable
-                    packages: openjdk11-jdk
+                    packages: openjdk17-jdk
                     maven-build-phases: install
                     maven-doc-phases: clean,site,site:stage
                     maven-stable-artifact-phases: clean,site,site:stage,deploy

--- a/.github/workflows/unstable-cicd.yaml
+++ b/.github/workflows/unstable-cicd.yaml
@@ -75,7 +75,7 @@ jobs:
                 uses: NASA-PDS/roundup-action@stable
                 with:
                     assembly: unstable
-                    packages: openjdk11-jdk
+                    packages: openjdk17-jdk
                     maven-build-phases: install
                     maven-doc-phases: clean,site,site:stage
                     maven-unstable-artifact-phases: clean,site,site:stage,deploy

--- a/pom.xml
+++ b/pom.xml
@@ -162,8 +162,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>11</source>
-          <target>11</target>
+          <source>17</source>
+          <target>17</target>
         </configuration>
       </plugin>
     </plugins>
@@ -305,25 +305,31 @@
     <dependency>
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter</artifactId>
-        <version>5.13.4</version>
+        <version>6.0.0</version>
         <scope>test</scope>
     </dependency>
     <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-engine</artifactId>
+        <version>6.0.0</version>
+        <scope>test</scope>
+    </dependency>
+    <dependency>
+        <groupId>org.junit.platform</groupId>
+        <artifactId>junit-platform-suite-api</artifactId>
+        <version>6.0.0</version>
+        <scope>test</scope>
+    </dependency>
+     <dependency>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-java</artifactId>
-        <version>7.29.0</version>
+        <version>7.30.0</version>
         <scope>test</scope>
     </dependency>
-    <dependency>
+   <dependency>
         <groupId>io.cucumber</groupId>
-        <artifactId>cucumber-junit</artifactId>
-        <version>7.28.2</version>
-        <scope>test</scope>
-    </dependency>
-    <dependency>
-        <groupId>org.junit.vintage</groupId>
-        <artifactId>junit-vintage-engine</artifactId>
-        <version>5.13.4</version>
+        <artifactId>cucumber-junit-platform-engine</artifactId>
+        <version>7.30.0</version>
         <scope>test</scope>
     </dependency>
     <dependency>
@@ -397,12 +403,12 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>opensearch</artifactId>
-      <version>2.34.5</version>
+      <version>2.35.0</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>apache-client</artifactId>
-      <version>2.34.5</version>
+      <version>2.35.0</version>
     </dependency>
   </dependencies>
 

--- a/src/site/xdoc/install/index.xml.vm
+++ b/src/site/xdoc/install/index.xml.vm
@@ -84,7 +84,7 @@ or
       </p>
 
       <subsection name="Java Runtime Environment">
-        <p>The Validate Tool was developed using Java and runs on any platform with a supported <a href="https://openjdk.java.net/install/">Java Runtime Environment (JRE)</a> >= Java  version 11. The software was specifically compiled for and tested in OpenJDK 15.0.1. The following commands test the local Java installation in a UNIX-based environment:
+        <p>The Validate Tool was developed using Java and runs on any platform with a supported <a href="https://openjdk.java.net/install/">Java Runtime Environment (JRE)</a> >= Java  version 17. The software was specifically compiled for and tested in OpenJDK 21.0.8. The following commands test the local Java installation in a UNIX-based environment:
         </p>
 
         <source>
@@ -92,9 +92,9 @@ or
 /usr/bin/java
 
 % java -version
-openjdk version "15.0.1" 2020-10-20
-OpenJDK Runtime Environment (build 15.0.1+9)
-OpenJDK 64-Bit Server VM (build 15.0.1+9, mixed mode, sharing)
+openjdk 21.0.8 2025-07-15
+OpenJDK Runtime Environment (build 21.0.8)
+OpenJDK 64-Bit Server VM (build 21.0.8, mixed mode, sharing)
         </source>
 
         <p><i>NOTE: Validate requires 64-bit Java in order to enable Java Virtual Machine memory requirements. In version output above, note the line <b>Java HotSpot(TM) 64-Bit Server VM</b></i>.</p>

--- a/src/test/java/cucumber/CucumberTest.java
+++ b/src/test/java/cucumber/CucumberTest.java
@@ -1,12 +1,12 @@
 package cucumber;
 
-import org.junit.runner.RunWith;
-import io.cucumber.junit.Cucumber;
-import io.cucumber.junit.CucumberOptions;
+import org.junit.platform.suite.api.IncludeEngines;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Cucumber.class)
-@CucumberOptions(plugin = {"pretty", "summary", "html:target/cucumber.html"},
-    features = "src/test/resources/features/", glue = "cucumber")
+@Suite
+@IncludeEngines("cucumber")
+
 public class CucumberTest {
   public CucumberTest() {}
 }
+

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -1,0 +1,3 @@
+cucumber.features=classpath:features/
+cucumber.glue=cucumber
+cucumber.plugin=pretty,summary,html:target/cucumber.html


### PR DESCRIPTION
## 🗒️ Summary
Requires JUnit 5 and Java 17. Requires eclipse update to build path for JUnit 5 and possibly Java 17.

## ⚙️ Test Data and/or Report
All unit tests below pass.

## ♻️ Related Issues
NA


