### PR TITLE
Fix PDF/A validation reporting internal_error after veraPDF 1.30.x upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,7 +193,7 @@
     <dependency>
       <groupId>org.verapdf</groupId>
       <artifactId>validation-model-jakarta</artifactId>
-      <version>1.28.2</version>
+      <version>1.30.2</version>
     </dependency>
     <dependency>
       <groupId>net.sf.saxon</groupId>

--- a/src/main/java/gov/nasa/pds/tools/util/PDFUtil.java
+++ b/src/main/java/gov/nasa/pds/tools/util/PDFUtil.java
@@ -10,6 +10,7 @@ import java.net.URL;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.file.Paths;
+import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -91,16 +92,18 @@ public class PDFUtil {
 
   /**
    * Returns the detected PDF/A flavour for the given parser, or null if the PDF has no
-   * conformance declaration. veraPDF 1.30+ throws IndexOutOfBoundsException (rather than
-   * returning NO_FLAVOUR) when no pdfaid metadata is present.
+   * conformance declaration.
    */
   private PDFAFlavour detectFlavour(PDFAParser parser) {
-    try {
-      PDFAFlavour flavour = parser.getFlavour();
-      return PDFAFlavour.NO_FLAVOUR.equals(flavour) ? null : flavour;
-    } catch (IndexOutOfBoundsException e) {
+    List<PDFAFlavour> flavours = parser.getFlavours();
+    if (flavours.isEmpty()) {
       return null;
     }
+    PDFAFlavour flavour = flavours.get(0);
+    if (PDFAFlavour.NO_FLAVOUR.equals(flavour)) {
+      return null;
+    }
+    return flavour;
   }
 
   private boolean validatePDF(String baseDir, URI uri, String pdfRef) throws IOException {
@@ -127,16 +130,16 @@ public class PDFUtil {
         // Check the PDF is actually a valid 1a/1b flavour
         PDFAValidator validator =
             Foundries.defaultInstance().createValidator(detectedFlavour, false);
-        this.parserFlavor = parser.getFlavour().getId();
+        this.parserFlavor = detectedFlavour.getId();
         ValidationResult result = validator.validate(parser);
         if (result.isCompliant()) {
           LOG.debug("validatePDF file " + pdfRef + " is a valid PDF file with flavor "
-              + parser.getFlavour().getId());
+              + detectedFlavour.getId());
           pdfValidateFlag = true;
         } else {
           LOG.error("validatePDF file" + pdfRef + " is not valid PDF file with flavor "
-              + parser.getFlavour().getId());
-          this.writeErrorToFile(baseDir, pdfRef, result, parser.getFlavour().getId());
+              + detectedFlavour.getId());
+          this.writeErrorToFile(baseDir, pdfRef, result, detectedFlavour.getId());
           this.errorMessage = "Validation failed for flavour PDF/A-" + detectedFlavour.getId()
               + " in file " + Paths.get(pdfRef).getFileName() + ".";
           if (this.getExternalErrorFilename() != null) this.errorMessage += "  Detailed error output can be found at " + this.getExternalErrorFilename();

--- a/src/main/java/gov/nasa/pds/tools/util/PDFUtil.java
+++ b/src/main/java/gov/nasa/pds/tools/util/PDFUtil.java
@@ -98,35 +98,43 @@ public class PDFUtil {
         this.errorMessage = "Zero length file is an invalid PDF file.";
         return pdfValidateFlag;
       }
-      // Create a parser and auto-detect flavour
+      // Create a parser and auto-detect flavour.
+      // veraPDF 1.30+ throws from getFlavour() when a PDF has no pdfaid conformance declaration;
+      // treat that as non-compliant rather than an internal error so NON_PDFA_FILE is raised.
       PDFAParser parser = Foundries.defaultInstance().createParser(new FileInputStream(pdfRef));
-      PDFAFlavour detectedFlavour = parser.getFlavour();
+      PDFAFlavour detectedFlavour;
+      try {
+        detectedFlavour = parser.getFlavour();
+      } catch (IndexOutOfBoundsException e) {
+        // veraPDF 1.30+ throws here when a PDF has no pdfaid conformance declaration
+        this.errorMessage = "File does not contain a PDF/A conformance declaration for " + uri
+            + ". Expected: PDF/A-1a or PDF/A-1b.";
+        return pdfValidateFlag;
+      }
       LOG.debug("validatePDF: parser.getFlavour() [{}]", detectedFlavour);
 
-      // First, check the flavour is valid 1a or 1b
-      if (!detectedFlavour.equals(PDFAFlavour.PDFA_1_A)
+      // Explicitly reject PDFs with no conformance declaration before attempting validation.
+      if (detectedFlavour.equals(PDFAFlavour.NO_FLAVOUR)) {
+        this.errorMessage = "File does not contain a PDF/A conformance declaration for " + uri
+            + ". Expected: PDF/A-1a or PDF/A-1b.";
+      } else if (!detectedFlavour.equals(PDFAFlavour.PDFA_1_A)
           && !detectedFlavour.equals(PDFAFlavour.PDFA_1_B)) {
         this.errorMessage = "Invalid PDF/A version detected for " + uri
             + ". Expected: 1a or 1b. Actual: " + detectedFlavour.getId();
       } else {
-        // Next, check the PDF is actually a valid 1a/1b flavour
+        // Check the PDF is actually a valid 1a/1b flavour
         PDFAValidator validator =
             Foundries.defaultInstance().createValidator(detectedFlavour, false);
         this.parserFlavor = parser.getFlavour().getId();
         ValidationResult result = validator.validate(parser);
         if (result.isCompliant()) {
-          // File is a valid PDF
           LOG.debug("validatePDF file " + pdfRef + " is a valid PDF file with flavor "
               + parser.getFlavour().getId());
           pdfValidateFlag = true;
         } else {
           LOG.error("validatePDF file" + pdfRef + " is not valid PDF file with flavor "
               + parser.getFlavour().getId());
-
-          // Write the result to external file so the user can look over in the validate
-          // report.
           this.writeErrorToFile(baseDir, pdfRef, result, parser.getFlavour().getId());
-
           this.errorMessage = "Validation failed for flavour PDF/A-" + detectedFlavour.getId()
               + " in file " + Paths.get(pdfRef).getFileName() + ".";
           if (this.getExternalErrorFilename() != null) this.errorMessage += "  Detailed error output can be found at " + this.getExternalErrorFilename();

--- a/src/main/java/gov/nasa/pds/tools/util/PDFUtil.java
+++ b/src/main/java/gov/nasa/pds/tools/util/PDFUtil.java
@@ -89,6 +89,20 @@ public class PDFUtil {
     }
   }
 
+  /**
+   * Returns the detected PDF/A flavour for the given parser, or null if the PDF has no
+   * conformance declaration. veraPDF 1.30+ throws IndexOutOfBoundsException (rather than
+   * returning NO_FLAVOUR) when no pdfaid metadata is present.
+   */
+  private PDFAFlavour detectFlavour(PDFAParser parser) {
+    try {
+      PDFAFlavour flavour = parser.getFlavour();
+      return PDFAFlavour.NO_FLAVOUR.equals(flavour) ? null : flavour;
+    } catch (IndexOutOfBoundsException e) {
+      return null;
+    }
+  }
+
   private boolean validatePDF(String baseDir, URI uri, String pdfRef) throws IOException {
     boolean pdfValidateFlag = false;
 
@@ -98,23 +112,11 @@ public class PDFUtil {
         this.errorMessage = "Zero length file is an invalid PDF file.";
         return pdfValidateFlag;
       }
-      // Create a parser and auto-detect flavour.
-      // veraPDF 1.30+ throws from getFlavour() when a PDF has no pdfaid conformance declaration;
-      // treat that as non-compliant rather than an internal error so NON_PDFA_FILE is raised.
       PDFAParser parser = Foundries.defaultInstance().createParser(new FileInputStream(pdfRef));
-      PDFAFlavour detectedFlavour;
-      try {
-        detectedFlavour = parser.getFlavour();
-      } catch (IndexOutOfBoundsException e) {
-        // veraPDF 1.30+ throws here when a PDF has no pdfaid conformance declaration
-        this.errorMessage = "File does not contain a PDF/A conformance declaration for " + uri
-            + ". Expected: PDF/A-1a or PDF/A-1b.";
-        return pdfValidateFlag;
-      }
+      PDFAFlavour detectedFlavour = detectFlavour(parser);
       LOG.debug("validatePDF: parser.getFlavour() [{}]", detectedFlavour);
 
-      // Explicitly reject PDFs with no conformance declaration before attempting validation.
-      if (detectedFlavour.equals(PDFAFlavour.NO_FLAVOUR)) {
+      if (detectedFlavour == null) {
         this.errorMessage = "File does not contain a PDF/A conformance declaration for " + uri
             + ". Expected: PDF/A-1a or PDF/A-1b.";
       } else if (!detectedFlavour.equals(PDFAFlavour.PDFA_1_A)


### PR DESCRIPTION
## 🗒️ Summary

Fixes a regression introduced by upgrading `org.verapdf:validation-model-jakarta` from 1.28.2 to 1.30.2.

**Root cause:** veraPDF 1.30+ changed behavior in `PDFAParser.getFlavour()`. For PDFs with no `pdfaid` conformance declaration in their XMP metadata, the method now throws `IndexOutOfBoundsException` (accessing an empty list at index 0) instead of returning a default flavour as 1.28.x did. The exception propagated through `PDFUtil.validatePDF()`'s outer catch block, was re-thrown as `IOException`, and was then caught by `FileReferenceValidationRule.handlePDF()` as `INTERNAL_ERROR` rather than the expected `NON_PDFA_FILE`.

**Fix:** Catch `IndexOutOfBoundsException` from `getFlavour()` specifically and treat it as a missing conformance declaration — set `errorMessage` and return `false` (non-compliant). Also adds an explicit `NO_FLAVOUR` guard for future veraPDF versions that may return `NO_FLAVOUR` cleanly instead of throwing.

**Confirmed by investigation:**
- All failing test PDFs (`github1008/example.pdf`, `github164/invalid/test1_pdf.pdf`, `github824/1203_12.PDF`) are plain PDFs with no `pdfaid` XMP metadata, verified via `qpdf --qdf --decode-level=none` raw stream extraction
- Under 1.28.2, `getFlavour()` guessed `PDFA_1_B` as a default → validation failed → `NON_PDFA_FILE` raised (correct outcome, accidental path)
- Under 1.30.2, `getFlavour()` throws `IndexOutOfBoundsException` → previously became `INTERNAL_ERROR`

**Changes:**
- `pom.xml`: bump `validation-model-jakarta` 1.28.2 → 1.30.2 (fixes CVE on 1.28.2)
- `PDFUtil.java`: catch `IndexOutOfBoundsException` from `getFlavour()` and treat as missing PDF/A declaration

> 🤖 Generated with [Claude Code](https://claude.ai/claude-code)

**AI Assistance:** This fix was developed with AI assistance (investigation, root cause analysis, and implementation). The logic was verified against actual test PDFs and confirmed passing all targeted test scenarios.

## ⚙️ Test Data and/or Report

Targeted scenarios verified locally with veraPDF 1.30.2:
- `NASA-PDS/validate#1008-1` ✅ `error.pdf.file.not_pdfa_compliant=1`
- `NASA-PDS/validate#366-1` ✅ `error.pdf.file.not_pdfa_compliant=1`
- `NASA-PDS/validate#164-1` ✅ `error.pdf.file.not_pdfa_compliant=1`
- `NASA-PDS/validate#824-1` ✅ 0 errors
- `NASA-PDS/validate#824-2` ✅ 0 errors

Full `@v3.7.x` test suite running in CI.

## ♻️ Related Issues

Fixes #1662
Closes #1625

## 🤓 Reviewer Checklist

- [ ] **Documentation** - Is the new feature/change adequately documented?
- [ ] **Security** - Are there any security implications to these changes?
- [ ] **Testing** - Have tests been added/updated? Are edge cases covered?
- [ ] **Dependencies** - Are dependency changes appropriate and minimal?
