### PR TITLE
#1370: add lidvid to all reports

### DIFF
--- a/src/main/java/gov/nasa/pds/tools/validate/TargetExaminer.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/TargetExaminer.java
@@ -15,7 +15,6 @@ package gov.nasa.pds.tools.validate;
 
 import java.net.URL;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import javax.annotation.Nullable;

--- a/src/main/java/gov/nasa/pds/validate/report/FullReport.java
+++ b/src/main/java/gov/nasa/pds/validate/report/FullReport.java
@@ -61,14 +61,17 @@ public class FullReport extends Report {
   private String currentTarget = "";
   
   @Override
-  protected void append(Status status, String target) {
+  protected void append(Status status, String lidvid, String target) {
     this.currentStatus = status;
     this.currentTarget = target;
     this.getWriter().println();
     this.getWriter().print("  ");
     this.getWriter().print(status.getName());
     this.getWriter().print(": ");
-    this.getWriter().println(target);
+    this.getWriter().print(target);
+    this.getWriter().print(" (");
+    this.getWriter().print(lidvid);
+    this.getWriter().println(")");
   }
 
   @Override

--- a/src/main/java/gov/nasa/pds/validate/report/JSONReport.java
+++ b/src/main/java/gov/nasa/pds/validate/report/JSONReport.java
@@ -70,11 +70,12 @@ public class JSONReport extends Report {
     }
   }
   @Override
-  protected void append(Status status, String target) {
+  protected void append(Status status, String lidvid, String target) {
     try {
       this.target = target;
       this.stream.name("status").value(status.getName());
       this.stream.name("label").value(target);
+      this.stream.name("lidvid").value(lidvid);
     } catch (IOException ioe) {
       ioe.printStackTrace();
     }

--- a/src/main/java/gov/nasa/pds/validate/report/Report.java
+++ b/src/main/java/gov/nasa/pds/validate/report/Report.java
@@ -309,7 +309,10 @@ public abstract class Report {
           result = parts.get(0) + "::" + parts.get(1);
         }
       }
-    } catch (MalformedURLException e) {
+    } catch (IllegalArgumentException e) {
+      // some unit tests cause this error but should never happen in real life
+      result = "label path was not absolute";
+    }catch (MalformedURLException e) {
       // We did our best. Just ignore it if malformed as default string says it all
     }
     return result;

--- a/src/main/java/gov/nasa/pds/validate/report/XmlReport.java
+++ b/src/main/java/gov/nasa/pds/validate/report/XmlReport.java
@@ -60,9 +60,9 @@ public class XmlReport extends Report {
   private XMLBuilder2 summary = null;
 
   @Override
-  protected void append(Status status, String target) {
+  protected void append(Status status, String lidvid, String target) {
     this.target = target;
-    this.label = this.bodyBlock.e("label").a("target", target).a("status", status.getName());
+    this.label = this.bodyBlock.e("label").a("target", target).a("status", status.getName()).a("lidvid", lidvid);
     this.content = this.label.e("dataContents");
     this.fragments = this.label.e("fragments");
     this.messages = this.label.e("messages");


### PR DESCRIPTION
## 🗒️ Summary
Updated the report interface then all of the reports.

## ⚙️ Test Data and/or Report
All automated unit/regression tests below should pass.

new test report looks like:
```
Product Level Validation Results

  PASS: file:/home/niessner/Projects/PDS/validate/src/test/resources/github1391/vl0axrat_delim.xml (urn:nasa:pds:vl_rocks:data_derived:vl0axrat::1.0)
        1 product validation(s) completed
```

JSON looks like:
```
    {
      "status": "PASS",
      "label": "file:/home/niessner/Projects/PDS/validate/src/test/resources/github1201/lend_rdr_dld_20240615.lblx",
      "lidvid": "urn:nasa:pds:lro_lend:data_science_derived:lend_rdr_dld_20240615::1.0",
      "messages": [],
      "fragments": [],
      "dataContents": []
    },
```

added to XML report as an attribute.

## ♻️ Related Issues
Closes #1370 


