### PR TITLE
Fix error.directory.unallowed_name not raised on Windows for absolute directory_path_name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,5 @@ override.tf
 override.tf.json
 *_override.tf
 *_override.tf.json
+/.apt_generated/
+/.apt_generated_tests/

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/FileReferenceValidationRule.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/FileReferenceValidationRule.java
@@ -19,8 +19,6 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -300,13 +298,12 @@ public class FileReferenceValidationRule extends AbstractValidationRule {
                 // https://github.com/NASA-PDS/validate/issues/349 validate allows absolute path
                 // in directory_path_name but shouldn't
 
-                Path p = Paths.get(FilenameUtils.getFullPath(directory)); // Use getFullPath()
-                                                                          // function
-                                                                          // to get the actual name
-                                                                          // to
-                                                                          // avoid sonatype-lift
-                                                                          // complains.
-                if (p.isAbsolute()) {
+                // Use a platform-independent check: PDS4 directory_path_name uses
+                // forward-slash separators, so a leading '/' means absolute regardless of OS.
+                // Java's Path.isAbsolute() is platform-dependent: on Windows it returns false
+                // for paths starting with '/' that lack a drive letter (e.g. /test/foo/),
+                // which would miss this error on Windows.
+                if (directory.startsWith("/")) {
                   LOG.error(
                       "The directory name {} for tag 'directory_path_name' cannot be absolute",
                       directory);


### PR DESCRIPTION
## 🗒️ Summary

Replace platform-dependent `Path.isAbsolute()` with `directory.startsWith("/")` in `FileReferenceValidationRule.java`.

On Windows, `java.nio.file.Path.isAbsolute()` returns `false` for paths that start with `/` but lack a drive letter (e.g. `/test/meca_rdr_sis_files/`). Java treats these as "drive-relative" paths rather than absolute, so the `error.directory.unallowed_name` check was silently skipped on Windows. PDS4 `directory_path_name` always uses forward-slash separators, so a leading `/` unambiguously means absolute on all platforms.

**AI Assistance:** This fix was developed with AI assistance (Claude). The logic change is a single-line substitution with clear rationale.

## ⚙️ Test Data and/or Report

This is a platform-specific Windows bug — a Cucumber integration test running on Linux CI would always pass regardless of which check is used and would not catch a regression. The fix is covered by the existing test data (`Product_Document_FAIL_pathname_20260316.xml`, file06: `/test/meca_rdr_sis_files/`) and verified against the Linux/Windows report comparison provided in the issue.

Confirmed with @jshughes that `      ERROR  [error.directory.unallowed_name]   The directory name /test/meca_rdr_sis_files/ for tag 'directory_path_name' cannot be absolute.` is now thrown on windows as expected.

## ♻️ Related Issues

Fixes #1539
Refs NASA-PDS/pds4-information-model#1001

## 🤓 Reviewer Checklist

- [x] Are one or more documentation pages needed?
- [x] Are there security concerns with the changes in this PR?
- [x] Does this PR introduce breaking changes?
- [x] Are there any linting or code quality issues?
- [x] Have tests been added/updated to cover this change?
- [x] Is the CI/CD passing?
