### PR TITLE
Fix missing_constant not suppressing min/max range errors in ASCII tables

### DIFF
--- a/src/main/java/gov/nasa/pds/tools/validate/SpecialConstantChecker.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/SpecialConstantChecker.java
@@ -184,6 +184,17 @@ public class SpecialConstantChecker {
         }
       }
     }
+    boolean hasDecimalPoint = constant_repr.contains(".");
+    boolean hasScientificNotation = (constant_repr.contains("E") || constant_repr.contains("e"))
+        && !constant_repr.startsWith("0x") && !constant_repr.startsWith("0X");
+    boolean repr_decimal = hasDecimalPoint || hasScientificNotation;
+    // For ASCII numeric fields, the value arrives as BigDecimal. Compare directly
+    // against a decimal constant representation to avoid lossy BigDecimal→Double→BigInteger
+    // conversion that causes missing_constant values like "-.99999" to never match.
+    if (number instanceof BigDecimal && repr_decimal) {
+      BigDecimal constant = SpecialConstantBitPatternTransforms.asBigDecimal(constant_repr, radix);
+      return constant.compareTo((BigDecimal) number) == 0;
+    }
     if (number instanceof BigDecimal) number = ((BigDecimal)number).doubleValue();
     if (number instanceof Byte) number = BigInteger.valueOf(number.byteValue());
     if (number instanceof Double) number = BigInteger.valueOf(Double.doubleToRawLongBits((Double)number));
@@ -191,9 +202,6 @@ public class SpecialConstantChecker {
     if (number instanceof Integer || number instanceof UnsignedInteger) number = BigInteger.valueOf(number.intValue());
     if (number instanceof Long || number instanceof UnsignedLong) number = BigInteger.valueOf(number.longValue());
     if (number instanceof Short) number = BigInteger.valueOf(number.shortValue());
-    boolean repr_decimal = constant_repr.contains (".") || 
-        ((constant_repr.contains("E") || constant_repr.contains("e")) &&
-            !(constant_repr.startsWith("0x") || constant_repr.startsWith("0X")));
     if (repr_decimal) {
       BigDecimal constant = SpecialConstantBitPatternTransforms.asBigDecimal(constant_repr, radix);
       return constant.equals (number);

--- a/src/main/java/gov/nasa/pds/tools/validate/SpecialConstantChecker.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/SpecialConstantChecker.java
@@ -184,9 +184,9 @@ public class SpecialConstantChecker {
         }
       }
     }
-    boolean hasDecimalPoint = constant_repr.contains(".");
-    boolean hasScientificNotation = (constant_repr.contains("E") || constant_repr.contains("e"))
-        && !constant_repr.startsWith("0x") && !constant_repr.startsWith("0X");
+    boolean isHex = constant_repr.startsWith("0x") || constant_repr.startsWith("0X");
+    boolean hasDecimalPoint = constant_repr.contains(".") && !isHex;
+    boolean hasScientificNotation = (constant_repr.contains("E") || constant_repr.contains("e")) && !isHex;
     boolean repr_decimal = hasDecimalPoint || hasScientificNotation;
     // For ASCII numeric fields, the value arrives as BigDecimal. Compare directly
     // against a decimal constant representation to avoid lossy BigDecimal→Double→BigInteger

--- a/src/test/resources/features/4.0.x.feature
+++ b/src/test/resources/features/4.0.x.feature
@@ -10,7 +10,7 @@ Feature: 4.0.x
 | 1408 | 1 | "github1408" | " -t {datasrc}/" | "summary:totalErrors=1,summary:productValidation:failed=1,summary:messageTypes:error.label.table_definition_problem=1" |
 | 1391 | 1 | "github1391" | "--skip-context-validation -t {datasrc}/vl0axrat_char.xml" |  |
 | 1391 | 2 | "github1391" | "--skip-context-validation -t {datasrc}/vl0axrat_delim.xml" |  |
-| 1379 | 1 | "github1379" | " -v1 -t {datasrc}/V11979080.xml" | "summary:totalWarnings=3,summary:messageTypes:warning.table.field_value_out_of_special_constant_min_max_range=3,summary:messageTypes:info.label.context_ref_found=3,summary:messageTypes:info.label.missing_filesize=1,summary:messageTypes:info.table.field_value_is_special_constant=3" |
+| 1379 | 1 | "github1379" | " -v1 -t {datasrc}/V11979080.xml" | "summary:messageTypes:info.label.context_ref_found=3,summary:messageTypes:info.label.missing_filesize=1,summary:messageTypes:info.table.field_value_is_special_constant=6" |
 | 1359 | 1 | "github1359" | "--skip-context-validation --label-extension lblx -R pds4.label --strict-field-checks -t {datasrc}/collection_hyb2_nirs3_sp_ard_data_iof_thermalcorr_v001.lblx" |  |
 | 1358 | 1 | "github1358" | "--skip-context-validation -C {datasrc}/catalog.xml --label-extension lblx -R pds4.label --strict-field-checks -t {datasrc}/uvi_20151207_051953_283_l2b_v21_edited.lblx " |  |
 | 1357 | 1 | "github1357" | "--skip-context-validation --label-extension lblx -R pds4.label -t {datasrc}/uvi_20151207_051953_283_l3b_v21.lblx" |  |

--- a/src/test/resources/features/4.2.x.feature
+++ b/src/test/resources/features/4.2.x.feature
@@ -15,4 +15,7 @@ Feature: 4.2.x
 # github1635: M4A/AAC should be a recognized encoding type; content validation not yet supported → WARNING not ERROR
 | 1635 | 1 | "github1635" | "--skip-context-validation -t {datasrc}/audio_m4a.xml" | "summary:totalWarnings=1,summary:messageTypes:warning.validation.content_validation_not_yet_supported=1" |
 
+# github1660: missing_constant must suppress min/max range errors in ASCII table fields
+| 1660 | 1 | "github1660" | "--skip-context-validation -t {datasrc}/pccds.xml" | "summary:productValidation:passed=1,summary:totalErrors=0,summary:totalWarnings=2,summary:messageTypes:warning.label.bad_schematypens=1,summary:messageTypes:warning.label.missing_schematron_spec=1" |
+
 #end

--- a/src/test/resources/features/pre.3.6.x.feature
+++ b/src/test/resources/features/pre.3.6.x.feature
@@ -15,7 +15,7 @@ Feature: < 3.6
 | 755 | 2 | "github755" | "--skip-context-validation -t {datasrc}/m221011.0013.xml {datasrc}/m221011.0015.xml" |  |
 | 754 | 1 | "github754" | "--skip-context-validation -t {datasrc}/Cassini_ISS_CB2_Jupiter_global_map_2.xml" | "summary:totalWarnings=1,summary:messageTypes:warning.label.schema=1" |
 | 693 | 1 | "github693" | "--skip-context-validation -t {datasrc}/" | "summary:totalErrors=4,summary:productValidation:failed=4,summary:messageTypes:error.pdf.file.not_pdfa_compliant=4" |
