### PR TITLE
Fix cleanly-passing products not counted, triggering false no_products_found error

### DIFF
--- a/src/main/java/gov/nasa/pds/validate/report/Report.java
+++ b/src/main/java/gov/nasa/pds/validate/report/Report.java
@@ -228,7 +228,7 @@ public abstract class Report {
         }
       }
     } else {
-      if (!Utility.isDir(sourceUri.toString()) && problems.size() - ignoreFromTotalCounts > 0) {
+      if (!Utility.isDir(sourceUri.toString())) {
         if (!this.integrityCheckFlag) {
           this.numPassedProds++;
         } else {


### PR DESCRIPTION
## 🗒️ Summary

Fix `no_products_found` error incorrectly triggered when a product validates cleanly (zero errors, zero warnings).

In `Report.java`, `numPassedProds` was only incremented when `problems.size() - ignoreFromTotalCounts > 0`. A cleanly-passing product has all its problems classified as `GENERAL`/`EXECUTION` category (which increment `ignoreFromTotalCounts`), so the net count evaluated to `<= 0` and the product was never tallied. `getTotalProducts()` then returned 0, causing `ValidateLauncher` to fire the false `no_products_found` error even though the product appeared as `PASS` in the report.

**Fix:** Remove the spurious `problems.size() - ignoreFromTotalCounts > 0` guard so any non-directory target that passes validation is correctly counted.

### 🤖 AI Assistance Disclosure
- [ ] No AI assistance used
- [ ] AI used for light assistance (e.g., suggestions, refactoring, documentation help, minor edits)
- [x] AI used for moderate content generation (AI generated some code or logic, but the developer authored or heavily revised the majority)
- [ ] AI generated substantial portions of this code

Estimated % of code influenced by AI: 50%

## ⚙️ Test Data and/or Report

Manually verified with a valid PDS4 label and user-supplied schema/schematron:

**Before fix:**
```
PASS: file://.../tc_Valid_Product_Resource.xml (urn:nasa:pds:resources:resources:opus::3.0)
ERROR [error.execution.no_products_found] No Products found during Validate execution.
  0 product(s) | 0 product(s) passed | 0 product(s) total
```

**After fix:**
```
PASS: file://.../tc_Valid_Product_Resource.xml (urn:nasa:pds:resources:resources:opus::3.0)
  1 product(s) | 1 product(s) passed | 1 product(s) total
```

## ♻️ Related Issues

Fixes #1557
Refs #1548, #1458

## 🤓 Reviewer Checklist

*Reviewers: Please verify the following before approving this pull request.*

### Documentation and PR Content
- [ ] **Documentation:** README, Wiki, or inline documentation (Sphinx, Javadoc, Docstrings) have been updated to reflect these changes.
- [ ] **Issue Traceability:** The PR is linked to a valid GitHub Issue
- [ ] **PR Title:** The PR title is "user-friendly" clearly identifying what is being fixed or the new feature being added, that if you saw it in the Release Notes for a tool, you would be able to get the gist of what was done.

### Security & Quality
- [ ] **SonarCloud:** Confirmed no new High or Critical security findings.
- [ ] **Secrets Detection:** Verified that the Secrets Detection scan passed and no sensitive information (keys, tokens, PII) is exposed.
- [ ] **Code Quality:** Code follows organization style guidelines and best practices for the specific language (e.g., PEP 8, Google Java Style).

### Testing & Validation
- [ ] **Test Accuracy:** Verified that test data is accurate, representative of real-world PDS4 scenarios, and sufficient for the logic being tested.
- [ ] **Coverage:** Automated tests cover new logic and edge cases.
- [ ] **Local Verification:** (If applicable) Successfully built and ran the changes in a local or staging environment.

### Maintenance
- [ ] **Backward Compatibility:** Confirmed that these changes do not break existing downstream dependencies or API contracts (or that breaking changes are clearly documented).
