### PR TITLE
Add support for MSSS ODR encoding types without requiring known file extensions

### DIFF
--- a/src/main/java/gov/nasa/pds/tools/util/EncodingMimeMapping.java
+++ b/src/main/java/gov/nasa/pds/tools/util/EncodingMimeMapping.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 public enum EncodingMimeMapping {
   DAT(Arrays.asList("dat","DAT")),
+  UNKNOWN_EXTENSION(new ArrayList<>()),
   GIF(Arrays.asList("gif")),
   J2C(Arrays.asList("j2c", "jp2", "mj2", "mjp2")),
   JPEG(Arrays.asList("jpg", "jpeg")),
@@ -36,6 +37,8 @@ public enum EncodingMimeMapping {
       if (encoding.equalsIgnoreCase("MP4/H.264")) return MP4;
       if (encoding.equalsIgnoreCase("MP4/H.264/AAC")) return MP4;
       if (encoding.equalsIgnoreCase("MSSS Camera Mini Header")) return DAT;
+      if (encoding.equalsIgnoreCase("MSSS Original Data Record Mini Header")) return UNKNOWN_EXTENSION;
+      if (encoding.equalsIgnoreCase("MSSS Original Data Record Payload Data")) return UNKNOWN_EXTENSION;
       if (encoding.equalsIgnoreCase("PDF")) return PDF;
       if (encoding.equalsIgnoreCase("PDFA")) return PDFA;
       if (encoding.equalsIgnoreCase("PDF/A")) return PDFA;

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/FileReferenceValidationRule.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/FileReferenceValidationRule.java
@@ -137,7 +137,7 @@ public class FileReferenceValidationRule extends AbstractValidationRule {
         try {
           EncodingMimeMapping emm = EncodingMimeMapping.find (encoding);
           String suffix = filename.substring(filename.lastIndexOf(".")+1);
-          if (!emm.contains (suffix)) {
+          if (!emm.allowed().isEmpty() && !emm.contains (suffix)) {
             this.getListener().addProblem(new ValidationProblem(
                 new ProblemDefinition(
                     ExceptionType.WARNING,


### PR DESCRIPTION
## 🗒️ Summary

Add support for two new MSSS ODR encoding types introduced in the PDS4 Information Model:

- `MSSS Original Data Record Mini Header`
- `MSSS Original Data Record Payload Data`

Since no guaranteed file extension exists for these encoding types, they are mapped to a new `UNKNOWN_EXTENSION` enum entry (empty extension list) and the file extension check is skipped rather than raising an error.

🤖 AI Assisted: ~80% of code changes were AI-influenced via Claude Code.

## ⚙️ Test Data and/or Report

Manual testing with a label containing `encoding_standard_id` = `MSSS Original Data Record Payload Data` confirmed the previous `INTERNAL_ERROR` is no longer raised and validation proceeds normally.

## ♻️ Related Issues

Resolves #1541

## 🤓 Reviewer Checklist

- [ ] **Documentation**: Do these changes require updates to documentation?
- [ ] **Security**: Are there any security concerns with these changes?
- [ ] **Testing**: Are there sufficient tests covering the changes?
- [ ] **Maintenance**: Will these changes require ongoing maintenance?