-| 690 | 1 | "github690" | "--skip-context-validation -S {datasrc}/../jaxa/PDS4_PDS_1J00.sch -S {datasrc}/../jaxa/PDS4_MSN_1J00_1300.sch -S {datasrc}/../jaxa/PDS4_VCO_1J00_1000.sch -x {datasrc}/../jaxa/PDS4_PDS_1J00.xsd -x {datasrc}/../jaxa/PDS4_MSN_1J00_1300.xsd -x {datasrc}/../jaxa/PDS4_VCO_1J00_1000.xsd -t {datasrc}/rs_20160518_014000_udsc64_l3_e_v10.xml" | "summary:totalWarnings=888,summary:messageTypes:warning.table.field_value_out_of_special_constant_min_max_range=888" |
+| 690 | 1 | "github690" | "--skip-context-validation -S {datasrc}/../jaxa/PDS4_PDS_1J00.sch -S {datasrc}/../jaxa/PDS4_MSN_1J00_1300.sch -S {datasrc}/../jaxa/PDS4_VCO_1J00_1000.sch -x {datasrc}/../jaxa/PDS4_PDS_1J00.xsd -x {datasrc}/../jaxa/PDS4_MSN_1J00_1300.xsd -x {datasrc}/../jaxa/PDS4_VCO_1J00_1000.xsd -t {datasrc}/rs_20160518_014000_udsc64_l3_e_v10.xml" |  |
 | 684 | 1 | "github684" | "--skip-context-validation -t {datasrc}/example_params_noFileSize.xml" |  |
 | 684 | 2 | "github684" | "--skip-context-validation -t {datasrc}/example_params_wFileSize.xml" |  |
 | 683 | 1 | "github614" | "--skip-context-validation -t {datasrc}/ss__0505_0711794861_465rmo__0261222srlc10000w0__cgnj02.xml" | "summary:totalWarnings=1,summary:messageTypes:warning.data_objects.out_of_order=1" |
@@ -72,7 +72,7 @@ Feature: < 3.6
 | 435 | 1 | "github435" | "--skip-context-validation -R pds4.label -t {datasrc}/flat_w.xml" |  |
 | 432 | 1 | "github432" | "-R pds4.bundle -t {datasrc}/bundle-voyager1-pls-sat-1.0.xml" | "summary:totalWarnings=1,summary:messageTypes:warning.integrity.reference_not_found=1" |
 | 429 | 1 | "github429" | "-R pds4.label --disable-context-mismatch-warnings -t {datasrc}/EPPS_EDR_SIS.xml" |  |
-| 427 | 1 | "github427" | "--skip-context-validation -S {datasrc}/../jaxa/PDS4_PDS_1J00.sch -S {datasrc}/../jaxa/PDS4_MSN_1J00_1300.sch -S {datasrc}/../jaxa/PDS4_VCO_1J00_1000.sch -x {datasrc}/../jaxa/PDS4_PDS_1J00.xsd -x {datasrc}/../jaxa/PDS4_MSN_1J00_1300.xsd -x {datasrc}/../jaxa/PDS4_VCO_1J00_1000.xsd -t {datasrc}/dir%20with%20spaces/rs_20160518_014000_udsc64_l3_e_v10.xml" | "summary:totalWarnings=2,summary:messageTypes:warning.table.field_value_out_of_special_constant_min_max_range=2" |
+| 427 | 1 | "github427" | "--skip-context-validation -S {datasrc}/../jaxa/PDS4_PDS_1J00.sch -S {datasrc}/../jaxa/PDS4_MSN_1J00_1300.sch -S {datasrc}/../jaxa/PDS4_VCO_1J00_1000.sch -x {datasrc}/../jaxa/PDS4_PDS_1J00.xsd -x {datasrc}/../jaxa/PDS4_MSN_1J00_1300.xsd -x {datasrc}/../jaxa/PDS4_VCO_1J00_1000.xsd -t {datasrc}/dir%20with%20spaces/rs_20160518_014000_udsc64_l3_e_v10.xml" |  |
 | 424 | 1 | "github424" | "-R pds4.label -t {datasrc}/asurpif_photos_amboycrater_v1.0_20211021_sip_v1.0.xml" |  |
 | 424 | 2 | "github424" | "-R pds4.label -t {datasrc}/asurpif_photos_amboycrater_v1.0_20211021_aip_v1.0.xml" |  |
 | 419 | 1 | "github419" | "-R pds4.label --disable-context-mismatch-warnings -t {datasrc}/bundle_astromat_chem.xml" |  |

