### PR TITLE
Add MSSS ODR and Nikon NEF encoding types for Product_Native

### DIFF
--- a/src/main/java/gov/nasa/pds/tools/util/EncodingMimeMapping.java
+++ b/src/main/java/gov/nasa/pds/tools/util/EncodingMimeMapping.java
@@ -11,6 +11,7 @@ public enum EncodingMimeMapping {
   J2C(Arrays.asList("j2c", "jp2", "mj2", "mjp2")),
   JPEG(Arrays.asList("jpg", "jpeg")),
   MP4(Arrays.asList("mp4")),
+  NEF(Arrays.asList("nef")),
   PDF(Arrays.asList("pdf")),
   PDFA(Arrays.asList("pdf", "pdfa")),
   PNG(Arrays.asList("png")),
@@ -37,6 +38,7 @@ public enum EncodingMimeMapping {
       if (encoding.equalsIgnoreCase("MP4/H.264")) return MP4;
       if (encoding.equalsIgnoreCase("MP4/H.264/AAC")) return MP4;
       if (encoding.equalsIgnoreCase("MSSS Camera Mini Header")) return DAT;
+      if (encoding.equalsIgnoreCase("Nikon Electronic Format (NEF)")) return NEF;
       if (encoding.equalsIgnoreCase("MSSS Original Data Record Mini Header")) return UNKNOWN_EXTENSION;
       if (encoding.equalsIgnoreCase("MSSS Original Data Record Payload Data")) return UNKNOWN_EXTENSION;
       if (encoding.equalsIgnoreCase("PDF")) return PDF;

--- a/src/main/java/gov/nasa/pds/tools/util/EncodingMimeMapping.java
+++ b/src/main/java/gov/nasa/pds/tools/util/EncodingMimeMapping.java
@@ -1,7 +1,6 @@
 package gov.nasa.pds.tools.util;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 public enum EncodingMimeMapping {
@@ -20,13 +19,13 @@ public enum EncodingMimeMapping {
   WAV(Arrays.asList("wav"));
   final private List<String> extensions;
   EncodingMimeMapping (List<String> extensions){
-    this.extensions = extensions;
+    this.extensions = List.copyOf(extensions);
   }
   public boolean contains (String extension) {
     return this.extensions.contains (extension.toLowerCase());
   }
   public List<String> allowed() {
-    return Collections.unmodifiableList(this.extensions);
+    return this.extensions;
   }
   public static EncodingMimeMapping find (String encoding) throws IllegalArgumentException {
     if (encoding != null) {

--- a/src/main/java/gov/nasa/pds/tools/util/EncodingMimeMapping.java
+++ b/src/main/java/gov/nasa/pds/tools/util/EncodingMimeMapping.java
@@ -1,12 +1,12 @@
 package gov.nasa.pds.tools.util;
 
 import java.util.Arrays;
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public enum EncodingMimeMapping {
   DAT(Arrays.asList("dat","DAT")),
-  UNKNOWN_EXTENSION(new ArrayList<>()),
+  UNKNOWN_EXTENSION(List.of()),
   GIF(Arrays.asList("gif")),
   J2C(Arrays.asList("j2c", "jp2", "mj2", "mjp2")),
   JPEG(Arrays.asList("jpg", "jpeg")),
@@ -25,7 +25,7 @@ public enum EncodingMimeMapping {
     return this.extensions.contains (extension.toLowerCase());
   }
   public List<String> allowed() {
-    return new ArrayList<String>(this.extensions);
+    return Collections.unmodifiableList(this.extensions);
   }
   public static EncodingMimeMapping find (String encoding) throws IllegalArgumentException {
     if (encoding != null) {

--- a/src/main/java/gov/nasa/pds/tools/util/EncodingMimeMapping.java
+++ b/src/main/java/gov/nasa/pds/tools/util/EncodingMimeMapping.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 public enum EncodingMimeMapping {
   DAT(Arrays.asList("dat","DAT")),
+  UNKNOWN_EXTENSION(new ArrayList<>()),
   GIF(Arrays.asList("gif")),
   J2C(Arrays.asList("j2c", "jp2", "mj2", "mjp2")),
   JPEG(Arrays.asList("jpg", "jpeg")),
@@ -36,6 +37,8 @@ public enum EncodingMimeMapping {
       if (encoding.equalsIgnoreCase("MP4/H.264")) return MP4;
       if (encoding.equalsIgnoreCase("MP4/H.264/AAC")) return MP4;
       if (encoding.equalsIgnoreCase("MSSS Camera Mini Header")) return DAT;
+      if (encoding.equalsIgnoreCase("MSSS Original Data Record Mini Header")) return UNKNOWN_EXTENSION;
+      if (encoding.equalsIgnoreCase("MSSS Original Data Record Payload Data")) return UNKNOWN_EXTENSION;
       if (encoding.equalsIgnoreCase("PDF")) return PDF;
       if (encoding.equalsIgnoreCase("PDFA")) return PDFA;
       if (encoding.equalsIgnoreCase("PDF/A")) return PDFA;

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/FileReferenceValidationRule.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/FileReferenceValidationRule.java
@@ -137,7 +137,7 @@ public class FileReferenceValidationRule extends AbstractValidationRule {
         try {
           EncodingMimeMapping emm = EncodingMimeMapping.find (encoding);
           String suffix = filename.substring(filename.lastIndexOf(".")+1);
-          if (!emm.contains (suffix)) {
+          if (!emm.allowed().isEmpty() && !emm.contains (suffix)) {
             this.getListener().addProblem(new ValidationProblem(
                 new ProblemDefinition(
                     ExceptionType.WARNING,

--- a/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/FileReferenceValidationRule.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/FileReferenceValidationRule.java
@@ -136,14 +136,15 @@ public class FileReferenceValidationRule extends AbstractValidationRule {
       if (filename.contains(".")) {
         try {
           EncodingMimeMapping emm = EncodingMimeMapping.find (encoding);
+          List<String> allowed = emm.allowed();
           String suffix = filename.substring(filename.lastIndexOf(".")+1);
-          if (!emm.allowed().isEmpty() && !emm.contains (suffix)) {
+          if (!allowed.isEmpty() && !emm.contains (suffix)) {
             this.getListener().addProblem(new ValidationProblem(
                 new ProblemDefinition(
                     ExceptionType.WARNING,
                     ProblemType.FILE_NAMING_PROBLEM,
-                    "From the encoding type '" + encoding + "'the file extension '" + suffix + "' is not one of the allowed: " + emm.allowed().toString()),
-                this.target));            
+                    "From the encoding type '" + encoding + "'the file extension '" + suffix + "' is not one of the allowed: " + allowed.toString()),
+                this.target));
           }
         } catch (IllegalArgumentException iae) {
           this.getListener().addProblem(new ValidationProblem(

--- a/src/test/java/gov/nasa/pds/validate/EncodingMimeMappingTest.java
+++ b/src/test/java/gov/nasa/pds/validate/EncodingMimeMappingTest.java
@@ -1,0 +1,51 @@
+package gov.nasa.pds.validate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import gov.nasa.pds.tools.util.EncodingMimeMapping;
+import org.junit.jupiter.api.Test;
+
+public class EncodingMimeMappingTest {
+
+  @Test
+  public void testMsssOdrMiniHeaderMapsToUnknownExtension() {
+    assertEquals(EncodingMimeMapping.UNKNOWN_EXTENSION,
+        EncodingMimeMapping.find("MSSS Original Data Record Mini Header"));
+  }
+
+  @Test
+  public void testMsssOdrPayloadDataMapsToUnknownExtension() {
+    assertEquals(EncodingMimeMapping.UNKNOWN_EXTENSION,
+        EncodingMimeMapping.find("MSSS Original Data Record Payload Data"));
+  }
+
+  @Test
+  public void testNikonNefMapsToNef() {
+    assertEquals(EncodingMimeMapping.NEF,
+        EncodingMimeMapping.find("Nikon Electronic Format (NEF)"));
+  }
+
+  @Test
+  public void testNefAllowedExtension() {
+    assertTrue(EncodingMimeMapping.NEF.contains("nef"));
+  }
+
+  @Test
+  public void testUnknownExtensionAllowedIsEmpty() {
+    assertTrue(EncodingMimeMapping.UNKNOWN_EXTENSION.allowed().isEmpty());
+  }
+
+  @Test
+  public void testFindThrowsOnUnknownEncoding() {
+    assertThrows(IllegalArgumentException.class,
+        () -> EncodingMimeMapping.find("Not A Real Encoding"));
+  }
+
+  @Test
+  public void testFindThrowsOnNull() {
+    assertThrows(IllegalArgumentException.class,
+        () -> EncodingMimeMapping.find(null));
+  }
+}


### PR DESCRIPTION
## 🗒️ Summary

Adds two new `encoding_standard_id` values to `EncodingMimeMapping` to prevent `error.validation.internal_error` when validating `Product_Native` labels that use these encoding types:

- **#1541** — `MSSS Original Data Record Mini Header` and `MSSS Original Data Record Payload Data` (both map to `UNKNOWN_EXTENSION`, skipping the extension check since no fixed extension applies)
- **#1542** — `Nikon Electronic Format (NEF)` (maps to `.nef` extension, for Artemis data products)

Also addresses Copilot review feedback from #1543:
- `UNKNOWN_EXTENSION` now uses `List.of()` to communicate immutability by intent
- `allowed()` returns `Collections.unmodifiableList()` to avoid per-file `ArrayList` allocations on the hot validation path

> ⚠️ Cucumber regression tests for the new encoding values cannot be added until PDS4 Information Model v1.26.0.0 is released. Tests will be added to `4.1.x.feature` at that time.

## 🤖 AI Assistance Disclosure

- [x] Some portions of this PR were generated with AI assistance (~50% AI-influenced)

## ⚙️ Test Data and/or Report

Automated tests pass (`mvn test -Dcucumber.filter.tags='@4.1.x'`). Manual validation confirmed the new encoding types no longer trigger `error.validation.internal_error`.

Test cases for the new encoding values are deferred pending PDS4 IM v1.26.0.0 release (see summary above).

## ♻️ Related Issues

Fixes #1541
Fixes #1542