--- a/src/test/resources/github1660/pccds.tab
+++ b/src/test/resources/github1660/pccds.tab
@@ -1,0 +1,187 @@
+   C/1955 G1   1954 V    1955b Abell                         2   0.6  -9.9 0.2     -  ---                         
+   C/1953 X1   1954 II   1953h Pajdusakova                   2   4.   -9.9 0.0058  -  ---                         
+   C/1954 M1   1954 I    1954c Harrington                    2   0.8  -9.9 -.99999 -  ---                         
+   C/1954 M2   1954 XII  1954d Kresak-Peltier                2   3.    9.  -.99999 -  ---                         
+   C/1954 O1   1954 VIII 1954f Vozarova                      2   6.8  -9.9 0.008   A  ---                         
+   C/1953 T1   1954 X    1953g Abell                         2   4.2  -9.9 0.025   1  ---                         
+ 12P/1953 M1   1954 VII  1953c Pons-Brooks                   2  12.   -9.9 0.047   -  ---                         
+ 44P/1953 N1   1954 VI   1953d Reinmuth 2                    2   0.4  -9.9 0.001   -  ---                         
+ 45P/1954 C1   1954 III  1954a Honda-Mrkos-Pajdusakova       2   1.0  -9.9 0.0035  1  ---                         
+ 46P/1954 R2   1954 XI   1954j Wirtanen                      2   1.0  -9.9 -.99999 -  ---                         
+ 53P/1954 R1   1954 IV   1954i van Biesbroeck                2   0.15 -9.9 -.99999 -  ---                         
+   C/1954 O2   1955 VI   1954h Baade                         2   5.8  -9.9 0.019   -  ---                         
+   C/1955 L1   1955 III  1955e Mrkos                         2   5.4   7.4 0.047   1  ---                         
+   C/1955 L1   1955 III  1955e Mrkos                         2  -9.99 -9.9 0.018   3  ---                         
+ 31P/---       1955 I    1954g Schwassmann-Wachmann 2        2   1.6   2.2 0.002   -  ---                         
+   C/1955 N1   1955 IV   1955f Bakharev-Macfarlane-Krienke   2   4.2   6.5 0.042   1  ---                         
+  4P/---       1955 II   1954e Faye                          2  -9.99 -9.9 0.0014  -  ---                         
+ 18P/1955 U1   1955 VII  1955i Perrine-Mrkos                 2   3.0  -9.9 0.003   -  ---                         
+   C/1955 O1   1955 V    1955g Honda                         2   6.75 -9.9 0.020   1  ---                         
+   C/1955 O1   1955 V    1955g Honda                         2  -9.99 -9.9 0.0015  3  ---                         
+ 36P/---       1955 VIII 1955d Whipple                       2   0.24 -9.9 0.001   -  Tail length is a lower limit
+   C/1954 Y1   1956 I    1954k Haro-Chavira                  2   1.6  -9.9 0.027   -  1956 head diameter          
+   C/1954 Y1   1956 I    1954k Haro-Chavira                  2   3.5  -9.9 -.99999 -  1958 head diameter          
+   C/1956 E1   1956 III  1956b Mrkos                         2   1.5  -9.9 0.0007  -  ---                         
+ 13P/1956 A1   1956 IV   1956a Olbers                        2   8.    5.  0.08    -  ---                         
+ 27P/1956 S1   1956 VI   1956g Crommelin                     2   1.4  -9.9 0.004   1  ---                         
+ 47P/1955 H1   1956 II   1955c Ashbrook-Jackson              2  -9.99 -9.9 0.0008  -  ---                         
+ 48P/1956 P1   1956 V    1956f Johnson                       2   0.7  -9.9 -.99999 -  ---                         
+   C/1956 F1-A 1957 VI   1956c Wirtanen                      2   4.   -9.9 0.056   -  ---                         
+   C/1956 R1   1957 III  1956h Arend-Roland                  2   4.    5.  0.300   1  1957 head diameter          
+   C/1956 R1   1957 III  1956h Arend-Roland                  2   0.7  -9.9 0.191   A  1958 head diameter          
+   C/1957 P1   1957 V    1957d Mrkos                         2  10.    3.  0.176   1  ---                         
+   C/1957 P1   1957 V    1957d Mrkos                         2  -9.99 -9.9 0.085   2  ---                         
+   C/1957 U1   1957 IX   1957f Latyshev-Wild-Burnham         2   6.3  -9.9 0.0036  -  ---                         
+  2P/---       1957 VIII 1957c Encke                         2   3.6  -9.9 -.99999 -  ---                         
+ 29P/---       1957 IV   ---   Schwassmann-Wachmann 1        2  25.    1.  0.01    -  ---                         
+   C/1958 D1   1958 III  1958a Burnham                       2   3.8  -9.9 0.008   -  ---                         
+ 22P/---       1958 I    1958d Kopff                         2   0.4  -9.9 -.99999 -  ---                         
+ 30P/---       1958 II   1957e Reinmuth 1                    2  -9.99 -9.9 0.0003  -  ---                         
+ 39P/---       1958 IV   ---   Oterma                        2   0.5  -9.9 0.03    -  ---                         
+ 43P/---       1958 V    1957g Wolf-Harrington               2  -9.99 -9.9 0.001   -  ---                         
+ 56P/1959 B1   1958 VI   1959a Slaughter-Burnham             2  -9.99 -9.9 1.      -  ---                         
+   C/1958 R1   1959 I    1958e Burnham-Slaughter             2   1.4  -9.9 0.003   -  ---                         
+   C/1959 Q1   1959 IV   1959e Alcock                        2   1.9  -9.9 0.007   1  ---                         
+   C/1959 Q2   1959 VI   1959f Alcock                        2   1.9  -9.9 0.064   1  ---                         
+   C/1959 X1   1959 IX   1959j Mrkos                         2   0.6  -9.9 0.004   -  ---                         
+   C/1960 B1   1959 VII  1960a Burnham                       2   0.4  -9.9 0.002   -  ---                         
+   C/1960 M1   1959 X    1960e Humason                       2   1.6  -9.9 0.029   -  ---                         
+ 21P/---       1959 VIII 1959b Giacobini-Zinner              2   1.2  -9.9 0.003   1  ---                         
+ 50P/1959 N1   1959 V    1959c Arend                         2   1.0  -9.9 -.99999 -  ---                         
+   C/1959 Y1   1960 II   1959k Burnham                       2   1.6  -9.9 0.041   1  ---                         
+   C/1959 Y1   1960 II   1959k Burnham                       2  -9.99 -9.9 0.02    3  ---                         
+ 15P/---       1960 VIII 1960d Finlay                        2   1.4  -9.9 -.99999 -  ---                         
+ 16P/---       1960 VI   1960h Brooks 2                      2   0.5  -9.9 0.0073  -  ---                         
+ 19P/---       1960 V    1960k Borrelly                      2   0.6  -9.9 0.0002  -  ---                         
+ 24P/---       1960 III  1959h Schaumasse                    2   0.4  -9.9 -.99999 -  ---                         
+ 40P/---       1960 IV   1959i Vaisala 1                     2   0.6  -9.9 0.0004  -  ---                         
+ 51P/1960 P1   1960 VII  1960g Harrington                    2  -9.99 -9.9 0.0002  -  ---                         
+ 63P/1960 G1   1960 I    1960b Wild 1                        2   0.4  -9.9 -.99999 -  ---                         
+   C/1960 Y1   1961 II   1960n Candy                         3  -9.99 -9.9 0.007   -  ---                         
+   C/1961 O1   1961 V    1961d Wilson-Hubbard                3  19.2  -9.9 0.8     -  ---                         
+   C/1961 O1   1961 V    1961d Wilson-Hubbard                3  -9.99 -9.9 0.37    -  ---                         
+   C/1961 O1   1961 V    1961d Wilson-Hubbard                3  -9.99 -9.9 0.06    -  ---                         
+   C/1961 T1   1961 VIII 1961f Seki                          3  16.   -9.9 0.075   -  ---                         
+  2P/---       1961 I    1960i Encke                         3   5.6  -9.9 0.023   -  ---                         
+ 31P/---       1961 VII  1960j Schwassmann-Wachmann 2        3   0.5  -9.9 0.002   -  ---                         
+ 32P/---       1961 III  1960f Comas Sola                    3   0.5  -9.9 0.002   -  ---                         
+ 37P/---       1961 VI   1961a Forbes                        3  -9.99 -9.9 0.001   -  ---                         
+   C/1961 R1   1962 VIII 1961e Humason                       3  30.   43.  0.285   -  ---                         
+   C/1962 C1   1962 III  1962c Seki-Lines                    3   7.0  -9.9 0.287   -  ---                         
+   C/1962 C1   1962 III  1962c Seki-Lines                    3  -9.99 -9.9 0.010   -  ---                         
+   C/1962 H1   1962 IV   1962d Honda                         3   2.7  -9.9 0.058   -  ---                         
+  4P/---       1962 VII  1961c Faye                          3  -9.99 -9.9 0.001   -  ---                         
+ 10P/---       1962 VI   1961b Tempel 2                      3   0.8  -9.9 -.99999 -  ---                         
+ 18P/---       1962 I    1961h Perrine-Mrkos                 3   0.9  -9.9 -.99999 -  ---                         
+ 41P/---       1962 V    1962b Tuttle-Giacobini-Kresak       3   1.0  -9.9 -.99999 -  ---                         
+   C/1963 A1   1963 I    1963a Ikeya                         3   8.2  -9.9 0.163   -  ---                         
+   C/1963 F1   1963 III  1963b Alcock                        3  15.   -9.9 0.013   -  ---                         
+   C/1963 R1   1963 V    1963e Pereyra                       3  -9.99 -9.9 1.2     -  ---                         
+ 47P/---       1963 VI   1962e Ashbrook-Jackson              3  -9.99 -9.9 0.003   -  ---                         
+ 48P/---       1963 IV   1963c Johnson                       3   0.6  -9.9 -.99999 -  ---                         
+ 59P/1963 Q1   1963 VIII 1963d Kearns-Kwee                   3   3.7  -9.9 0.0024  -  ---                         
+   C/1964 L1   1964 VI   1964c Tomita-Gerber-Honda           3   6.2  -9.9 0.53    -  ---                         
+   C/1964 N1   1964 VIII 1964f Ikeya                         3   5.9  -9.9 0.055   -  ---                         
+   C/1964 P1   1964 IX   1964h Everhart                      3  27.   -9.9 0.04    -  ---                         
+  7P/---       1964 I    1964b Pons-Winnecke                 3   0.5  -9.9 -.99999 -  ---                         
+ 22P/---       1964 III  1963i Kopff                         3   2.   10.  0.0033  -  ---                         
+   C/1965 S1-A 1965 VIII 1965f Ikeya-Seki                    5   4.2   1.6 1.39    -  ---                         
+   C/1965 S2   1965 IX   1965h Alcock                        5   0.7  -9.9 -.99999 -  ---                         
+ 43P/---       1965 III  1964g Wolf-Harrington               5   0.5  -9.9 0.00005 -  ---                         
+ 54P/1965 M1   1965 VII  1965e de Vico-Swift                 5   0.3  -9.9 0.0005  -  ---                         
+ 60P/1965 A2   1965 II   1965c Tsuchinshan 2                 5  -9.99 -9.9 0.00001 -  ---                         
+ 62P/1965 A1   1965 I    1965b Tsuchinshan 1                 5   0.2   0.3 -.99999 -  ---                         
+ 68P/1965 U1   1965 VI   1965j Klemola                       5   0.2  -9.9 -.99999 -  ---                         
+   C/1966 P1   1966 V    1966b Kilston                       5   5.0   7.5 0.095   -  ---                         
+   C/1966 P2   1966 II   1966c Barbon                        5   5.9  -9.9 0.33    -  ---                         
+   C/1966 R1   1966 IV   1966d Ikeya-Everhart                5   7.0  -9.9 0.003   -  ---                         
+ 28P/---       1966 VI   1966a Neujmin 1                     5   0.4  -9.9 -.99999 -  ---                         
+ 53P/1965 J1   1966 III  1965d van Biesbroeck                5   0.7  -9.9 -.99999 -  ---                         
+   C/1966 T1   1967 II   1966e Rudnicki                      5   2.1  -9.9 0.015   -  ---                         
+   C/1967 C1   1967 IV   1967b Seki                          5   2.0  -9.9 0.001   -  ---                         
+   C/1967 C2   1967 III  1967c Wild                          5   2.8  -9.9 0.001   -  ---                         
+   C/1967 M1   1967 VII  1967f Mitchell-Jones-Gerber         5  13.4  -9.9 0.11    -  ---                         
+  2P/---       1967 XIII 1967h Encke                         5   1.3  -9.9 -.99999 -  ---                         
+  8P/---       1967 V    1967a Tuttle                        5   2.2  -9.9 -.99999 -  ---                         
+ 10P/---       1967 X    1967d Tempel 2                      5   2.0  -9.9 0.0005  -  ---                         
+ 44P/---       1967 XI   1967e Reinmuth 2                    5   0.8  -9.9 -.99999 -  ---                         
+ 46P/---       1967 XIV  1967k Wirtanen                      5   0.1  -9.9 -.99999 -  ---                         
+   C/1967 Y1   1968 I    1967n Ikeya-Seki                    5   9.5  -9.9 0.045   -  ---                         
+   C/1968 H1   1968 IV   1968a Tago-Honda-Yamamoto           5   2.8  -9.9 0.002   -  ---                         
+   C/1968 L1   1968 V    1968b Whitaker-Thomas               5   1.8  -9.9 -.99999 -  ---                         
+   C/1968 N1   1968 VI   1968c Honda                         5   6.0   6.9 0.041   -  ---                         
+   C/1968 Q1   1968 VII  1968d Bally-Clayton                 5   4.0  -9.9 0.005   -  ---                         
+   C/1968 Q2   1968 IX   1968e Honda                         5   2.8  -9.9 0.002   -  ---                         
+   C/1968 U1   1968 III  1968f Wild                          5   1.0  -9.9 0.004   -  ---                         
+ 18P/---       1968 VIII 1968h Perrine-Mrkos                 5   0.9  -9.9 -.99999 -  ---                         
+ 31P/---       1968 II   1967i Schwassmann-Wachmann 2        5   1.0  -9.9 -.99999 -  ---                         
+   C/1968 Y1   1969 I    1968j Thomas                        5   2.7   3.0 0.012   -  ---                         
+   C/1969 P1   1969 VII  1969d Fujikawa                      5   5.   -9.9 0.032   -  ---                         
+   C/1969 T1   1969 IX   1969g Tago-Sato-Kosaka              5  13.   -9.9 0.119   -  ---                         
+  4P/---       1969 VI   1969a Faye                          5   2.3  -9.9 0.006   -  ---                         
+ 32P/---       1969 VIII 1968g Comas Sola                    5   1.   -9.9 0.003   -  ---                         
+ 45P/---       1969 V    1969e Honda-Mrkos-Pajdusakova       5   1.0  -9.9 -.99999 -  ---                         
+ 67P/1969 R1   1969 IV   1969h Churyumov-Gerasimenko         5   1.3  -9.9 0.004   -  ---                         
+   C/1969 O1-A 1970 III  1969b Kohoutek                      5   1.2  -9.9 0.003   -  ---                         
+   C/1969 Y1   1970 II   1969i Bennett                       5   4.   11.  0.39    -  ---                         
+   C/1970 B1   1970 I    1970a Daido-Fujikawa                5  -9.99 -9.9 0.077   -  ---                         
+   C/1970 K1   1970 VI   1970f White-Ortiz-Bolelli           5   6.7  -9.9 0.58    -  Tail length range: .58-.88  
+   C/1970 N1   1970 XV   1970g Abe                           5   5.    7.  0.18    -  ---                         
+   C/1970 U1   1970 X    1970m Suzuki-Sato-Seki              5   5.4  -9.9 0.02    -  ---                         
+  6P/---       1970 VII  1970d d'Arrest                      5   1.6  -9.9 -.99999 -  ---                         
+ 48P/---       1970 IV   1970h Johnson                       5  -9.99 -9.9 0.0001  -  ---                         
+ 57P/1970 N2   1970 XIII 1970i du Toit-Neujmin-Delporte      5   0.25 -9.9 -.99999 -  ---                         
+ 58P/1970 R1   1970 IX   1970k Jackson-Neujmin               5   0.4   0.8 0.0004  -  ---                         
+ 70P/1970 Y1   1970 XII  1970r Kojima                        5   2.   -9.9 0.0005  -  ---                         
+ 65P/1970 U2   1969 II   1970p Gunn                          5   1.   -9.9 0.0005  -  ---                         
+   C/1972 F1   1971 I    1972e Gehrels                       6  -9.99 -9.9 0.013   -  ---                         
+  2P/---       1971 II   1970l Encke                         6   1.2  -9.9 -.99999 -  ---                         
+ 47P/---       1971 III  1970e Ashbrook-Jackson              6  -9.99 -9.9 0.0004  -  ---                         
+   C/1971 E1   1971 V    1971a Toba                          6   1.5  -9.9 0.0011  -  ---                         
+ 43P/---       1971 VI   1970o Wolf-Harrington               6  -9.99 -9.9 0.002   -  ---                         
+ 61P/1971 S2   1971 IX   1971e Shajn-Schaldach               6   1.2  -9.9 0.001   -  ---                         
+ 60P/1971 S1   1971 X    1971d Tsuchinshan 2                 6   1.   -9.9 0.002   -  ---                         
+ 17P/---       1972 I    1971b Holmes                        6  -9.99 -9.9 0.0001  -  ---                         
+ 26P/---       1972 II   1972b Grigg-Skjellerup              6  -9.99 -9.9 0.1     -  ---                         
+   C/1972 E1   1972 III  1972f Bradfield                     6  10.0  -9.9 0.019   -  ---                         
+  9P/1972 A1   1972 V    1972a Tempel 1                      6   0.2  -9.9 0.001   -  ---                         
+ 21P/---       1972 VI   1972d Giacobini-Zinner              6   1.4  -9.9 0.007   -  ---                         
+ 64P/1973 C1   1972 VII  1973d Swift-Gehrels                 6   0.6  -9.9 -.99999 -  ---                         
+   C/1973 A1   1972 VIII 1973a Heck-Sause                    6   1.4  -9.9 0.0031  -  ---                         
+   C/1972 L1   1972 IX   1972h Sandage                       6   7.8  -9.9 0.04    -  ---                         
+ 59P/1971 O1   1972 XI   1971c Kearns-Kwee                   6   1.0  -9.9 0.0014  -  ---                         
+   C/1972 X1   1972 XII  1972l Araya                         6   0.7  -9.9 -.99999 -  ---                         
+   C/1972 U1   1973 II   1972j Kojima                        6  -9.99 -9.9 0.002   -  ---                         
+   C/1973 H1   1973 III  1973h Huchra                        6   2.8  -9.9 -.99999 -  ---                         
+ 71P/1973 L1   1973 V    1973i Clark                         6   0.1  -9.9 0.00016 -  ---                         
+ 41P/---       1973 VI   1973b Tuttle-Giacobini-Kresak       6   6.5  -9.9 0.0016  -  ---                         
+   C/1973 D1   1973 VII  1973e Kohoutek                      6   3.0  -9.9 -.99999 -  ---                         
+ 63P/1973 A2   1973 VIII 1973c Wild 1                        6   0.1  -9.9 0.00001 -  ---                         
+   C/1973 W1   1973 IX   1973o Gibson                        6   1.5  -9.9 0.004   -  ---                         
+   C/1973 N1   1973 X    1973k Sandage                       6  -9.99 -9.9 0.006   -  ---                         
+ 78P/1973 S1   1973 XI   1973n Gehrels 2                     6  -9.99 -9.9 0.001   -  ---                         
+   C/1973 E1   1973 XII  1973f Kohoutek                      6  10.   -9.9 0.167   -  ---                         
+ 16P/---       1974 I    1973j Brooks 2                      6  -9.99 -9.9 0.00002 -  ---                         
+ 29P/---       1974 II   ---   Schwassmann-Wachmann 1        6  15.   -9.9 0.0005  -  ---                         
+   C/1974 C1   1974 III  1974b Bradfield                     6   4.8  -9.9 0.095   -  ---                         
+ 66P/1974 F2   1974 IV   ---   du Toit                       6   1.6  -9.9 -.99999 -  ---                         
+  2P/---       1974 V    ---   Encke                         6   1.4  -9.9 -.99999 -  ---                         
+ 44P/---       1974 VI   1973g Reinmuth 2                    6   0.2  -9.9 -.99999 -  ---                         
+   C/1974 O1   1974 VIII 1974e Cesco                         6   0.2  -9.9 -.99999 -  ---                         
+ 37P/---       1974 IX   1974a Forbes                        6   1.3  -9.9 0.0056  -  ---                         
+   C/1974 V1   1974 XII  1974g van den Bergh                 6   0.7  -9.9 0.020   -  ---                         
+ 31P/---       1974 XIII 1973l Schwassmann-Wachmann 2        6  -9.99 -9.9 0.013   -  ---                         
+ 77P/1975 L1   1974 XIV  1975g Longmore                      6  -9.99 -9.9 0.002   -  ---                         
+   C/1974 V2   1974 XV   1974h Bennett                       6   0.4  -9.9 -.99999 -  ---                         
+ 45P/---       1974 XVI  1974f Honda-Mrkos-Pajdusakova       6   1.8  -9.9 0.0001  -  ---                         
+ 85P/1975 A1   1975 I    1975a Boethin                       6   2.8  -9.9 -.99999 -  ---                         
+   C/1976 D2   1975 II   1976c Schuster                      6   0.3  -9.9 0.02    -  ---                         
+ 75P/1975 C1   1975 III  1975c Kohoutek                      6   2.   -9.9 -.99999 -  ---                         
+ 76P/1975 D1   1975 IV   1975b West-Kohoutek-Ikemura         6   3.   -9.9 0.0006  -  ---                         
+   C/1975 E1   1975 V    1975d Bradfield                     6   4.    6.  0.0005  -  ---                         
+ 74P/1975 E2   1975 VII  1975e Smirnova-Chernykh             6   1.   -9.9 -.99999 -  ---                         
+   C/1974 F1   1975 VIII 1974c Lovas                         6   2.5  -9.9 -.99999 -  ---                         
+   C/1975 N1   1975 IX   1975h Kobayashi-Berger-Milon        6   9.   10.  0.046   -  Tail length 1975-07         
+   C/1975 N1   1975 IX   1975h Kobayashi-Berger-Milon        6  -9.99 -9.9 0.160   -  Tail length 1975-08         
+   C/1975 T2   1975 X    1975k Suzuki-Saigusa-Mori           6  -9.99 -9.9 0.005   -  ---                         
+   C/1975 V2   1975 XI   1975p Bradfield                     6   3.   -9.9 0.020   -  ---                         

--- a/src/test/resources/github1660/pccds.xml
+++ b/src/test/resources/github1660/pccds.xml
@@ -1,0 +1,387 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1B00.sch" schemtatypens="http://purl.oclc.org/dsdl/schematron"?>
+
+<Product_Observational xmlns="http://pds.nasa.gov/pds4/pds/v1"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1 http://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1B00.xsd">
+    
+    <Identification_Area>
+        <logical_identifier>urn:nasa:pds:compil-comet:phys_char:head_diameters_and_tail_lengths</logical_identifier>
+        <version_id>1.0</version_id>
+        <title>Physical Charecteristics of Comets - Head Diameters and Tail Lengths</title>
+        <information_model_version>1.11.0.0</information_model_version>
+        <product_class>Product_Observational</product_class>
+		
+		<Citation_Information>
+			<publication_year>2019</publication_year>
+			<description>This file lists the head diameters and tail lengths (columns D1 and       
+					S) from the tabels of observations collected by S. K. Vsekhsvyatskii      
+					and published as a series of articles during the period 1963-1975.        
+					Also included are tail type indications where those were supplied in      
+					the (later) original source tables.  Only those table entries which       
+					contained head diameter or tail length data are represented here.</description>
+		</Citation_Information>
+        
+        <Modification_History>
+            <Modification_Detail>
+                <modification_date>2015-08-25</modification_date>
+                <version_id>1.0</version_id>
+                <description>Migration from PDS3</description>
+            </Modification_Detail>
+        </Modification_History>
+    </Identification_Area>
+    
+    <Observation_Area>
+        
+        <comment>The earliest observation recorded in this data file is from UTC year -466.</comment>
+        <Time_Coordinates>
+            <start_date_time>0000Z</start_date_time>
+            <stop_date_time>1975Z</stop_date_time>
+        </Time_Coordinates>
+        
+        <Primary_Result_Summary>
+            <purpose>Science</purpose>
+            <processing_level>Derived</processing_level>
+            <description>Head Diameters and Tail Lengths</description>
+            <Science_Facets>
+                
+                <discipline_name>Small Bodies</discipline_name>
+                <facet1>Physical Properties</facet1>
+                
+            </Science_Facets>
+        </Primary_Result_Summary>
+        
+        <Investigation_Area>
+            <name>None</name>
+            <type>Other Investigation</type>
+            <Internal_Reference>
+                <lid_reference>urn:nasa:pds:context:investigation:individual.none</lid_reference>
+                <reference_type>data_to_investigation</reference_type>
+            </Internal_Reference>
+        </Investigation_Area>
+        
+        <Observing_System>
+            <Observing_System_Component>
+                <name>Literature Search</name>
+                <type>Literature Search</type>
+            </Observing_System_Component>
+        </Observing_System>
+
+        <Target_Identification>
+            <name>Multiple Comets</name>
+            <type>Comet</type>
+        </Target_Identification>
+    </Observation_Area>
+    
+    <Reference_List>
+        <Internal_Reference>
+            <lid_reference>urn:nasa:pds:compil-comet:phys_char:references</lid_reference>
+            <reference_type>data_to_associate</reference_type>
+            <comment>
+                This data product contains a numbered list of the references cited by
+                code in the data table, and also provides some additional notes on 
+                each reference.
+            </comment>
+        </Internal_Reference>
+        
+        <External_Reference>
+            <reference_text>S.K. Vsekhsvyatskii, 1963. 'Absolute Magnitudes of      
+                1954-1960 Comets', Soviet Astronomy - AJ [in English], Vol. 6, 849-53.</reference_text>
+        </External_Reference>
+        
+        <External_Reference>
+            <reference_text>S.K. Vsekhsvyatskii, 1964. 'Physical Characteristics    
+                of Comets', trans. Israel Program for Scientific Translations,            
+                NASA TT F-80 / OTS 62-11031.</reference_text>
+            <description>Some of the product data come from this reference.</description>
+        </External_Reference>
+        
+        <External_Reference>
+            <reference_text>S.K. Vsekhsvyatskii, 1967. 'Physical Characteristics    
+                of Comets Observed During 1961-1965', Soviet Astronomy - AJ [in           
+                English], Vol. 10, 1034-41.</reference_text>
+            <description>Some of the product data come from this reference.</description>
+        </External_Reference>
+        
+        <External_Reference>
+            <reference_text>S.K. Vsekhsvyatskii and Il'ichishina, N.I., 1971.       
+                'Absolute Magnitudes of Comets, 1965-1969', Soviet Astronomy - AJ         
+                [in English], Vol 15, 310-13.</reference_text>
+        </External_Reference>
+        
+        <External_Reference>
+            <reference_text>S.K. Vsekhsvyatskii and Il'chishina, N.I., 1974.        
+                'Fizicheskie Kharakteristiki Komet, 1965-1970gg' [in Russian]             
+                (Moskva: Izdatel'stva Nauka).</reference_text>
+            <description>Some of the product data come from this reference.</description>
+        </External_Reference>
+        
+        <External_Reference>
+            <reference_text>S.K. Vsekhsvyatskii, 1979. 'Fizicheskie Kharakteristiki 
+                Komet 1971-1975gg' [in Russian] (Kiev: Kaukova Dumka).</reference_text>
+            <description>Some of the product data come from this reference.</description>
+        </External_Reference>
+    </Reference_List>
+    
+    <File_Area_Observational>
+        <File>
+            <file_name>pccds.tab</file_name>
+			<file_size unit="byte">21692</file_size>
+			<records>187</records>
+        </File>
+        
+        <Table_Character>
+            
+            <offset unit="byte">0</offset>
+            <records>187</records>
+            <description> This file lists the head diameters and tail lengths (columns D1 and       
+                S) from the tabels of observations collected by S. K. Vsekhsvyatskii      
+                and published as a series of articles during the period 1963-1975.        
+                Also included are tail type indications where those were supplied in      
+                the (later) original source tables.  Only those table entries which       
+                contained head diameter or tail length data are represented here.         
+                </description>
+            <record_delimiter>Carriage-Return Line-Feed</record_delimiter>
+            
+            <Record_Character>
+                <fields>12</fields>
+                <groups>0</groups>
+                <record_length unit="byte">116</record_length>
+                
+                <Field_Character>
+                    <name>Periodic Number</name>
+                    <field_number>1</field_number>
+                    <field_location unit="byte">1</field_location>
+                    <data_type>ASCII_String</data_type>
+                    <field_length unit="byte">3</field_length>
+                    <field_format>%3s</field_format>
+                   
+                    <description>Periodic comet number, or blank if this is either        
+                        not a short-period comet or had not yet been numbered.</description>
+                </Field_Character>
+                
+                <Field_Character>
+                    <name>Comet Type</name>
+                    <field_number>2</field_number>
+                    <field_location unit="byte">4</field_location>
+                    <data_type>ASCII_String</data_type>
+                    <field_length unit="byte">1</field_length>
+                    <field_format>%-1s</field_format>
+                    
+                    <description>
+                        Single-character code identifying the type of comet:     
+                         C = long-period or unrecovered                                    
+                         D = deceased or defunct                                           
+                         P = short-period                                                  
+                        This field is separated from the following designation field by a       
+                        slash (/).</description>
+                </Field_Character>
+                
+                <Field_Character>
+                    <name>IAU Designation</name>
+                    <field_number>3</field_number>
+                    <field_location unit="byte">6</field_location>
+                    <data_type>ASCII_String</data_type>
+                    <field_length unit="byte">9</field_length>
+                    <field_format>%-9s</field_format>
+                   
+                    <description>IAU Comet Designation:  Discovery year followed by a bimonthly          
+                        designation and, in cases of a visually compound object, a component    
+                        designation of the form '-A', '-B', etc.  This designation has been     
+                        assigned retrospectively to all comet apparitions recognized by the     
+                        Minor Planet Center.</description>
+                    <Special_Constants>
+                        <not_applicable_constant>---</not_applicable_constant>
+                    </Special_Constants>
+                </Field_Character>
+                
+                <Field_Character>
+                    <name>Perihelion Number</name>
+                    <field_number>4</field_number>
+                    <field_location unit="byte">16</field_location>
+                    <data_type>ASCII_String</data_type>
+                    <field_length unit="byte">9</field_length>
+                    <field_format>%-9s</field_format>
+                    
+                    <description>Old IAU Comet Perihelion Number:  Perihelion year followed              
+                        by a roman numeral indicating the chronological order of                
+                        perihelion passage within the year.  When only one comet passed         
+                        perihelion in a given year the numeral 'I' is omitted.
+                    </description>
+                </Field_Character>
+                
+                <Field_Character>
+                    <name>Provisional Number </name>
+                    <field_number>5</field_number>
+                    <field_location unit="byte">26</field_location>
+                    <data_type>ASCII_String</data_type>
+                    <field_length unit="byte">5</field_length>
+                    <field_format>%-5s</field_format>
+                    
+                    <description>Old IAU Comet Provisional Number:  Discovery year followed              
+                        by a letter indicating the order of discovery. This designation         
+                        is not applied to comets observed prior to 1869.</description>
+                    <Special_Constants>
+                        <not_applicable_constant>---</not_applicable_constant>
+                    </Special_Constants>
+                </Field_Character>
+                
+                <Field_Character>
+                    <name>Comet Name</name>
+                    <field_number>6</field_number>
+                    <field_location unit="byte">32</field_location>
+                    <data_type>ASCII_String</data_type>
+                    <field_length unit="byte">28</field_length>
+                    <field_format>%-28s</field_format>
+                   
+                    <description>Name of the comet. Comets are named by the surnames      
+                        of up to three co-discoverers.</description>
+                </Field_Character>
+                
+                <Field_Character>
+                    <name>Reference Code</name>
+                    <field_number>7</field_number>
+                    <field_location unit="byte">62</field_location>
+                    <data_type>ASCII_Integer</data_type>
+                    <field_length unit="byte">1</field_length>
+                    <field_format>%1d</field_format>
+                    
+                    <description>Code number indicating the reference from which the      
+                        record data were taken.  References are numbered chronologically; the     
+                        codes in the file range from 2 to 6, with no data having been included  
+                        from reference 1, which did not provide head diameter and tail length   
+                        measurements, or reference 4, which was completely superceded by the     
+                        data in reference 5.  For more information and full citations, see      
+                        the accompanying reference code list file.</description>
+                </Field_Character>
+                
+                <Field_Character>
+                    <name>Head Diameter</name>
+                    <field_number>8</field_number>
+                    <field_location unit="byte">65</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">5</field_length>
+                    <field_format>%5.2f</field_format>
+                    <unit>arcminute</unit>
+                    
+                    <description>Reduced value for the maximum observed head diameter  
+                        in minutes of arc, where provided.  To convert to kilometers,           
+                        multiply by 44,000.                                                     
+                        
+                        The number of digits in each value corresponds to the significant       
+                        digits provided in the original reference.</description>
+                    <Special_Constants>
+                        <missing_constant>-9.99</missing_constant>
+                    </Special_Constants>
+                    <Field_Statistics>
+                        <maximum>30.0</maximum>
+                        <minimum>0.1</minimum>
+                    </Field_Statistics>
+                    
+                </Field_Character>
+                
+                <Field_Character>
+                    <name>Head Diameter Variation</name>
+                    <field_number>9</field_number>
+                    <field_location unit="byte">71</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">4</field_length>
+                    <field_format>%4.1f</field_format>
+                    <unit>arcminute</unit>
+                                      
+                    <description>Occasionally the head diameter was cited as a range.  
+                        In those cases, this value is the second end point of the given         
+                        range; otherwise it contains a filler value.</description>
+                    <Special_Constants>
+                        <missing_constant>-9.9</missing_constant>
+                    </Special_Constants>
+                    <Field_Statistics>
+                        <maximum>43.0</maximum>
+                        <minimum>0.3</minimum>
+                    </Field_Statistics>
+                    
+                </Field_Character>
+                
+                <Field_Character>
+                    <name>Tail Length</name>
+                    <field_number>10</field_number>
+                    <field_location unit="byte">76</field_location>
+                    <data_type>ASCII_Real</data_type>
+                    <field_length unit="byte">7</field_length>
+                    <field_format>%7.5f</field_format>
+                    <unit>AU</unit>
+                    
+                    <description>Reduced length of the tail in AU, corresponding to    
+                        the maximum observed angular length, if provided; otherwise this        
+                        column contains a filler value.                                         
+                        
+                        The number of significant digits in each value here corresponds to      
+                        the number of significant digits provided in the cited publication.</description>
+                    <Special_Constants>
+                        <missing_constant>-.99999</missing_constant>
+                    </Special_Constants>
+                    <Field_Statistics>
+                        <maximum>1.39</maximum>
+                        <minimum>0.00001</minimum>
+                    </Field_Statistics>
+                    
+                </Field_Character>
+                
+                <Field_Character>
+                    <name>Tail Type</name>
+                    <field_number>11</field_number>
+                    <field_location unit="byte">84</field_location>
+                    <data_type>ASCII_String</data_type>
+                    <field_length unit="byte">1</field_length>
+                    <field_format>%-1s</field_format>
+                    
+                    
+                    <description>Code letter indicating the type of tail. These codes were provided      
+                        only in the second reference as unexplained parenthetical remarks       
+                        to the tail length.  The original notation used Roman numerals,         
+                        which have been translated to Arabic numbers here.                      
+                        
+                        Most likely the Roman numerals correspond to a tail structure           
+                        classification scheme developed by Bredikhin and described in           
+                        the first reference (Vsekhsvyatskii 1964):         
+                        
+                        Code  Tail Type   Bredikhin description                                 
+                        ----  ---------   -------------------------------------------------     
+                          A   anti-tail   anamolous, sunward tail                               
+                          1   ion tail    straight, scarcely deviating from the extended        
+                                          radius-vector; they are strung out by a repulsive     
+                                          force about 20 times greater than the solar           
+                                          gravitational attraction                              
+                          2   dust tail   broad and curving; the rpulsive force comes           
+                                          out about even with gravitational attraction          
+                          3   dust tail   usually small, faint, formed by particles             
+                                          repelled by a force about 01.-0.3 of                  
+                                          gravitational attraction.
+                    </description>
+                    <Special_Constants>
+                        <missing_constant>-</missing_constant>
+                    </Special_Constants>
+                </Field_Character>
+                
+                <Field_Character>
+                    <name>Comments</name>
+                    <field_number>12</field_number>
+                    <field_location unit="byte">87</field_location>
+                    <data_type>ASCII_String</data_type>
+                    <field_length unit="byte">28</field_length>
+                    <field_format>%-28s</field_format>
+                    
+                    <description>Some of the records in the published tables contained
+                        qualifying notes or additional explanatory remarks. Also, there were    
+                        format irregularities in the printed versions which could not easily    
+                        be maintained in this archival dataset.  This note field documents      
+                        these additional details.</description>
+                    <Special_Constants>
+                        <not_applicable_constant>---</not_applicable_constant>
+                    </Special_Constants>
+                </Field_Character>
+                          
+              </Record_Character>
+        </Table_Character>
+    </File_Area_Observational>
+</Product_Observational>


### PR DESCRIPTION
## 🗒️ Summary

Fixes a bug where `missing_constant` (and other special constants with decimal values) were not suppressing `error.table.field_value_out_of_min_max_range` errors in ASCII character/delimited/binary table fields.

**Root cause:** In `SpecialConstantChecker.sameContent()`, values arriving as `BigDecimal` (all ASCII numeric field types go through `NumberUtils.createBigDecimal()`) were being converted `BigDecimal → Double → BigInteger(raw IEEE 754 bit pattern)` before comparison. For a decimal constant like `-.99999`, the code then called `BigDecimal.equals(BigInteger)`, which is always `false`, so the special constant was never recognized. The value then fell through to the `Field_Statistics` min/max comparison and incorrectly triggered an error.

**Fix:** Added an early-return path in `sameContent()`: when the incoming `Number` is a `BigDecimal` and the constant representation is decimal (contains `.` or scientific notation `e`/`E`), compare directly via `BigDecimal.compareTo()` before the bit-pattern conversion path.

Also refactors the `repr_decimal` boolean into two named variables (`hasDecimalPoint`, `hasScientificNotation`) for readability.

> 🤖 Generated with [Claude Code](https://claude.ai/claude-code) — fix and analysis ~90% AI-assisted

## ⚙️ Test Data and/or Report

Added Cucumber scenario `1660-1` using the real-world `pccds.xml`/`pccds.tab` dataset from the compil-comet archive (linked in the issue). Before fix: 46 `error.table.field_value_out_of_min_max_range` errors. After fix: 0 errors, product passes.

```
mvn test -Dtest=\!ReferenceIntegrityTest* -Dcucumber.filter.tags="@4.2.x"
# Tests run: 324, Failures: 0, Errors: 0
```

### Test expectation updates for related issues

The `sameContent()` fix is broader than just #1660 — it also correctly resolves decimal/scientific-notation constant matching for two older issues whose test expectations had been written against the broken behavior:

- **#690** (*"Validate does not accurately check for missing_constant values"*): The test expected 888 `warning.table.field_value_out_of_special_constant_min_max_range` warnings because `invalid_constant=-0.9999E+01` was not being matched against data values of `-0.9999E+01`. With the fix, all values are now correctly recognized as the invalid constant — 0 warnings. Test expectation updated to empty (clean pass).

- **#427** (*"validate does not work correct when path name contains a space on mac"*): Same JAXA dataset as #690, 1-record version. Expected 2 range warnings for the same reason; now correctly 0. Test expectation updated to empty.

- **#1379** (*"missing_constant treated differently to valid_minimum/valid_maximum"*): Was already a pre-existing test failure on `main`. The test data has 6 rows — 3 matching `error_constant=-1.0` and 3 matching `missing_constant=-9`. The old expectation (3 warnings, 3 special-constant info hits) reflected a partially-broken state. With the fix, all 6 rows are correctly recognized as special constants: 0 warnings, `info.table.field_value_is_special_constant=6`. Test expectation updated accordingly.

## ♻️ Related Issues

Fixes #1660

Also resolves residual test-expectation debt from #690, #427, and #1379 (all previously closed; expectations now corrected to reflect proper behavior).

## 🤓 Reviewer Checklist

- [ ] **Documentation** - Are the changes properly documented?
- [ ] **Security** - Have security implications been considered?
- [ ] **Testing** - Are the changes covered by tests?
- [ ] **Maintenance** - Does this introduce tech debt?